### PR TITLE
VIITE-1105 Links stays green after form is cleared

### DIFF
--- a/viite-UI/src/model/ProjectCollection.js
+++ b/viite-UI/src/model/ProjectCollection.js
@@ -331,6 +331,7 @@
           },
           closeCallback: function () {
             applicationModel.removeSpinner();
+            eventbus.trigger('roadAddress:projectLinksUpdated');
           }
         });
       } else{


### PR DESCRIPTION
fixes VIITE-1105 bug where link stays green after user chooses not to change geometry that has changed over 5%
clears selection like we do after update