### PR TITLE
VIITE-1113 - "Lähetä muutosilmoitus Tierekisteriin"-nappi on aktiivinen Tierekisteriin jo lähetetyssä projektissa

### DIFF
--- a/viite-UI/src/view/ProjectChangeTable.js
+++ b/viite-UI/src/view/ProjectChangeTable.js
@@ -9,6 +9,8 @@
       'Numerointi',
       'Lakkautettu'
     ];
+      var ProjectStatus = LinkValues.ProjectStatus;
+
     var unchangedStatus = 1;
     var newLinkStatus = 2;
     var transferredLinkStatus = 3;
@@ -125,7 +127,8 @@
         $('.change-table-dimensions').append($(htmlTable));
         if (projectChangeData.validationErrors.length === 0){
           $('.change-table-header').html($('<div>Validointi ok. Alla näet muutokset projektissa.</div>'));
-          if($('.change-table-frame').css('display')==="block")
+          var currentProject = projectCollection.getCurrentProject();
+          if($('.change-table-frame').css('display')==="block" && (currentProject.project.statusCode === ProjectStatus.Incomplete.value || currentProject.project.statusCode ===  ProjectStatus.ErroredInTR.value))
             $('#send-button').attr('disabled',false); //enables send button if changetable is open
         }
         else


### PR DESCRIPTION
Added an additional check in order to enable the send to TR button, based on the project status (Incomplete/Error in TR only).