### PR TITLE
VIITE-1117_change_road_styling_of_municipal_roads_based_to_road_addres.road_type_instead_of_vvh

### DIFF
--- a/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
+++ b/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
@@ -22,6 +22,7 @@ import org.scalatra.json.JacksonJsonSupport
 import org.scalatra.{NotFound, _}
 import org.slf4j.LoggerFactory
 
+import scala.reflect.macros.blackbox
 import scala.util.parsing.json._
 import scala.util.{Left, Right}
 
@@ -765,7 +766,8 @@ class ViiteApi(val roadLinkService: RoadLinkService, val vVHClient: VVHClient,
       "endMValue" -> roadAddressLink.endMValue,
       "sideCode" -> roadAddressLink.sideCode.value,
       "linkType" -> roadAddressLink.linkType.value,
-      "roadLinkSource" -> roadAddressLink.roadLinkSource.value
+      "roadLinkSource" -> roadAddressLink.roadLinkSource.value,
+      "blackUnderline" -> roadAddressLink.blackUnderline
     )
   }
 

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
@@ -842,7 +842,7 @@ class RoadAddressService(roadLinkService: RoadLinkService, eventbus: DigiroadEve
       val (number, part) = grouped._1
       val addresses = grouped._2
       val (municipalityAddresses, regularAddresses) = addresses.partition(_.roadType == RoadType.MunicipalityStreetRoad)
-      if (municipalityAddresses.nonEmpty){
+      if (municipalityAddresses.nonEmpty) {
         logger.info(s"Found municipality roads, fetching by roadNumber: $number and roadPartNumber: $part")
         withDynTransaction {
           val fullRoads = RoadAddressDAO.fetchByRoadPart(number, part)

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
@@ -118,7 +118,7 @@ class RoadAddressService(roadLinkService: RoadLinkService, eventbus: DigiroadEve
     val combinedFuture = fetchBoundingBoxF(boundingRectangle, roadNumberLimits, municipalities, everything, publicRoads)
     val roadAddressLinks = getRoadAddressLinks(combinedFuture, boundingRectangle, Seq(), municipalities, everything)
     val suravageAddresses = getSuravageRoadLinkAddresses(boundingRectangle, municipalities, combinedFuture)
-    suravageAddresses ++ roadAddressLinks
+    setBlackUnderline(suravageAddresses ++ roadAddressLinks)
   }
 
   private def withTiming[T](f: => T, s: String): T = {
@@ -264,7 +264,7 @@ class RoadAddressService(roadLinkService: RoadLinkService, eventbus: DigiroadEve
 
     val returningTopology = filledTopology.filterNot(p => p.anomaly == Anomaly.NoAddressGiven)
 
-    returningTopology ++ missingFloating
+    setBlackUnderline(returningTopology ++ missingFloating)
 
   }
 
@@ -282,7 +282,7 @@ class RoadAddressService(roadLinkService: RoadLinkService, eventbus: DigiroadEve
     val buildEndTime = System.currentTimeMillis()
     logger.info("End building road address in %.3f sec".format((buildEndTime - buildStartTime) * 0.001))
 
-   viiteRoadLinks.values.toSeq
+    setBlackUnderline(viiteRoadLinks.values.toSeq)
   }
 
   def applyChanges(roadLinks: Seq[RoadLink], changedRoadLinks: Seq[ChangeInfo], addresses: Map[(Long, Long), LinkRoadAddressHistory]): Seq[LinkRoadAddressHistory] = {
@@ -825,6 +825,46 @@ class RoadAddressService(roadLinkService: RoadLinkService, eventbus: DigiroadEve
     groupedChanges.foreach{ group =>
       println(s"""changeType: ${group._1}""" + "\n" + group._2.foldLeft("")((stream, nextChange) => concatenate(nextChange, stream))+ "\n")
     }
+  }
+
+  /**
+    * This will define what road_addresses should have a black outline according to the following rule:
+    * Address must have road type = 3 (MunicipalityStreetRoad)
+    * The length of all addresses in the same road number and road part number that posses road type = 3  must be
+    * bigger than the combined length of ALL the road numbers that have the same road number and road part number divided by 2.
+    * @param addresses Sequence of all road addresses that were fetched
+    * @return Sequence of road addresses properly tagged in order to get the
+    */
+  private def setBlackUnderline(addresses: Seq[RoadAddressLink]): Seq[RoadAddressLink] = {
+    logger.info("Starting the setting of the blackUnderline")
+    val groupedAddresses = addresses.groupBy(a => (a.roadNumber, a.roadPartNumber))
+    groupedAddresses.flatMap(grouped => {
+      val (number, part) = grouped._1
+      val addresses = grouped._2
+      val (municipalityAddresses, regularAddresses) = addresses.partition(_.roadType == RoadType.MunicipalityStreetRoad)
+      if (municipalityAddresses.nonEmpty){
+        logger.info(s"Found municipality roads, fetching by roadNumber: $number and roadPartNumber: $part")
+        withDynTransaction {
+          val fullRoads = RoadAddressDAO.fetchByRoadPart(number, part)
+          val allMunicipalityAddresses = fullRoads.filter(_.roadType == RoadType.MunicipalityStreetRoad)
+          if (allMunicipalityAddresses.nonEmpty) {
+            logger.info(s"Within the fetch, found municipality roads, testing lengths")
+            val fullRoadLength = fullRoads.map(r => GeometryUtils.geometryLength(r.geometry)).sum
+            val municipalityLength = allMunicipalityAddresses.map(r => GeometryUtils.geometryLength(r.geometry)).sum
+            if (municipalityLength >= fullRoadLength / 2) {
+              logger.info(s"Municipality roads summed geometryLength >= fetchedRoads summed geometryLength / 2, all are eligible for black underline")
+              (municipalityAddresses.map(_.copy(blackUnderline = true)) ++ regularAddresses).sortBy(_.endAddressM)
+            } else {
+              addresses
+            }
+          } else {
+            addresses
+          }
+        }
+      } else {
+        addresses
+      }
+    }).toSeq
   }
 }
 

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectDAO.scala
@@ -87,7 +87,7 @@ case class ProjectLink(id: Long, roadNumber: Long, roadPartNumber: Long, track: 
                        calibrationPoints: (Option[CalibrationPoint], Option[CalibrationPoint]) = (None, None), floating: Boolean = false,
                        geometry: Seq[Point], projectId: Long, status: LinkStatus, roadType: RoadType,
                        linkGeomSource: LinkGeomSource = LinkGeomSource.NormalLinkInterface, geometryLength: Double, roadAddressId: Long,
-                       ely: Long, reversed: Boolean, connectedLinkId: Option[Long] = None, linkGeometryTimeStamp: Long, commonHistoryId: Long = NewCommonHistoryId)
+                       ely: Long, reversed: Boolean, connectedLinkId: Option[Long] = None, linkGeometryTimeStamp: Long, commonHistoryId: Long = NewCommonHistoryId, blackUnderline: Boolean = false)
   extends BaseRoadAddress with PolyLine {
   lazy val startingPoint = if (sideCode == SideCode.AgainstDigitizing) geometry.last else geometry.head
   lazy val endPoint = if (sideCode == SideCode.AgainstDigitizing) geometry.head else geometry.last

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadAddressDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadAddressDAO.scala
@@ -138,7 +138,7 @@ case class RoadAddress(id: Long, roadNumber: Long, roadPartNumber: Long, roadTyp
                        lrmPositionId: Long, linkId: Long, startMValue: Double, endMValue: Double, sideCode: SideCode,
                        adjustedTimestamp: Long, calibrationPoints: (Option[CalibrationPoint], Option[CalibrationPoint]) = (None, None),
                        floating: Boolean = false, geometry: Seq[Point], linkGeomSource: LinkGeomSource, ely: Long,
-                       terminated: TerminationCode = NoTermination,commonHistoryId: Long,blackUnderline: Boolean = false) extends BaseRoadAddress {
+                       terminated: TerminationCode = NoTermination,commonHistoryId: Long, blackUnderline: Boolean = false) extends BaseRoadAddress {
   val endCalibrationPoint = calibrationPoints._2
   val startCalibrationPoint = calibrationPoints._1
 

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadAddressDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadAddressDAO.scala
@@ -125,6 +125,7 @@ trait BaseRoadAddress {
   def linkGeomSource: LinkGeomSource
   def reversed: Boolean
   def commonHistoryId: Long
+  def blackUnderline: Boolean
 
   def copyWithGeometry(newGeometry: Seq[Point]): BaseRoadAddress
 
@@ -137,7 +138,7 @@ case class RoadAddress(id: Long, roadNumber: Long, roadPartNumber: Long, roadTyp
                        lrmPositionId: Long, linkId: Long, startMValue: Double, endMValue: Double, sideCode: SideCode,
                        adjustedTimestamp: Long, calibrationPoints: (Option[CalibrationPoint], Option[CalibrationPoint]) = (None, None),
                        floating: Boolean = false, geometry: Seq[Point], linkGeomSource: LinkGeomSource, ely: Long,
-                       terminated: TerminationCode = NoTermination, commonHistoryId: Long) extends BaseRoadAddress {
+                       terminated: TerminationCode = NoTermination,commonHistoryId: Long,blackUnderline: Boolean = false) extends BaseRoadAddress {
   val endCalibrationPoint = calibrationPoints._2
   val startCalibrationPoint = calibrationPoints._1
 

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/model/ProjectAddressLink.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/model/ProjectAddressLink.scala
@@ -52,7 +52,7 @@ case class ProjectAddressLink(id: Long, linkId: Long, geometry: Seq[Point],
                               startAddressM: Long, endAddressM: Long, startMValue: Double, endMValue: Double, sideCode: SideCode,
                               startCalibrationPoint: Option[CalibrationPoint], endCalibrationPoint: Option[CalibrationPoint],
                               anomaly: Anomaly = Anomaly.None, lrmPositionId: Long, status: LinkStatus, roadAddressId: Long, reversed: Boolean = false,
-                              connectedLinkId: Option[Long] = None, originalGeometry: Option[Seq[Point]] = None) extends ProjectAddressLinkLike {
+                              connectedLinkId: Option[Long] = None, originalGeometry: Option[Seq[Point]] = None, blackUnderline: Boolean = false) extends ProjectAddressLinkLike {
   override def partitioningName: String = {
     if (roadNumber > 0)
       s"$roadNumber/$roadPartNumber/$trackCode"

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/model/RoadAddressLink.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/model/RoadAddressLink.scala
@@ -36,6 +36,7 @@ trait RoadAddressLinkLike extends PolyLine {
   def endCalibrationPoint: Option[CalibrationPoint]
   def anomaly: Anomaly
   def lrmPositionId: Long
+  def blackUnderline: Boolean
 }
 
 case class RoadAddressLink(id: Long, linkId: Long, geometry: Seq[Point],
@@ -44,7 +45,7 @@ case class RoadAddressLink(id: Long, linkId: Long, geometry: Seq[Point],
                            attributes: Map[String, Any] = Map(), roadNumber: Long, roadPartNumber: Long, trackCode: Long, elyCode: Long, discontinuity: Long,
                            startAddressM: Long, endAddressM: Long, startDate: String, endDate: String, startMValue: Double, endMValue: Double, sideCode: SideCode,
                            startCalibrationPoint: Option[CalibrationPoint], endCalibrationPoint: Option[CalibrationPoint],
-                           anomaly: Anomaly = Anomaly.None, lrmPositionId: Long, commonHistoryID: Long = 0, newGeometry: Option[Seq[Point]] = None) extends RoadAddressLinkLike {
+                           anomaly: Anomaly = Anomaly.None, lrmPositionId: Long, commonHistoryID: Long = 0, newGeometry: Option[Seq[Point]] = None, blackUnderline: Boolean = false) extends RoadAddressLinkLike {
 }
 
 sealed trait Anomaly {

--- a/viite-UI/src/view/Styler.js
+++ b/viite-UI/src/view/Styler.js
@@ -87,6 +87,12 @@
       }
     };
 
+    var generateUnderLineColor = function(roadLinkData, opacityMultiplier, middleLineWidth) {
+      if(roadLinkData.blackUnderline)
+        return {color: 'rgba(30, 30, 30,' + opacityMultiplier + ')', width: middleLineWidth + 7};
+      else return {color: undefined, width: undefined};
+    };
+
     /**
      * Inspired in the LinkPropertyLayerStyles complementaryRoadAddressRules and unknownRoadAddressAnomalyRules,
      * @param roadLinkType The roadLink roadLinkType.
@@ -222,12 +228,10 @@
       // If the line we need to generate is a dashed line, middleLineColor will be the white one sitting behind the
       // dashed/colored line and above the border and grey lines
       var middleLineColor;
-      var adminClassColor;
       var borderColor;
       var lineCap;
       var borderCap;
       var middleLineCap;
-      var adminClassWidth;
       var lineColor = generateStrokeColor(roadLinkData.roadClass, roadLinkData.anomaly, roadLinkData.constructionType,
         roadLinkData.roadLinkType, roadLinkData.gapTransfering, roadLinkData.roadLinkSource, roadLinkData.id);
       if (roadLinkData.roadClass >= 7 && roadLinkData.roadClass <= 10) {
@@ -257,10 +261,6 @@
         lineCap: borderCap
       });
       var middleLineWidth = strokeWidth;
-      if (roadLinkData.id !== 0 && roadLinkData.administrativeClass == "Municipality") {
-        adminClassColor = generateStrokeColor(97, roadNormalType, roadNormalType, roadLinkData.roadLinkType, roadLinkData.gapTransfering, roadLinkData.roadLinkSource, roadLinkData.id);
-        adminClassWidth = middleLineWidth + 7;
-      }
       var middleLine = new ol.style.Stroke({
         width: middleLineWidth,
         color: middleLineColor,
@@ -277,9 +277,10 @@
         lineCap: lineCap
       });
 
-      var adminClassLine = new ol.style.Stroke({
-        width: adminClassWidth,
-        color: adminClassColor,
+      var roadTypeDetails = generateUnderLineColor(roadLinkData, opacityMultiplier, middleLineWidth);
+      var roadTypeLine = new ol.style.Stroke({
+        width: roadTypeDetails.width,
+        color: roadTypeDetails.color,
         lineCap: lineCap
       });
 
@@ -305,16 +306,16 @@
       var underlineStyle = new ol.style.Style({
         stroke: underline
       });
-      var adminClassStyle = new ol.style.Style({
-        stroke: adminClassLine
+      var roadTypeStyle = new ol.style.Style({
+        stroke: roadTypeLine
       });
       var zIndex = determineZIndex(roadLinkData.roadLinkType, roadLinkData.anomaly, roadLinkData.roadLinkSource);
       underlineStyle.setZIndex(zIndex - 1);
       borderStyle.setZIndex(zIndex);
       middleLineStyle.setZIndex(zIndex + 1);
       lineStyle.setZIndex(zIndex + 2);
-      adminClassStyle.setZIndex(zIndex - 2);
-      return [borderStyle, underlineStyle, middleLineStyle, lineStyle, adminClassStyle];
+      roadTypeStyle.setZIndex(zIndex - 2);
+      return [borderStyle, underlineStyle, middleLineStyle, lineStyle, roadTypeStyle];
     };
 
     var setOpacityMultiplier = function (multiplier) {

--- a/viite-UI/src/view/Styler.js
+++ b/viite-UI/src/view/Styler.js
@@ -88,7 +88,7 @@
     };
 
     var generateUnderLineColor = function(roadLinkData, opacityMultiplier, middleLineWidth) {
-      if(roadLinkData.blackUnderline)
+      if (roadLinkData.blackUnderline)
         return {color: 'rgba(30, 30, 30,' + opacityMultiplier + ')', width: middleLineWidth + 7};
       else return {color: undefined, width: undefined};
     };


### PR DESCRIPTION
Backend:   
    .Added a additional call to the end of each fetch option in order to determine which sequence of addresses (by number and part number) get to have a black line underneath it.
    .Added said new parameter to all address objects, that go out to the UI.

UI:
    .Reworked the way the LinkProperty Styler handles the previously mentioned adminClassLine in order to depend on the newly created parameter from the backend.