### PR TITLE
VIITE-1183 - Addressing discontinuity validation false positives

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectValidator.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectValidator.scala
@@ -627,8 +627,24 @@ object ProjectValidator {
       val startRoad = groupedProjectLinks.head
       val endRoad = groupedProjectLinks.last
       val anomalousAtBorders = checkValidation(startRoad, endRoad)
+      /*
+      We check the possible anomalous roads if they are:
+        Adjacent
+        Share the same track code and road number
+        Are continuous
+      If we have all those conditions then we discard them for they are not anomalous then it means that those roads are in the same road address number and
+      only changed part, therefore there is no logic in defining their discontinuity as "End of Road".
+       */
+      val grouped = anomalousAtBorders.groupBy(anom => {
+        (anom.roadNumber, anom.track, anom.discontinuity)
+      })
+      val remaining = grouped.mapValues(addresses => {
+        addresses.sliding(2).toSeq.filterNot(a => {
+          GeometryUtils.areAdjacent(a.head.geometry, a.last.geometry)
+        }).flatten
+      })
 
-      error(ValidationErrorList.TerminationContinuity)(anomalousAtBorders)
+      error(ValidationErrorList.TerminationContinuity)(remaining.values.flatten.toSeq)
     }
 
     /**

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectValidator.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectValidator.scala
@@ -638,13 +638,16 @@ object ProjectValidator {
       val grouped = anomalousAtBorders.groupBy(anom => {
         (anom.roadNumber, anom.track, anom.discontinuity)
       })
-      val remaining = grouped.mapValues(addresses => {
+      val (groupedTrueAnomalous, possibleAnomalous) = grouped.partition(_._2.length <= 1)
+      val trueAnomalous = groupedTrueAnomalous.values.flatten.toSeq
+      val remaining = possibleAnomalous.mapValues(addresses => {
         addresses.sliding(2).toSeq.filterNot(a => {
           GeometryUtils.areAdjacent(a.head.geometry, a.last.geometry)
         }).flatten
-      })
+      }).values.flatten.toSeq
 
-      error(ValidationErrorList.TerminationContinuity)(remaining.values.flatten.toSeq)
+
+      error(ValidationErrorList.TerminationContinuity)(trueAnomalous ++ remaining)
     }
 
     /**

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectValidatorSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectValidatorSpec.scala
@@ -27,12 +27,21 @@ class ProjectValidatorSpec extends FunSuite with Matchers {
     }
   }
 
-  private def testDataForCheckTerminationContinuity() = {
+  private def testDataForCheckTerminationContinuity(noErrorTest: Boolean = false) = {
     val roadAddressId = RoadAddressDAO.getNextRoadAddressId
     val ra = Seq(RoadAddress(roadAddressId, 27L, 20L, RoadType.PublicRoad, Track.Combined, Discontinuity.Continuous, 4278L, 4387L,
       Some(DateTime.parse("1996-01-01")), None, Option("TR"), 0, 1817196, 0.0, 108.261, SideCode.AgainstDigitizing, 1476392565000L, (None, None), floating = false,
       Seq(Point(0.0, 40.0), Point(0.0, 50.0)), LinkGeomSource.NormalLinkInterface, 8, TerminationCode.NoTermination, 0))
-    RoadAddressDAO.create(ra)
+    if(noErrorTest) {
+      val nextRoadAddressId = RoadAddressDAO.getNextRoadAddressId
+      val roadsToCreate = ra ++ Seq(RoadAddress(nextRoadAddressId, 27L, 21L, RoadType.PublicRoad, Track.Combined, Discontinuity.Continuous, 4387L, 4397L,
+        Some(DateTime.parse("1996-01-01")), None, Option("TR"), 1, 1817197, 0.0, 108.261, SideCode.AgainstDigitizing, 1476392565000L, (None, None), floating = false,
+        Seq(Point(0.0, 40.0), Point(0.0, 55.0)), LinkGeomSource.NormalLinkInterface, 8, TerminationCode.NoTermination, 0))
+      println(s"Test Roads to create : ${roadsToCreate.mkString(", ")}")
+      RoadAddressDAO.create(roadsToCreate)
+    } else {
+      RoadAddressDAO.create(ra)
+    }
   }
 
   private def projectLink(startAddrM: Long, endAddrM: Long, track: Track, projectId: Long, status: LinkStatus = LinkStatus.NotHandled,
@@ -412,9 +421,22 @@ class ProjectValidatorSpec extends FunSuite with Matchers {
     }
   }
 
-  test("validator should return an issue whenever a road gets terminated and adjacent to that same roa lies other roads with discontinuity value = 1") {
+  test("validator should return an issue whenever a road gets terminated and adjacent to that same road lies other roads with discontinuity value = 1") {
     runWithRollback {
       testDataForCheckTerminationContinuity()
+      val project = setUpProjectWithLinks(LinkStatus.Terminated, Seq(0L, 10L, 20L, 30L, 40L), changeTrack = false, 16320L, 1L, Discontinuity.ChangingELYCode)
+      val projectLinks = ProjectDAO.getProjectLinks(project.id)
+
+      val validationErrors = ProjectValidator.checkTerminationContinuity(project, projectLinks)
+      validationErrors.size should be(1)
+      validationErrors.head.validationError.value should be(TerminationContinuity.value)
+    }
+  }
+
+  test("validator should NOT return an issue whenever a road gets terminated and adjacent lies other roads with discontinuity value = 1," +
+    "that share the same road number, track code and are adjacent between them") {
+    runWithRollback {
+      testDataForCheckTerminationContinuity(true)
       val project = setUpProjectWithLinks(LinkStatus.Terminated, Seq(0L, 10L, 20L, 30L, 40L), changeTrack = false, 16320L, 1L, Discontinuity.ChangingELYCode)
       val projectLinks = ProjectDAO.getProjectLinks(project.id)
 

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectValidatorSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectValidatorSpec.scala
@@ -37,7 +37,6 @@ class ProjectValidatorSpec extends FunSuite with Matchers {
       val roadsToCreate = ra ++ Seq(RoadAddress(nextRoadAddressId, 27L, 21L, RoadType.PublicRoad, Track.Combined, Discontinuity.Continuous, 4387L, 4397L,
         Some(DateTime.parse("1996-01-01")), None, Option("TR"), 1, 1817197, 0.0, 108.261, SideCode.AgainstDigitizing, 1476392565000L, (None, None), floating = false,
         Seq(Point(0.0, 40.0), Point(0.0, 55.0)), LinkGeomSource.NormalLinkInterface, 8, TerminationCode.NoTermination, 0))
-      println(s"Test Roads to create : ${roadsToCreate.mkString(", ")}")
       RoadAddressDAO.create(roadsToCreate)
     } else {
       RoadAddressDAO.create(ra)


### PR DESCRIPTION
Added another check after the main finding of invalid road addresses that test if they are part of the same road address, are continuous, have the same track code and are adjacent if they are then we discard them.