### PR TITLE
Viite 1281 monitoring

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -134,6 +134,7 @@ object Digiroad2Build extends Build {
         "org.eclipse.jetty" % "jetty-webapp" % "9.2.10.v20150310" % "compile",
         "org.eclipse.jetty" % "jetty-servlets" % "9.2.10.v20150310" % "compile",
         "org.eclipse.jetty" % "jetty-proxy" % "9.2.10.v20150310" % "compile",
+        "org.eclipse.jetty" % "jetty-jmx" % "9.2.10.v20150310" % "compile",
         "org.eclipse.jetty.orbit" % "javax.servlet" % "3.0.0.v201112011016" % "provided;test" artifacts (Artifact("javax.servlet", "jar", "jar"))
       ),
       unmanagedResourceDirectories in Compile += baseDirectory.value / "conf" /  env,

--- a/src/main/scala/fi/liikennevirasto/digiroad2/DigiroadServer.scala
+++ b/src/main/scala/fi/liikennevirasto/digiroad2/DigiroadServer.scala
@@ -1,20 +1,18 @@
 package fi.liikennevirasto.digiroad2
 
+import java.lang.management.ManagementFactory
 import java.util.Properties
-import java.util.logging.Logger
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
-
-import org.eclipse.jetty.client.{HttpClient, HttpProxy, ProxyConfiguration}
-
-import scala.collection.JavaConversions._
-import org.eclipse.jetty.http.{HttpURI, MimeTypes}
-import org.eclipse.jetty.proxy.ProxyServlet
-import org.eclipse.jetty.server.{Handler, Server}
-import org.eclipse.jetty.webapp.WebAppContext
+import org.eclipse.jetty.jmx.MBeanContainer
 import org.eclipse.jetty.client.api.Request
-import org.eclipse.jetty.server.handler.{ContextHandler, ContextHandlerCollection}
+import org.eclipse.jetty.client.{HttpClient, HttpProxy}
+import org.eclipse.jetty.proxy.ProxyServlet
+import org.eclipse.jetty.server.handler.ContextHandlerCollection
+import org.eclipse.jetty.server.{Handler, Server}
 import org.eclipse.jetty.util.ssl.SslContextFactory
+import org.eclipse.jetty.webapp.WebAppContext
 import org.slf4j.LoggerFactory
+import scala.collection.JavaConversions._
 
 
 trait DigiroadServer {
@@ -43,6 +41,9 @@ trait DigiroadServer {
   def startServer() {
     val server = new Server(9080)
     val handler = new ContextHandlerCollection()
+    val mbContainer = new MBeanContainer(ManagementFactory.getPlatformMBeanServer)
+    server.addEventListener(mbContainer)
+    server.addBean(mbContainer)
     val handlers = Array(createViiteContext())
     handler.setHandlers(handlers.map(_.asInstanceOf[Handler]))
     server.setHandler(handler)

--- a/start.sh
+++ b/start.sh
@@ -7,5 +7,6 @@ fi
 jarfile="target/scala-2.11/viite-assembly-0.1.0-SNAPSHOT.jar"
 javaopts="-javaagent:newrelic.jar $javaopts -Dfile.encoding=UTF8 -Djava.security.egd=file:///dev/urandom -jar $jarfile"
 logfile="digiroad2.boot.log"
+jmxmonitoring="Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9020 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.rmi.port=9020"
 
-nohup java $javaopts > $logfile &
+nohup java $jmxmonitoring $javaopts > $logfile &


### PR DESCRIPTION
added  jetty-jmx for monitoring (download package, needed lines to enable it in code and to start script) tested and it works on windows and *should* work with script as well