### PR TITLE
VIITE-1309 Logs accessible to monitoring

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -30,6 +30,7 @@ namespace :deploy do
       execute "cd #{deploy_path} && cp keys.properties #{release_path}/conf/#{fetch(:stage)}/."
       execute "cd #{deploy_path} && cp keys.properties #{release_path}/digiroad2-oracle/src/test/resources/."
       execute "cd #{release_path} && cp revision.properties #{release_path}/conf/#{fetch(:stage)}/. || echo 'SKIP: No revision information available'"
+      execute "cd #{release_path} && ln -s /data1/viite/logs"
       execute "cd #{release_path} && ./sbt -Ddigiroad2.env=#{fetch(:stage)} assembly"
       execute "cd #{release_path} && rsync -a dist-viite/ src/main/webapp/viite/"
       execute "cd #{release_path} && rsync -a --exclude-from 'copy_exclude.txt' viite-UI/ src/main/webapp/viite/"

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -30,7 +30,7 @@ namespace :deploy do
       execute "cd #{deploy_path} && cp keys.properties #{release_path}/conf/#{fetch(:stage)}/."
       execute "cd #{deploy_path} && cp keys.properties #{release_path}/digiroad2-oracle/src/test/resources/."
       execute "cd #{release_path} && cp revision.properties #{release_path}/conf/#{fetch(:stage)}/. || echo 'SKIP: No revision information available'"
-      execute "cd #{release_path} && ln -s /data1/viite/logs"
+      execute "cd #{release_path} && ln -s /data1/logs/viite"
       execute "cd #{release_path} && ./sbt -Ddigiroad2.env=#{fetch(:stage)} assembly"
       execute "cd #{release_path} && rsync -a dist-viite/ src/main/webapp/viite/"
       execute "cd #{release_path} && rsync -a --exclude-from 'copy_exclude.txt' viite-UI/ src/main/webapp/viite/"


### PR DESCRIPTION
Deploy script makes symbolic link from “./logs” to “/data1/viite/logs”.