### PR TITLE
VIITE-1325 Roads can't be selected after cancel button in an empty project

### DIFF
--- a/viite-UI/src/view/ProjectEditForm.js
+++ b/viite-UI/src/view/ProjectEditForm.js
@@ -371,21 +371,14 @@
       };
 
       var cancelChanges = function() {
-        selectedProjectLinkProperty.setDirty(false);
-        if(projectCollection.isDirty()) {
-          projectCollection.revertLinkStatus();
-          projectCollection.setDirty([]);
-          projectCollection.setTmpDirty([]);
-          projectLinkLayer.clearHighlights();
-          $('.wrapper').remove();
-          formCommon.toggleAdditionalControls();
-          eventbus.trigger('roadAddress:projectLinksEdited');
-          eventbus.trigger('roadAddressProject:toggleEditingRoad', true);
-          eventbus.trigger('roadAddressProject:reOpenCurrent');
-        } else {
-          eventbus.trigger('roadAddress:openProject', projectCollection.getCurrentProject());
-          eventbus.trigger('roadLinks:refreshView');
-        }
+        projectCollection.revertLinkStatus();
+        projectCollection.setDirty([]);
+        projectCollection.setTmpDirty([]);
+        projectLinkLayer.clearHighlights();
+        $('.wrapper').remove();
+        eventbus.trigger('roadAddress:projectLinksEdited');
+        eventbus.trigger('roadAddressProject:toggleEditingRoad', true);
+        eventbus.trigger('roadAddressProject:reOpenCurrent');
       };
 
       rootElement.on('change', '#endDistance', function(eventData){

--- a/viite-UI/src/view/ProjectForm.js
+++ b/viite-UI/src/view/ProjectForm.js
@@ -244,7 +244,7 @@
         return text;
       };
 
-      var toggleAditionalControls = function () {
+      var toggleAdditionalControls = function () {
         rootElement.find('header').replaceWith('<header>' +
         titleWithEditingTool(currentProject.name) +
         '</header>');
@@ -306,7 +306,7 @@
         rootElement.html(selectedProjectLinkTemplate(currentProject));
         _.defer(function () {
           applicationModel.selectLayer('roadAddressProject');
-          toggleAditionalControls();
+          toggleAdditionalControls();
         });
       };
 
@@ -324,7 +324,7 @@
           rootElement.html(selectedProjectLinkTemplate(currentProject));
           _.defer(function () {
             applicationModel.selectLayer('roadAddressProject');
-            toggleAditionalControls();
+            toggleAdditionalControls();
             selectedProjectLinkProperty.setDirty(false);
             eventbus.trigger('roadAddressProject:toggleEditingRoad', true);
           });
@@ -619,7 +619,7 @@
         selectedProjectLinkProperty.setDirty(false);
         nextStage();
         rootElement.html(selectedProjectLinkTemplate(currentProject));
-        toggleAditionalControls();
+        toggleAdditionalControls();
         eventbus.trigger('roadAddressProject:enableInteractions');
       };
 


### PR DESCRIPTION
Before selection of a new road and canceling immediately in a fresh new project, user wasn't able to select a new road without restarting the project. Also the cancel button worked unlogically. Now these bugs are fixed and hopefully my fixes didn't create new bugs.