### PR TITLE
VIITE-1330 Unnecessary popup window after cancel in edit project view

### DIFF
--- a/viite-UI/src/view/ProjectEditForm.js
+++ b/viite-UI/src/view/ProjectEditForm.js
@@ -371,21 +371,14 @@
       };
 
       var cancelChanges = function() {
-        selectedProjectLinkProperty.setDirty(false);
-        if(projectCollection.isDirty()) {
-          projectCollection.revertLinkStatus();
-          projectCollection.setDirty([]);
-          projectCollection.setTmpDirty([]);
-          projectLinkLayer.clearHighlights();
-          $('.wrapper').remove();
-          formCommon.toggleAdditionalControls();
-          eventbus.trigger('roadAddress:projectLinksEdited');
-          eventbus.trigger('roadAddressProject:toggleEditingRoad', true);
-          eventbus.trigger('roadAddressProject:reOpenCurrent');
-        } else {
-          eventbus.trigger('roadAddress:openProject', projectCollection.getCurrentProject());
-          eventbus.trigger('roadLinks:refreshView');
-        }
+        projectCollection.revertLinkStatus();
+        projectCollection.setDirty([]);
+        projectCollection.setTmpDirty([]);
+        projectLinkLayer.clearHighlights();
+        $('.wrapper').remove();
+        eventbus.trigger('roadAddress:projectLinksEdited');
+        eventbus.trigger('roadAddressProject:toggleEditingRoad', true);
+        eventbus.trigger('roadAddressProject:reOpenCurrent');
       };
 
       rootElement.on('change', '#endDistance', function(eventData){

--- a/viite-UI/src/view/ProjectForm.js
+++ b/viite-UI/src/view/ProjectForm.js
@@ -629,24 +629,29 @@
       });
 
       rootElement.on('click', '#cancelEdit', function () {
-        new GenericConfirmPopup('Haluatko tallentaa tekemäsi muutokset?', {
-          successCallback: function () {
+        if($('#generalNext').is(':enabled') || $('#saveEdit').is(':enabled')){
+          new GenericConfirmPopup('Haluatko tallentaa tekemäsi muutokset?', {
+            successCallback: function () {
 
-            if (!disabledInput) {
-              saveAndNext();
-            } else {
-              reOpenCurrent();
+              if (!disabledInput) {
+                saveAndNext();
+              } else {
+                reOpenCurrent();
+              }
+              eventbus.trigger('roadAddressProject:enableInteractions');
+            },
+            closeCallback: function () {
+              cancelChanges();
             }
-            eventbus.trigger('roadAddressProject:enableInteractions');
-          },
-          closeCallback: function () {
-            cancelChanges();
-          }
-        });
+          });
+        }else{
+          cancelChanges();
+        }
         eventbus.trigger("roadAddressProject:startAllInteractions");
       });
 
       rootElement.on('click', '#saveAndCancelDialogue', function (eventData) {
+        console.log("cancel dialogue");
         var defaultPopupMessage = 'Haluatko tallentaa tekemäsi muutokset?';
         displayCloseConfirmMessage(defaultPopupMessage, true);
       });

--- a/viite-UI/src/view/ProjectForm.js
+++ b/viite-UI/src/view/ProjectForm.js
@@ -629,7 +629,7 @@
       });
 
       rootElement.on('click', '#cancelEdit', function () {
-        if($('#generalNext').is(':enabled') || $('#saveEdit').is(':enabled')){
+        if($('#saveEdit').is(':enabled')){
           new GenericConfirmPopup('Haluatko tallentaa tekemäsi muutokset?', {
             successCallback: function () {
 
@@ -651,7 +651,6 @@
       });
 
       rootElement.on('click', '#saveAndCancelDialogue', function (eventData) {
-        console.log("cancel dialogue");
         var defaultPopupMessage = 'Haluatko tallentaa tekemäsi muutokset?';
         displayCloseConfirmMessage(defaultPopupMessage, true);
       });


### PR DESCRIPTION
There was an unnecessary popup window after pressing cancel button in edit project view when user hasn't made any edits. Now the popup shows up only when there is something to save and user presses cancel button.