### PR TITLE
VIITE-1238 Move the change table only from title bar

### DIFF
--- a/viite-UI/src/view/ProjectChangeTable.js
+++ b/viite-UI/src/view/ProjectChangeTable.js
@@ -244,6 +244,7 @@
     function enableTableInteractions() {
       interact('.change-table-frame')
         .draggable({
+          allowFrom: '.change-table-header',
           onmove: dragListener,
           restrict: {
             restriction: '.container',


### PR DESCRIPTION
Added a simple line which let's the user to move the change table only from the header.