### PR TITLE
VIITE-1361

### DIFF
--- a/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
+++ b/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
@@ -980,7 +980,8 @@ class ViiteApi(val roadLinkService: RoadLinkService, val vVHClient: VVHClient,
             "status" -> splittedLinks.status.value,
             "roadTypeId" -> splittedLinks.roadType.value,
             "discontinuity" -> splittedLinks.discontinuity.value,
-            "elyCode" -> splittedLinks.ely
+            "elyCode" -> splittedLinks.ely,
+            "roadName" -> splittedLinks.roadName.getOrElse("")
           ))
       }
       case LinkStatus.Terminated => {
@@ -994,7 +995,8 @@ class ViiteApi(val roadLinkService: RoadLinkService, val vVHClient: VVHClient,
             "status" -> splittedLinks.status.value,
             "roadTypeId" -> splittedLinks.roadType.value,
             "discontinuity" -> splittedLinks.discontinuity.value,
-            "elyCode" -> splittedLinks.ely
+            "elyCode" -> splittedLinks.ely,
+            "roadName" -> splittedLinks.roadName.getOrElse("")
           ))
       }
       case _ => {
@@ -1008,7 +1010,8 @@ class ViiteApi(val roadLinkService: RoadLinkService, val vVHClient: VVHClient,
             "status" -> splittedLinks.status.value,
             "roadTypeId" -> splittedLinks.roadType.value,
             "discontinuity" -> splittedLinks.discontinuity.value,
-            "elyCode" -> splittedLinks.ely
+            "elyCode" -> splittedLinks.ely,
+            "roadName" -> splittedLinks.roadName.getOrElse("")
           ))
       }
     }

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -550,15 +550,15 @@ class ProjectService(roadAddressService: RoadAddressService, roadLinkService: Ro
           previousSplitToSplitOptions(previousSplit, splitOptions)
         } else
           splitOptions
-      val r = preSplitSuravageLinkInTX(linkId, userName, updatedSplitOptions)
+      val (splitResultOption, errorMessage, splitVector) = preSplitSuravageLinkInTX(linkId, userName, updatedSplitOptions)
       dynamicSession.rollback()
-      val allTerminatedProjectLinks = if (r._1.isEmpty) {
+      val allTerminatedProjectLinks = if (splitResultOption.isEmpty) {
         Seq.empty[ProjectLink]
       } else {
-        r._1.get.allTerminatedProjectLinks.map(fillRoadNames)
+        splitResultOption.get.allTerminatedProjectLinks.map(fillRoadNames)
       }
-      val splitWithMergeTerminated = r._1.map(rs => rs.toSeqWithMergeTerminated.map(fillRoadNames))
-      (splitWithMergeTerminated, allTerminatedProjectLinks, r._2, r._3)
+      val splitWithMergeTerminated = splitResultOption.map(rs => rs.toSeqWithMergeTerminated.map(fillRoadNames))
+      (splitWithMergeTerminated, allTerminatedProjectLinks, errorMessage, splitVector)
     }
   }
 

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -538,18 +538,9 @@ class ProjectService(roadAddressService: RoadAddressService, roadLinkService: Ro
       * @return
       */
     def fillRoadNames(projectLink: ProjectLink): ProjectLink = {
-      val projectLinkName = ProjectLinkNameDAO.get(projectLink.roadNumber, projectLink.projectId)
-      val trueRoadName = if (projectLinkName.isEmpty) {
-        val roadName = RoadNameDAO.getLatestRoadName(projectLink.roadNumber)
-        if (roadName.isEmpty) {
-          projectLink.roadName
-        } else {
-          Option(roadName.get.roadName)
-        }
-      } else {
-        Option(projectLinkName.get.roadName)
-      }
-      projectLink.copy(roadName = trueRoadName)
+      val projectLinkName = ProjectLinkNameDAO.get(projectLink.roadNumber, projectLink.projectId).map(_.roadName)
+        .getOrElse(RoadNameDAO.getLatestRoadName(projectLink.roadNumber).map(_.roadName).getOrElse(projectLink.roadName.get))
+      projectLink.copy(roadName = Option(projectLinkName))
     }
 
     withDynTransaction {


### PR DESCRIPTION
Made a simple method to return the name of the road that is being split.

The origin is firstly the project link, then the road address, if none if found from these 2 sources then we return the original, un-modified value of the name that resides in the project link.

Also corrected a little bug, resulting of calling a .map() method on a empty collection.

Added the road name parameter to the list of outgoing values.