### PR TITLE
VIITE-1359 Profile code and improve logging

### DIFF
--- a/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
+++ b/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
@@ -8,6 +8,7 @@ import fi.liikennevirasto.digiroad2.client.vvh.VVHClient
 import fi.liikennevirasto.digiroad2.oracle.OracleDatabase
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.user.{User, UserProvider}
+import fi.liikennevirasto.digiroad2.util.LogUtils.time
 import fi.liikennevirasto.digiroad2.util.{DigiroadSerializers, RoadAddressException, RoadPartReservedException, Track}
 import fi.liikennevirasto.viite.AddressConsistencyValidator.AddressErrorDetails
 import fi.liikennevirasto.viite.ProjectValidator.ValidationErrorDetails

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/vvh/VVHClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/vvh/VVHClient.scala
@@ -369,18 +369,16 @@ trait VVHClientOperations {
   }
 
   protected def fetchVVHFeatures(url: String, formparams: ArrayList[NameValuePair]): Either[List[Map[String, Any]], VVHError] = {
-    val fetchVVHStartTime = System.currentTimeMillis()
-    val request = new HttpPost(url)
-    request.setEntity(new UrlEncodedFormEntity(formparams, "utf-8"))
-    val client = HttpClientBuilder.create().build()
-    val response = client.execute(request)
-    try {
-      mapFields(parse(StreamInput(response.getEntity.getContent)).values.asInstanceOf[Map[String, Any]], url)
-    } finally {
-      response.close()
-      val fetchVVHTimeSec = (System.currentTimeMillis()-fetchVVHStartTime)*0.001
-      if(fetchVVHTimeSec > 5)
-        logger.info("fetch vvh took %.3f sec with the following url %s".format(fetchVVHTimeSec, url))
+    time(logger, s"Fetch VVH features with url '$url'") {
+      val request = new HttpPost(url)
+      request.setEntity(new UrlEncodedFormEntity(formparams, "utf-8"))
+      val client = HttpClientBuilder.create().build()
+      val response = client.execute(request)
+      try {
+        mapFields(parse(StreamInput(response.getEntity.getContent)).values.asInstanceOf[Map[String, Any]], url)
+      } finally {
+        response.close()
+      }
     }
   }
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/vvh/VVHClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/vvh/VVHClient.scala
@@ -7,6 +7,7 @@ import com.vividsolutions.jts.geom.Polygon
 import fi.liikennevirasto.digiroad2.Point
 import fi.liikennevirasto.digiroad2.asset._
 import fi.liikennevirasto.digiroad2.linearasset.RoadLinkLike
+import fi.liikennevirasto.digiroad2.util.LogUtils.time
 import org.apache.http.NameValuePair
 import org.apache.http.client.entity.UrlEncodedFormEntity
 import org.apache.http.client.methods.{HttpGet, HttpPost}
@@ -354,17 +355,16 @@ trait VVHClientOperations {
   }
 
   protected def fetchVVHFeatures(url: String): Either[List[Map[String, Any]], VVHError] = {
-    val fetchVVHStartTime = System.currentTimeMillis()
-    val request = new HttpGet(url)
-    val client = HttpClientBuilder.create().build()
-    val response = client.execute(request)
-    try {
-      mapFields(parse(StreamInput(response.getEntity.getContent)).values.asInstanceOf[Map[String, Any]], url)
-    } finally {
-      response.close()
-      val fetchVVHTimeSec = (System.currentTimeMillis()-fetchVVHStartTime)*0.001
-      if(fetchVVHTimeSec > 5)
-        logger.info("fetch vvh took %.3f sec with the following url %s".format(fetchVVHTimeSec, url))
+    time(logger, s"Fetch VVH features with url '$url'") {
+      val fetchVVHStartTime = System.currentTimeMillis()
+      val request = new HttpGet(url)
+      val client = HttpClientBuilder.create().build()
+      val response = client.execute(request)
+      try {
+        mapFields(parse(StreamInput(response.getEntity.getContent)).values.asInstanceOf[Map[String, Any]], url)
+      } finally {
+        response.close()
+      }
     }
   }
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/LogUtils.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/LogUtils.scala
@@ -1,0 +1,18 @@
+package fi.liikennevirasto.digiroad2.util
+
+import org.slf4j.Logger
+
+object LogUtils {
+  val timeLoggingThresholdInMs = 1
+
+  def time[R](logger: Logger, operationName: String)(f: => R): R = {
+    val begin = System.currentTimeMillis()
+    val result = f
+    val duration = System.currentTimeMillis() - begin
+    if (duration >= timeLoggingThresholdInMs) {
+      logger.info(s"$operationName completed in $duration ms")
+    }
+    result
+  }
+
+}

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
@@ -252,7 +252,7 @@ class RoadAddressService(roadLinkService: RoadLinkService, eventbus: DigiroadEve
     val linkIds = roadLinks.map(_.linkId).toSet
 
     val changedRoadLinks = Await.result(changedRoadLinksF, Duration.Inf)
-    logger.info("Change info fetched in %d ms".format((System.currentTimeMillis() - fetchVVHEndTime)))
+    logger.info("Fetch change info completed in %d ms".format((System.currentTimeMillis() - fetchVVHEndTime)))
 
     val complementedWithChangeAddresses = time(logger, "Complemented with change addresses") {
       applyChanges(roadLinks, if (!frozenTimeVVHAPIServiceEnabled) changedRoadLinks else Seq(), addresses)

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
@@ -284,7 +284,7 @@ class RoadAddressService(roadLinkService: RoadLinkService, eventbus: DigiroadEve
 
     val fetchRoadAddressesByBoundingBoxF = Future(fetchRoadAddressesByBoundingBox(boundingRectangle, fetchOnlyFloating = false, onlyNormalRoads = true, roadNumberLimits))
 
-    val fetchResult = time(logger, "fetchRoadAddressesByBoundingBox") {
+    val fetchResult = time(logger, "Fetch road addresses by bounding box") {
       Await.result(fetchRoadAddressesByBoundingBoxF, Duration.Inf)
     }
     val (historyLinkAddresses, addresses) = (fetchResult.historyLinkAddresses, fetchResult.current)

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadAddressChangesDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadAddressChangesDAO.scala
@@ -3,8 +3,6 @@ package fi.liikennevirasto.viite.dao
 import java.sql.PreparedStatement
 
 import fi.liikennevirasto.viite.RoadType
-import com.github.tototoshi.slick.MySQLJodaSupport._
-import fi.liikennevirasto.digiroad2.oracle.OracleDatabase
 import fi.liikennevirasto.viite.dao.RoadAddressDAO.formatter
 import fi.liikennevirasto.viite.process.{Delta, ProjectDeltaCalculator, RoadAddressSection}
 import org.joda.time.DateTime
@@ -258,7 +256,7 @@ object RoadAddressChangesDAO {
     }
 
     val startTime = System.currentTimeMillis()
-    logger.info("Starting delta insertion in ChangeTable ")
+    logger.info("Begin delta insertion in ChangeTable")
     ProjectDAO.getRoadAddressProjectById(projectId) match {
       case Some(project) => {
         project.ely match {
@@ -288,7 +286,7 @@ object RoadAddressChangesDAO {
             roadAddressChangePS.executeBatch()
             roadAddressChangePS.close()
             val endTime = System.currentTimeMillis()
-            logger.info("Ended delta insertion in ChangeTable in %.3f sec".format((endTime - startTime)*0.001))
+            logger.info("Delta insertion in ChangeTable completed in %d ms".format(endTime - startTime))
             true
           }
           case _=>  false

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadAddressDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadAddressDAO.scala
@@ -15,7 +15,7 @@ import fi.liikennevirasto.viite.model.{Anomaly, RoadAddressLinkLike}
 import fi.liikennevirasto.viite.process.InvalidAddressDataException
 import fi.liikennevirasto.viite.process.RoadAddressFiller.LRMValueAdjustment
 import fi.liikennevirasto.viite.util.CalibrationPointsUtils
-import fi.liikennevirasto.viite.{NewCommonHistoryId, NewRoadAddress, RoadCheckOptions, RoadType}
+import fi.liikennevirasto.viite._
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import org.slf4j.LoggerFactory
@@ -401,8 +401,10 @@ object RoadAddressDAO {
 
 
   private def queryList(query: String): List[RoadAddress] = {
-    val tuples = Q.queryNA[RoadAddress](query).list
-    tuples.groupBy(_.id).map{
+    val tuples = time(logger, "Fetch list of road addresses") {
+      Q.queryNA[RoadAddress](query).list
+    }
+    tuples.groupBy(_.id).map {
       case (id, roadAddressList) =>
         roadAddressList.head
     }.toList

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadAddressDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadAddressDAO.scala
@@ -6,16 +6,17 @@ import com.github.tototoshi.slick.MySQLJodaSupport._
 import fi.liikennevirasto.digiroad2.asset.{BoundingRectangle, LinkGeomSource, SideCode}
 import fi.liikennevirasto.digiroad2.dao.{Queries, Sequences}
 import fi.liikennevirasto.digiroad2.oracle.{MassQuery, OracleDatabase}
+import fi.liikennevirasto.digiroad2.util.LogUtils.time
 import fi.liikennevirasto.digiroad2.util.Track
 import fi.liikennevirasto.digiroad2.{GeometryUtils, Point}
 import fi.liikennevirasto.viite.AddressConsistencyValidator.{AddressError, AddressErrorDetails}
+import fi.liikennevirasto.viite._
 import fi.liikennevirasto.viite.dao.CalibrationPointDAO.CalibrationPointMValues
 import fi.liikennevirasto.viite.dao.TerminationCode.{NoTermination, Subsequent}
 import fi.liikennevirasto.viite.model.{Anomaly, RoadAddressLinkLike}
 import fi.liikennevirasto.viite.process.InvalidAddressDataException
 import fi.liikennevirasto.viite.process.RoadAddressFiller.LRMValueAdjustment
 import fi.liikennevirasto.viite.util.CalibrationPointsUtils
-import fi.liikennevirasto.viite._
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import org.slf4j.LoggerFactory

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/package.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/package.scala
@@ -6,6 +6,7 @@ import fi.liikennevirasto.digiroad2.util.Track
 import fi.liikennevirasto.viite.dao.{BaseRoadAddress, LinkStatus}
 import fi.liikennevirasto.viite.dao.Discontinuity.{ChangingELYCode, EndOfRoad}
 import fi.liikennevirasto.viite.model.RoadAddressLinkLike
+import org.slf4j.Logger
 
 import scala.util.matching.Regex.Match
 
@@ -106,6 +107,18 @@ package object viite {
   val DefaultLatitude = 390000.0
   val DefaultZoomLevel = 2
   val operationsLeavingHistory = List(LinkStatus.Transfer, LinkStatus.Terminated, LinkStatus.Numbering)
+
+  val timeLoggingThresholdInMs = 1
+
+  def time[R](logger: Logger, operationName: String)(f: => R): R = {
+    val begin = System.currentTimeMillis()
+    val result = f
+    val duration = System.currentTimeMillis() - begin
+    if (duration >= timeLoggingThresholdInMs) {
+      logger.info(s"$operationName completed in $duration ms")
+    }
+    result
+  }
 
   def switchSideCode(sideCode: SideCode): SideCode = {
     // Switch between against and towards 2 -> 3, 3 -> 2

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/package.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/package.scala
@@ -108,18 +108,6 @@ package object viite {
   val DefaultZoomLevel = 2
   val operationsLeavingHistory = List(LinkStatus.Transfer, LinkStatus.Terminated, LinkStatus.Numbering)
 
-  val timeLoggingThresholdInMs = 1
-
-  def time[R](logger: Logger, operationName: String)(f: => R): R = {
-    val begin = System.currentTimeMillis()
-    val result = f
-    val duration = System.currentTimeMillis() - begin
-    if (duration >= timeLoggingThresholdInMs) {
-      logger.info(s"$operationName completed in $duration ms")
-    }
-    result
-  }
-
   def switchSideCode(sideCode: SideCode): SideCode = {
     // Switch between against and towards 2 -> 3, 3 -> 2
     SideCode.apply(5-sideCode.value)

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/RoadAddressFiller.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/RoadAddressFiller.scala
@@ -3,11 +3,13 @@ package fi.liikennevirasto.viite.process
 import fi.liikennevirasto.digiroad2.GeometryUtils
 import fi.liikennevirasto.digiroad2.asset.State
 import fi.liikennevirasto.digiroad2.linearasset.RoadLinkLike
+import fi.liikennevirasto.digiroad2.util.LogUtils.time
 import fi.liikennevirasto.viite.RoadType.PublicRoad
-import fi.liikennevirasto.viite.{RoadAddressLinkBuilder, _}
 import fi.liikennevirasto.viite.dao.MissingRoadAddress
 import fi.liikennevirasto.viite.model.{Anomaly, ProjectAddressLink, RoadAddressLink}
+import fi.liikennevirasto.viite.{RoadAddressLinkBuilder, _}
 import org.slf4j.LoggerFactory
+
 
 object RoadAddressFiller {
 

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/RoadAddressFiller.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/RoadAddressFiller.scala
@@ -102,27 +102,28 @@ object RoadAddressFiller {
   }
 
   def fillTopology(roadLinks: Seq[RoadLinkLike], roadAddressMap: Map[Long, Seq[RoadAddressLink]]): (Seq[RoadAddressLink], AddressChangeSet) = {
-    val fillOperations: Seq[(RoadLinkLike, Seq[RoadAddressLink], AddressChangeSet) => (Seq[RoadAddressLink], AddressChangeSet)] = Seq(
-      dropSegmentsOutsideGeometry,
-      capToGeometry,
-      extendToGeometry,
-      dropShort
-    )
-    val initialChangeSet = AddressChangeSet(Set.empty, Nil, Nil)
-    logger.info(s"Starting filling topology.")
-    roadLinks.foldLeft(Seq.empty[RoadAddressLink], initialChangeSet) { case (acc, roadLink) =>
-      val (existingSegments, changeSet) = acc
-      val segments = roadAddressMap.getOrElse(roadLink.linkId, Nil)
-      val validSegments = segments.filterNot { segment => changeSet.toFloatingAddressIds.contains(segment.id) }
+    time(logger, "Fill topology") {
+      val fillOperations: Seq[(RoadLinkLike, Seq[RoadAddressLink], AddressChangeSet) => (Seq[RoadAddressLink], AddressChangeSet)] = Seq(
+        dropSegmentsOutsideGeometry,
+        capToGeometry,
+        extendToGeometry,
+        dropShort
+      )
+      val initialChangeSet = AddressChangeSet(Set.empty, Nil, Nil)
+      roadLinks.foldLeft(Seq.empty[RoadAddressLink], initialChangeSet) { case (acc, roadLink) =>
+        val (existingSegments, changeSet) = acc
+        val segments = roadAddressMap.getOrElse(roadLink.linkId, Nil)
+        val validSegments = segments.filterNot { segment => changeSet.toFloatingAddressIds.contains(segment.id) }
 
-      val (adjustedSegments, segmentAdjustments) = fillOperations.foldLeft(validSegments, changeSet) { case ((currentSegments, currentAdjustments), operation) =>
-        operation(roadLink, currentSegments, currentAdjustments)
+        val (adjustedSegments, segmentAdjustments) = fillOperations.foldLeft(validSegments, changeSet) { case ((currentSegments, currentAdjustments), operation) =>
+          operation(roadLink, currentSegments, currentAdjustments)
+        }
+        val generatedRoadAddresses = generateUnknownRoadAddressesForRoadLink(roadLink, adjustedSegments)
+        val generatedLinks = buildMissingRoadAddress(roadLink, generatedRoadAddresses)
+        (existingSegments ++ adjustedSegments ++ generatedLinks,
+          segmentAdjustments.copy(missingRoadAddresses = segmentAdjustments.missingRoadAddresses ++
+            generatedRoadAddresses.filterNot(_.anomaly == Anomaly.None)))
       }
-      val generatedRoadAddresses = generateUnknownRoadAddressesForRoadLink(roadLink, adjustedSegments)
-      val generatedLinks = buildMissingRoadAddress(roadLink, generatedRoadAddresses)
-      (existingSegments ++ adjustedSegments ++ generatedLinks,
-        segmentAdjustments.copy(missingRoadAddresses = segmentAdjustments.missingRoadAddresses ++
-          generatedRoadAddresses.filterNot(_.anomaly == Anomaly.None)))
     }
   }
 


### PR DESCRIPTION
Added logging of times different operations take especially in getting the road links. This helps us to identify the slow parts.

Currently the threshold for logging the time is only 1 ms, but later it can be changed to for example 100ms, so that only the slow operations are logged. Now we are interested to see from the logs also if something is working fast.