### PR TITLE
VIITE-1365 direction arrows are displayed at 50m

### DIFF
--- a/viite-UI/src/utils/zoom-levels.js
+++ b/viite-UI/src/utils/zoom-levels.js
@@ -10,7 +10,7 @@
       return zoom < 10 ? 10 : zoom;
     },
     minZoomForAssets: 6,
-    minZoomForDirectionalMarkers: 9,
+    minZoomForDirectionalMarkers: 11,
     minZoomForRoadLinks: 5,
     minZoomForEditMode: 10,
     maxZoomLevel: 15


### PR DESCRIPTION
Changed zoom level for directional arrows from 9 to 11.