### PR TITLE
VIITE-1402 Adding project markers to interactions and refactoring of markers

### DIFF
--- a/viite-UI/src/application.js
+++ b/viite-UI/src/application.js
@@ -74,14 +74,14 @@
       })
     });
 
-    var ctrlDragZoom = new ol.interaction.DragZoom({
+    var shiftDragZoom = new ol.interaction.DragZoom({
       duration: 1500,
       condition: function(mapBrowserEvent) {
         var originalEvent = mapBrowserEvent.originalEvent;
         return (
-        originalEvent.ctrlKey &&
+            originalEvent.shiftKey &&
         !(originalEvent.metaKey || originalEvent.altKey) &&
-        !originalEvent.shiftKey);
+            !originalEvent.ctrlKey);
       }
     });
     map.getInteractions().forEach(function(interaction) {
@@ -90,8 +90,8 @@
       }
     }, this);
 
-    ctrlDragZoom.setActive(true);
-    map.addInteraction(ctrlDragZoom);
+    shiftDragZoom.setActive(true);
+    map.addInteraction(shiftDragZoom);
     map.setProperties({extent : [-548576, 6291456, 1548576, 8388608]});
     return map;
   };

--- a/viite-UI/src/map/LinkPropertyMarker.js
+++ b/viite-UI/src/map/LinkPropertyMarker.js
@@ -1,12 +1,7 @@
 (function(root) {
   root.LinkPropertyMarker = function(data) {
-    var me = this;
-
     var createMarker = function(roadlink) {
       var middlePoint = calculateMiddlePoint(roadlink);
-      var bounds = getBounds(middlePoint.x, middlePoint.y);
-      var LinkGeomSource = LinkValues.LinkGeomSource;
-      var RoadLinkType = LinkValues.RoadLinkType;
       var box = new ol.Feature({
         geometry: new ol.geom.Point([middlePoint.x, middlePoint.y]),
         linkId : roadlink.linkId,
@@ -28,70 +23,15 @@
         zIndex: 10
       });
 
-      var colorMap =
-        {           //comment includes legend name
-          1:'#db0e0e',         //Valtatie
-          2:'#ff6600',         //Kantatie
-          3:'#ff9955',         //Seututie
-          4:'#1414db',         //Yhdystie (dark blue)
-          5:'#10bfc4',         //Yhdystie (light blue)
-          6:'#800080',         //Numeroitu katu
-          7:'#10bfc4',         //Ramppi tai kiertoliittymä
-          8:'#fc6da0',         //Jalka tai pyörätie
-          9:'#fc6da0',         //Talvitie
-          10:'#fc6da0',        //Polku
-          11:'#888888'         //Muu tieverkko
-        };
-
-      var directionMarkerColor= function(roadLink){
-        if(roadLink.status === 2){
-          return '#ff55dd';
-        } else if (roadLink.roadLinkSource === LinkGeomSource.SuravageLinkInterface.value && roadLink.id === 0) {
-          return '#d3aff6';
-        }
-        else if (roadLink.roadClass in colorMap) {
-          return colorMap[roadLink.roadClass];
-        } else
-          return '#888888';
-      };
-
-      function hex2Rgba(hex){
-        hex = hex.replace('#','');
-        var colorR = parseInt(hex.substring(0, hex.length/3), 16);
-        var colorG = parseInt(hex.substring(hex.length/3, 2*hex.length/3), 16);
-        var colorB = parseInt(hex.substring(2*hex.length/3, 3*hex.length/3), 16);
-        return 'rgba('+colorR+','+colorG+','+colorB+',1)';
-      }
-
-      var boxStyleDirectional = function(rl) {
-       var markerColor=hex2Rgba(directionMarkerColor(rl));
-       var directionMarker='<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 258.4 387.6" width="36px"  height="22px"> <g transform="translate(-350.8,-86.2)"> <path d="M 609.2,344.6 C 609.2,215.4 480,86.2 480,86.2 c 0,0 -129.2,129.2 -129.2,258.4 0,81.8 68.9,129.2 129.2,129.2 60.3,0 129.2,-47.3 129.2,-129.2 z M 480,441.5 c -53.8,0 -96.9,-43.1 -96.9,-96.9 0,-53.8 43.1,-96.9 96.9,-96.9 53.8,0 96.9,43.1 96.9,96.9 0,53.8 -43.1,96.9 -96.9,96.9 z" fill="'+markerColor+'"/><path d="M 582.7,341.9 C 582.7,234.9 480,128 480,128 c 0,0 -102.7,106.9 -102.7,213.9 0,67.7 54.8,106.9 102.7,106.9 47.9,0 102.7,-39.2 102.7,-106.9 z" fill="rgba(255,255,255,1)"/> 	<path    d="m 556.4,345.6 c 0,-40.9 -34.5,-75.4 -75.4,-75.4 -40.9,0 -75.4,34.5 -75.4,75.4 0,40.9 34.5,75.4 75.4,75.4 40.9,0 75.4,-34.5 75.4,-75.4 z " fill="'+markerColor+'"/> </g></svg>';
-        return new ol.style.Style({
-          image: new ol.style.Icon({
-            rotation: rl.sideCode === 3 ? middlePoint.angleFromNorth * Math.PI / 180 + Math.PI : middlePoint.angleFromNorth * Math.PI / 180,
-            src: 'data:image/svg+xml;utf8,' + directionMarker
-          }),
-          zIndex: 10
-        });
-      };
-
       if(roadlink.roadLinkType===-1){
         box.setStyle(boxStyleFloat);
-      } else if(roadlink.roadLinkSource===LinkGeomSource.SuravageLinkInterface.value){
-        box.setStyle(boxStyleDirectional(roadlink));
-      } else if(roadlink.id===0 && roadlink.roadLinkType === RoadLinkType.UnknownRoadLinkType.value){
+      } else if(roadlink.id===0 && roadlink.roadLinkType === LinkValues.RoadLinkType.UnknownRoadLinkType.value){
         box.setStyle(boxStyleUnknown);
-      } else {
-        box.setStyle(boxStyleDirectional(roadlink));
       }
 
       box.id = roadlink.linkId;
-      box.roadLinkData = roadlink;
+      box.linkData = roadlink;
       return box;
-    };
-
-    var getBounds = function(lon, lat) {
-      return [lon, lat, lat, lon];
     };
 
     var calculateMiddlePoint = function(link){
@@ -99,8 +39,7 @@
         return [point.x, point.y];
       });
       var lineString = new ol.geom.LineString(points);
-      var middlePoint = GeometryUtils.calculateMidpointOfLineString(lineString);
-      return middlePoint;
+      return GeometryUtils.calculateMidpointOfLineString(lineString);
     };
 
     return {

--- a/viite-UI/src/map/ProjectLinkMarker.js
+++ b/viite-UI/src/map/ProjectLinkMarker.js
@@ -1,0 +1,77 @@
+(function(root) {
+  root.ProjectLinkMarker = function() {
+
+    var createProjectMarker = function(roadLink) {
+      var middlePoint = calculateMiddlePoint(roadLink);
+      var box = new ol.Feature({
+        geometry: new ol.geom.Point([middlePoint.x, middlePoint.y]),
+        linkId : roadLink.linkId,
+        type : "marker"
+      });
+
+      var colorMap =
+        {           //comment includes legend name
+          1:'#db0e0e',         //Valtatie
+          2:'#ff6600',         //Kantatie
+          3:'#ff9955',         //Seututie
+          4:'#1414db',         //Yhdystie (dark blue)
+          5:'#10bfc4',         //Yhdystie (light blue)
+          6:'#800080',         //Numeroitu katu
+          7:'#10bfc4',         //Ramppi tai kiertoliittymä
+          8:'#fc6da0',         //Jalka tai pyörätie
+          9:'#fc6da0',         //Talvitie
+          10:'#fc6da0',        //Polku
+          11:'#888888'         //Muu tieverkko
+        };
+
+      var directionMarkerColor= function(roadLink){
+        if(roadLink.status === LinkValues.LinkStatus.New){
+          return '#ff55dd';
+        } else if (roadLink.roadLinkSource ===  LinkValues.LinkGeomSource.SuravageLinkInterface.value && roadLink.id === 0) {
+          return '#d3aff6';
+        }
+        else if (roadLink.roadClass in colorMap) {
+          return colorMap[roadLink.roadClass];
+        } else
+          return '#888888';
+      };
+
+      function hex2Rgba(hex){
+        hex = hex.replace('#','');
+        var colorR = parseInt(hex.substring(0, hex.length/3), 16);
+        var colorG = parseInt(hex.substring(hex.length/3, 2*hex.length/3), 16);
+        var colorB = parseInt(hex.substring(2*hex.length/3, 3*hex.length/3), 16);
+        return 'rgba('+colorR+','+colorG+','+colorB+',1)';
+      }
+
+      var boxStyleDirectional = function(rl) {
+       var markerColor=hex2Rgba(directionMarkerColor(rl));
+       var directionMarker='<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 258.4 387.6" width="36px"  height="22px"> <g transform="translate(-350.8,-86.2)"> <path d="M 609.2,344.6 C 609.2,215.4 480,86.2 480,86.2 c 0,0 -129.2,129.2 -129.2,258.4 0,81.8 68.9,129.2 129.2,129.2 60.3,0 129.2,-47.3 129.2,-129.2 z M 480,441.5 c -53.8,0 -96.9,-43.1 -96.9,-96.9 0,-53.8 43.1,-96.9 96.9,-96.9 53.8,0 96.9,43.1 96.9,96.9 0,53.8 -43.1,96.9 -96.9,96.9 z" fill="'+markerColor+'"/><path d="M 582.7,341.9 C 582.7,234.9 480,128 480,128 c 0,0 -102.7,106.9 -102.7,213.9 0,67.7 54.8,106.9 102.7,106.9 47.9,0 102.7,-39.2 102.7,-106.9 z" fill="rgba(255,255,255,1)"/> 	<path    d="m 556.4,345.6 c 0,-40.9 -34.5,-75.4 -75.4,-75.4 -40.9,0 -75.4,34.5 -75.4,75.4 0,40.9 34.5,75.4 75.4,75.4 40.9,0 75.4,-34.5 75.4,-75.4 z " fill="'+markerColor+'"/> </g></svg>';
+        return new ol.style.Style({
+          image: new ol.style.Icon({
+            rotation: rl.sideCode === LinkValues.SideCode.AgainstDigitizing ? middlePoint.angleFromNorth * Math.PI / 180 + Math.PI : middlePoint.angleFromNorth * Math.PI / 180,
+            src: 'data:image/svg+xml;utf8,' + directionMarker
+          }),
+          zIndex: 10
+        });
+      };
+
+      box.setStyle(boxStyleDirectional(roadLink));
+      box.id = roadLink.linkId;
+      box.linkData = roadLink;
+      return box;
+    };
+
+    var calculateMiddlePoint = function(link){
+      var points = _.map(link.points, function(point) {
+        return [point.x, point.y];
+      });
+      var lineString = new ol.geom.LineString(points);
+      return GeometryUtils.calculateMidpointOfLineString(lineString);
+    };
+
+    return {
+      createProjectMarker: createProjectMarker
+    };
+  };
+}(this));

--- a/viite-UI/src/model/RoadCollection.js
+++ b/viite-UI/src/model/RoadCollection.js
@@ -394,7 +394,7 @@
           var feature = new ol.Feature({
             geometry: new ol.geom.LineString(points)
           });
-          feature.projectLinkData = road;
+          feature.linkData = road;
           feature.projectId = projectId;
           return feature;
         });

--- a/viite-UI/src/model/SelectedLinkProperty.js
+++ b/viite-UI/src/model/SelectedLinkProperty.js
@@ -219,7 +219,7 @@
     var processOl3Features = function (visibleFeatures){
       var selectedOL3Features = _.filter(visibleFeatures, function(vf){
         return (_.some(get().concat(featuresToKeep), function(s){
-            return s.linkId === vf.roadLinkData.linkId &&  s.mmlId === vf.roadLinkData.mmlId;
+            return s.linkId === vf.linkData.linkId &&  s.mmlId === vf.linkData.mmlId;
           }));
       });
       eventbus.trigger('linkProperties:ol3Selected', selectedOL3Features);
@@ -775,7 +775,7 @@
         //Filter the features without said linkIds
         if(linkIdsToRemove.length !== 0){
           return _.reject(features, function(feature){
-            return _.contains(linkIdsToRemove, feature.roadLinkData.linkId);
+            return _.contains(linkIdsToRemove, feature.linkData.linkId);
           });
         } else {
           return features;

--- a/viite-UI/src/utils/LinkValues.js
+++ b/viite-UI/src/utils/LinkValues.js
@@ -109,5 +109,17 @@
         IndicatorLayer:             {value: 99}
     };
 
+  /*
+  The meta key codes are browser dependant, in proper:
+      Firefox: 224
+      Opera: 17
+      WebKit (Safari/Chrome): 91 (Left Apple) or 93 (Right Apple)
+
+   A blessing in disguise, CTRL key code is always fixed to 17.
+   */
+  root.MetaKeyCodes = [91, 93, 224, 17];
+
+  root.SelectKeyName = "ContextMenu";
+
 })(window.LinkValues = window.LinkValues || {});
 

--- a/viite-UI/src/utils/backend-utils.js
+++ b/viite-UI/src/utils/backend-utils.js
@@ -420,7 +420,7 @@
       return self;
     };
 
-    this.withRoadLinkData = function (roadLinkData, afterSaveRoadLinkData) {
+    this.withLinkData = function (linkData, afterSaveLinkData) {
 
       var fetchedRoadLinkModels = function (fetchedRoadLinks) {
        return _.map(fetchedRoadLinks, function (roadLinkGroup) {
@@ -431,11 +431,11 @@
       };
       self.getRoadLinks = function (boundingBox, callback) {
         if (afterSave) {
-          callback(afterSaveRoadLinkData);
+          callback(afterSaveLinkData);
         } else {
-          callback(roadLinkData);
+          callback(linkData);
         }
-        eventbus.trigger('roadLinks:fetched', afterSave ? fetchedRoadLinkModels(afterSaveRoadLinkData) : fetchedRoadLinkModels(roadLinkData));
+        eventbus.trigger('roadLinks:fetched', afterSave ? fetchedRoadLinkModels(afterSaveLinkData) : fetchedRoadLinkModels(linkData));
       };
       return self;
     };
@@ -454,10 +454,10 @@
     };
 
     this.withFloatingAdjacents = function (selectedFloatingData, selectedUnknownData) {
-      self.getFloatingAdjacent= function (roadLinkData, callback) {
-        if (roadLinkData.linkId === 1718151 || roadLinkData.linkId === 1718152) {
+      self.getFloatingAdjacent= function (linkData, callback) {
+        if (linkData.linkId === 1718151 || linkData.linkId === 1718152) {
           callback(selectedFloatingData);
-        } else if (roadLinkData.linkId === 500130202) {
+        } else if (linkData.linkId === 500130202) {
           callback(selectedUnknownData);
         } else {
           callback([]);

--- a/viite-UI/src/view/LinkPropertyLayer.js
+++ b/viite-UI/src/view/LinkPropertyLayer.js
@@ -64,7 +64,7 @@
     var geometryChangedLayer = new ol.layer.Vector({
       source: geometryChangedVector,
       style: function(feature) {
-        return styler.generateStyleByFeature(feature.roadLinkData,map.getView().getZoom());
+        return styler.generateStyleByFeature(feature.linkData,map.getView().getZoom());
       },
       zIndex: RoadZIndex.GeometryChangedLayer.value
     });
@@ -122,7 +122,7 @@
       source: pickRoadsLayerVector,
       name: 'pickRoadsLayer',
       style: function(feature) {
-        return styler.generateStyleByFeature(feature.roadLinkData,map.getView().getZoom());
+        return styler.generateStyleByFeature(feature.linkData,map.getView().getZoom());
       }
     });
 
@@ -130,7 +130,7 @@
       source: simulationVector,
       name: 'simulatedRoadsLayer',
       style: function(feature) {
-        return styler.generateStyleByFeature(feature.roadLinkData,map.getView().getZoom());
+        return styler.generateStyleByFeature(feature.linkData,map.getView().getZoom());
       }
     });
 
@@ -138,7 +138,7 @@
       source: suravageRoadLayerVector,
       name: 'suravageRoadLayer',
       style: function(feature) {
-        return styler.generateStyleByFeature(feature.roadLinkData,map.getView().getZoom());
+        return styler.generateStyleByFeature(feature.linkData,map.getView().getZoom());
       }
     });
 
@@ -146,7 +146,7 @@
       source: historicRoadsVector,
       name: 'historicRoadsLayer',
       style: function(feature) {
-        return styler.generateStyleByFeature(feature.roadLinkData,map.getView().getZoom());
+        return styler.generateStyleByFeature(feature.linkData,map.getView().getZoom());
       },
       zIndex: RoadZIndex.HistoricRoadLayer.value
     });
@@ -188,7 +188,7 @@
       var isAnomalousRoadLayerFeature = _.find(roadLayerFeatures,function(rlf){
         return rlf.id === featureId;
       });
-      var isAnomalousRoadLayer = _.isUndefined(isAnomalousRoadLayerFeature) ? false : isAnomalousRoadLayerFeature.roadLinkData.anomaly === Anomaly.NoAddressGiven.value;
+      var isAnomalousRoadLayer = _.isUndefined(isAnomalousRoadLayerFeature) ? false : isAnomalousRoadLayerFeature.linkData.anomaly === Anomaly.NoAddressGiven.value;
       return isAnomalous || isAnomalousRoadLayer;
     };
 
@@ -224,7 +224,7 @@
       condition: ol.events.condition.doubleClick,
       //The new/temporary layer needs to have a style function as well, we define it here.
       style: function(feature) {
-        return styler.generateStyleByFeature(feature.roadLinkData,map.getView().getZoom());
+        return styler.generateStyleByFeature(feature.linkData,map.getView().getZoom());
       }
     });
 
@@ -252,15 +252,15 @@
           setGeneralOpacity(0.2);
         }
         var selection = _.find(event.selected, function(selectionTarget){
-          return !_.isUndefined(selectionTarget.roadLinkData);
+          return !_.isUndefined(selectionTarget.linkData);
         });
-        if (selection.roadLinkData.roadLinkType === RoadLinkType.FloatingRoadLinkType.value &&
+        if (selection.linkData.roadLinkType === RoadLinkType.FloatingRoadLinkType.value &&
           ('all' === applicationModel.getSelectionType() || 'floating' === applicationModel.getSelectionType()) &&
           !applicationModel.isReadOnly()) {
-          selectedLinkProperty.openFloating(selection.roadLinkData.linkId, selection.roadLinkData.id, true, visibleFeatures);
+          selectedLinkProperty.openFloating(selection.linkData.linkId, selection.linkData.id, true, visibleFeatures);
           floatingMarkerLayer.setOpacity(1);
         } else {
-          selectedLinkProperty.open(selection.roadLinkData.linkId, selection.roadLinkData.id, true, visibleFeatures, selection.roadLinkData.roadLinkSource === LinkGeomSource.SuravageLinkInterface.value);
+          selectedLinkProperty.open(selection.linkData.linkId, selection.linkData.id, true, visibleFeatures, selection.linkData.roadLinkSource === LinkGeomSource.SuravageLinkInterface.value);
         }
       } else if (event.selected.length === 0 && event.deselected.length !== 0){
         selectedLinkProperty.close();
@@ -297,7 +297,7 @@
       condition: ol.events.condition.singleClick,
       //The new/temporary layer needs to have a style function as well, we define it here.
       style: function(feature, resolution) {
-        return styler.generateStyleByFeature(feature.roadLinkData,map.getView().getZoom(), true);
+        return styler.generateStyleByFeature(feature.linkData,map.getView().getZoom(), true);
       }
     });
     selectSingleClick.set('name','selectSingleClickInteractionLPL');
@@ -319,7 +319,7 @@
         selectDoubleClick.getFeatures().clear();
       }
       var selection = _.find(event.selected, function (selectionTarget) {
-        return !_.isUndefined(selectionTarget.roadLinkData);
+        return !_.isUndefined(selectionTarget.linkData);
       });
       //Since the selected features are moved to a new/temporary layer we just need to reduce the roadlayer's opacity levels.
       if (!_.isUndefined(selection)) {
@@ -327,22 +327,22 @@
           if (roadLayer.layer.getOpacity() === 1) {
             setGeneralOpacity(0.2);
           }
-          if (selection.roadLinkData.roadLinkType === RoadLinkType.FloatingRoadLinkType.value &&
+          if (selection.linkData.roadLinkType === RoadLinkType.FloatingRoadLinkType.value &&
             ('all' === applicationModel.getSelectionType() || 'floating' === applicationModel.getSelectionType()) &&
             !applicationModel.isReadOnly()) {
             selectedLinkProperty.close();
-            selectedLinkProperty.openFloating(selection.roadLinkData.linkId, selection.roadLinkData.id, false, visibleFeatures);
+            selectedLinkProperty.openFloating(selection.linkData.linkId, selection.linkData.id, false, visibleFeatures);
             floatingMarkerLayer.setOpacity(1);
             anomalousMarkerLayer.setOpacity(1);
-          } else if(selection.roadLinkData.roadLinkType !== RoadLinkType.FloatingRoadLinkType.value && 'floating' === applicationModel.getSelectionType() &&
+          } else if(selection.linkData.roadLinkType !== RoadLinkType.FloatingRoadLinkType.value && 'floating' === applicationModel.getSelectionType() &&
             !applicationModel.isReadOnly() && event.deselected.length !== 0) {
             var floatings = event.deselected;
             var nonFloatings = event.selected;
             removeFeaturesFromSelection(nonFloatings);
             addFeaturesToSelection(floatings);
           }else if('unknown' === applicationModel.getSelectionType() && !applicationModel.isReadOnly()) {
-            if ((selection.roadLinkData.anomaly === Anomaly.NoAddressGiven.value || selection.roadLinkData.anomaly === Anomaly.GeometryChanged.value) && selection.roadLinkData.roadLinkType !== RoadLinkType.FloatingRoadLinkType.value ) {
-              selectedLinkProperty.openUnknown(selection.roadLinkData.linkId, selection.roadLinkData.id, visibleFeatures);
+            if ((selection.linkData.anomaly === Anomaly.NoAddressGiven.value || selection.linkData.anomaly === Anomaly.GeometryChanged.value) && selection.linkData.roadLinkType !== RoadLinkType.FloatingRoadLinkType.value ) {
+              selectedLinkProperty.openUnknown(selection.linkData.linkId, selection.linkData.id, visibleFeatures);
             } else if(event.selected.length !== 0){
               var deselecting = event.deselected;
               var selecting = event.selected;
@@ -352,9 +352,9 @@
           }
           else {
             if (isAnomalousById(selection.id) || isFloatingById(selection.id)) {
-              selectedLinkProperty.open(selection.roadLinkData.linkId, selection.roadLinkData.id, false, visibleFeatures, selection.roadLinkData.roadLinkSource === LinkGeomSource.SuravageLinkInterface.value);
+              selectedLinkProperty.open(selection.linkData.linkId, selection.linkData.id, false, visibleFeatures, selection.linkData.roadLinkSource === LinkGeomSource.SuravageLinkInterface.value);
             } else {
-              selectedLinkProperty.open(selection.roadLinkData.linkId, selection.roadLinkData.id, true, visibleFeatures, selection.roadLinkData.roadLinkSource === LinkGeomSource.SuravageLinkInterface.value);
+              selectedLinkProperty.open(selection.linkData.linkId, selection.linkData.id, true, visibleFeatures, selection.linkData.roadLinkSource === LinkGeomSource.SuravageLinkInterface.value);
             }
           }
         }
@@ -366,7 +366,7 @@
       }
 
       if (!_.isUndefined(selection)) {
-        if(applicationModel.getSelectionType() === 'unknown' && selection.roadLinkData.roadLinkType !== RoadLinkType.FloatingRoadLinkType.value && (selection.roadLinkData.anomaly === Anomaly.NoAddressGiven.value || selection.roadLinkData.anomaly === Anomaly.GeometryChanged.value)){
+        if(applicationModel.getSelectionType() === 'unknown' && selection.linkData.roadLinkType !== RoadLinkType.FloatingRoadLinkType.value && (selection.linkData.anomaly === Anomaly.NoAddressGiven.value || selection.linkData.anomaly === Anomaly.GeometryChanged.value)){
           greenRoadLayer.setOpacity(1);
           var anomalousFeatures = _.uniq(_.filter(selectedLinkProperty.getFeaturesToKeep(), function (ft) {
               return ft.anomaly === Anomaly.NoAddressGiven.value;
@@ -507,10 +507,10 @@
       indicatorLayer.getSource().clear();
       greenRoadLayer.getSource().clear();
       _.map(roadLayer.layer.getSource().getFeatures(),function (feature){
-        if(feature.roadLinkData.gapTransfering) {
-          feature.roadLinkData.gapTransfering = false;
-          feature.roadLinkData.anomaly = feature.roadLinkData.prevAnomaly;
-          var unknownRoadStyle = styler.generateStyleByFeature(feature.roadLinkData,map.getView().getZoom());
+        if(feature.linkData.gapTransfering) {
+          feature.linkData.gapTransfering = false;
+          feature.linkData.anomaly = feature.linkData.prevAnomaly;
+          var unknownRoadStyle = styler.generateStyleByFeature(feature.linkData,map.getView().getZoom());
           feature.setStyle(unknownRoadStyle);
         }
       });
@@ -594,7 +594,7 @@
           });
           middlefloating = floatGroup[Math.floor(floatGroup.length / 2)];
           marker = cachedLinkPropertyMarker.createMarker(middlefloating);
-          if(applicationModel.getCurrentAction() !== applicationModel.actionCalculated && !_.contains(linkIdsToRemove,marker.roadLinkData.linkId))
+          if(applicationModel.getCurrentAction() !== applicationModel.actionCalculated && !_.contains(linkIdsToRemove,marker.linkData.linkId))
             floatingMarkerLayer.getSource().addFeature(marker);
         });
 
@@ -606,7 +606,7 @@
 
         _.each(anomalousRoadMarkers, function(anomalouslink) {
           var marker = cachedMarker.createMarker(anomalouslink);
-          if(applicationModel.getCurrentAction() !== applicationModel.actionCalculated && !_.contains(linkIdsToRemove,marker.roadLinkData.linkId))
+          if(applicationModel.getCurrentAction() !== applicationModel.actionCalculated && !_.contains(linkIdsToRemove,marker.linkData.linkId))
             anomalousMarkerLayer.getSource().addFeature(marker);
         });
 
@@ -632,7 +632,7 @@
             return [point.x, point.y];
           });
           var feature = new ol.Feature({ geometry: new ol.geom.LineString(points)});
-          feature.roadLinkData = newRoadLinkData;
+          feature.linkData = newRoadLinkData;
           roadCollection.addTmpRoadLinkGroups(newRoadLinkData);
           geometryChangedLayer.getSource().addFeature(feature);
         });
@@ -677,18 +677,18 @@
         drawIndicators(indicators);
       }
       if (applicationModel.getSelectionType() === 'unknown' && !applicationModel.isReadOnly() &&
-        targetFeature.roadLinkData.anomaly === Anomaly.NoAddressGiven.value && targetFeature.roadLinkData.roadLinkType !== RoadLinkType.FloatingRoadLinkType.value  ){
-        selectedLinkProperty.openUnknown(targetFeature.roadLinkData.linkId, targetFeature.roadLinkData.id, visibleFeatures);
+        targetFeature.linkData.anomaly === Anomaly.NoAddressGiven.value && targetFeature.linkData.roadLinkType !== RoadLinkType.FloatingRoadLinkType.value  ){
+        selectedLinkProperty.openUnknown(targetFeature.linkData.linkId, targetFeature.linkData.id, visibleFeatures);
       }
 
-      if(applicationModel.getSelectionType() === 'unknown' && targetFeature.roadLinkData.roadLinkType !== RoadLinkType.FloatingRoadLinkType.value && targetFeature.roadLinkData.anomaly === Anomaly.NoAddressGiven.value){
+      if(applicationModel.getSelectionType() === 'unknown' && targetFeature.linkData.roadLinkType !== RoadLinkType.FloatingRoadLinkType.value && targetFeature.linkData.anomaly === Anomaly.NoAddressGiven.value){
         greenRoadLayer.setOpacity(1);
         var anomalousFeatures = _.uniq(_.filter(selectedLinkProperty.getFeaturesToKeep(), function (ft) {
             return ft.anomaly === Anomaly.NoAddressGiven.value;
           })
         );
         anomalousFeatures.forEach(function (fmf) {
-          editFeatureDataForGreen(targetFeature.roadLinkData);
+          editFeatureDataForGreen(targetFeature.linkData);
         });
       }
     };
@@ -721,7 +721,7 @@
         var features = [];
         _.each(selectedLink, function (featureLink){
          _.each(roadLayer.layer.getSource().getFeatures(), function(feature){
-            if(featureLink.linkId !== 0 && _.contains(featureLink.selectedLinks, feature.roadLinkData.linkId)){
+            if(featureLink.linkId !== 0 && _.contains(featureLink.selectedLinks, feature.linkData.linkId)){
               return features.push(feature);
             }
           });
@@ -736,9 +736,9 @@
       eventListener.listenTo(eventbus, 'roadLinks:drawAfterGapCanceling', function() {
         currentRenderIntent = 'default';
         _.map(roadLayer.layer.getSource().getFeatures(), function (feature){
-          if(feature.roadLinkData.gapTransfering) {
-            feature.roadLinkData.gapTransfering = false;
-            feature.roadLinkData.anomaly = feature.roadLinkData.prevAnomaly;
+          if(feature.linkData.gapTransfering) {
+            feature.linkData.gapTransfering = false;
+            feature.linkData.anomaly = feature.linkData.prevAnomaly;
           }
         });
         unhighlightFeatures();
@@ -768,11 +768,11 @@
           }).uniq().value();
           var visibleFeatures = getVisibleFeatures(true,false,true);
           var featuresToReSelect = _.filter(visibleFeatures, function(feature){
-            return _.contains(floatingsLinkIds, feature.roadLinkData.linkId);
+            return _.contains(floatingsLinkIds, feature.linkData.linkId);
           });
           var filteredFeaturesToReselect = _.reject(featuresToReSelect, function (feat) {
                 return _.some(currentGreenFeatures, function (green) {
-                    return green.roadLinkData.id === feat.roadLinkData.id;
+                    return green.linkData.id === feat.linkData.id;
                 });
             });
             if (filteredFeaturesToReselect.length !== 0){
@@ -780,8 +780,8 @@
           }
 
           var fetchedDataInSelection = _.map(_.filter(roadLayer.layer.getSource().getFeatures(), function(feature){
-            return _.contains(_.unique(selectedIds), feature.roadLinkData.linkId);
-          }), function(feat){return feat.roadLinkData;});
+            return _.contains(_.unique(selectedIds), feature.linkData.linkId);
+          }), function(feat){return feat.linkData;});
 
                     var groups = _.flatten(eventData);
                     var fetchedLinksInSelection = _.filter(groups, function (group) {
@@ -805,7 +805,7 @@
           var feature = new ol.Feature({
             geometry: new ol.geom.LineString(points)
           });
-          feature.roadLinkData = roadData;
+          feature.linkData = roadData;
           return feature;
         });
         suravageRoadLayer.getSource().addFeatures(ol3SuravageRoads);
@@ -862,10 +862,10 @@
           });
           var feature =  new ol.Feature({ geometry: new ol.geom.LineString(points)
           });
-          feature.roadLinkData = road;
+          feature.linkData = road;
           simulatedOL3Features.push(feature);
           afterTransferLinks.push(road);
-          var marker = cachedMarker.createMarker(feature.roadLinkData);
+          var marker = cachedMarker.createMarker(feature.linkData);
           if(map.getView().getZoom() > zoomlevels.minZoomForDirectionalMarkers) {
             simulatedRoadsLayer.getSource().addFeature(marker);
           }
@@ -889,7 +889,7 @@
 
         _.each(simulatedOL3Features, function(elem) {
           roadLayer.layer.getSource().getFeatures().filter(function(item){
-            if( item.roadLinkData.linkId === elem.roadLinkData.linkId)
+            if( item.linkData.linkId === elem.linkData.linkId)
               roadLayer.layer.getSource().removeFeature(item);
           });
         });
@@ -933,7 +933,7 @@
             return of.linkId;
           });
           _.each(roadLayer.layer.getSource().getFeatures(), function (feature) {
-            if (!_.contains(extractedLinkIds, feature.roadLinkData.linkId) && feature.roadLinkData.roadLinkType === RoadLinkType.FloatingRoadLinkType.value){
+            if (!_.contains(extractedLinkIds, feature.linkData.linkId) && feature.linkData.roadLinkType === RoadLinkType.FloatingRoadLinkType.value){
               features.push(feature);
             }
           });
@@ -941,7 +941,7 @@
           if (!_.isEmpty(features)) {
             currentRenderIntent = 'select';
             var featureToSelect = _.first(features);
-            selectedLinkProperty.openFloating(featureToSelect.roadLinkData.linkId, featureToSelect.roadLinkData.id, false, visibleFeatures);
+            selectedLinkProperty.openFloating(featureToSelect.linkData.linkId, featureToSelect.linkData.id, false, visibleFeatures);
             highlightFeatures();
           }
         }
@@ -1025,15 +1025,15 @@
 
     var redrawNextSelectedTarget= function(targets, adjacents) {
       _.find(roadLayer.layer.getSource().getFeatures(), function(feature) {
-        return targets !== 0 && feature.roadLinkData.linkId === parseInt(targets);
-      }).roadLinkData.gapTransfering = true;
+        return targets !== 0 && feature.linkData.linkId === parseInt(targets);
+      }).linkData.gapTransfering = true;
       var targetFeature = _.find(geometryChangedLayer.getSource().getFeatures(), function(feature) {
-        return targets !== 0 && feature.roadLinkData.linkId === parseInt(targets);
+        return targets !== 0 && feature.linkData.linkId === parseInt(targets);
       });
       if(_.isUndefined(targetFeature))
       {
         targetFeature = _.find(roadLayer.layer.getSource().getFeatures(), function (feature) {
-          return targets !== 0 && feature.roadLinkData.linkId === parseInt(targets);
+          return targets !== 0 && feature.linkData.linkId === parseInt(targets);
         });
       }
       reselectRoadLink(targetFeature, adjacents);
@@ -1043,17 +1043,17 @@
 
     var reHighlightGreen = function() {
       var greenFeaturesLinkId = _.map(greenRoadLayer.getSource().getFeatures(), function(gf){
-        return gf.roadLinkData.linkId;
+        return gf.linkData.linkId;
       });
 
       if (greenFeaturesLinkId.length !== 0) {
         var features =[];
         _.each(roadLayer.layer.getSource().getFeatures(), function (feature) {
-          if (_.contains(greenFeaturesLinkId, feature.roadLinkData.linkId)) {
+          if (_.contains(greenFeaturesLinkId, feature.linkData.linkId)) {
 
-            feature.roadLinkData.prevAnomaly = feature.roadLinkData.anomaly;
-            feature.roadLinkData.gapTransfering = true;
-            var greenRoadStyle = styler.generateStyleByFeature(feature.roadLinkData,map.getView().getZoom());
+            feature.linkData.prevAnomaly = feature.linkData.anomaly;
+            feature.linkData.gapTransfering = true;
+            var greenRoadStyle = styler.generateStyleByFeature(feature.linkData,map.getView().getZoom());
             feature.setStyle(greenRoadStyle);
             features.push(feature);
           }
@@ -1067,35 +1067,35 @@
       var features =[];
       if(targets !== 0){
         var targetFeature = _.find(greenRoadLayer.getSource().getFeatures(), function(greenFeature){
-          return targets.linkId !== 0 && greenFeature.roadLinkData.linkId === parseInt(targets.linkId);
+          return targets.linkId !== 0 && greenFeature.linkData.linkId === parseInt(targets.linkId);
         });
         if(!targetFeature){
           _.map(roadLayer.layer.getSource().getFeatures(), function(feature){
-              if (feature.roadLinkData.linkId === targets.linkId) {
+              if (feature.linkData.linkId === targets.linkId) {
               var pickAnomalousMarker;
-              if(feature.roadLinkData.anomaly === Anomaly.GeometryChanged.value) {
-                var roadLink = feature.roadLinkData;
+              if(feature.linkData.anomaly === Anomaly.GeometryChanged.value) {
+                var roadLink = feature.linkData;
                 var points = _.map(roadLink.newGeometry, function (point) {
                   return [point.x, point.y];
                 });
                 feature = new ol.Feature({geometry: new ol.geom.LineString(points)});
-                feature.roadLinkData = roadLink;
+                feature.linkData = roadLink;
                 pickAnomalousMarker = _.filter(geometryChangedLayer.getSource().getFeatures(), function(marker){
-                  return marker.roadLinkData.linkId === feature.roadLinkData.linkId;
+                  return marker.linkData.linkId === feature.linkData.linkId;
                 });
                 _.each(pickAnomalousMarker, function(pickRoads){
                   geometryChangedLayer.getSource().removeFeature(pickRoads);
                 });
               }
 
-              feature.roadLinkData.prevAnomaly = feature.roadLinkData.anomaly;
-              feature.roadLinkData.gapTransfering = true;
-              var greenRoadStyle = styler.generateStyleByFeature(feature.roadLinkData,map.getView().getZoom());
+              feature.linkData.prevAnomaly = feature.linkData.anomaly;
+              feature.linkData.gapTransfering = true;
+              var greenRoadStyle = styler.generateStyleByFeature(feature.linkData,map.getView().getZoom());
               feature.setStyle(greenRoadStyle);
               features.push(feature);
               roadCollection.addPreMovedRoadAddresses(feature.data);
               pickAnomalousMarker = _.filter(pickRoadsLayer.getSource().getFeatures(), function(markersPick){
-                return markersPick.roadLinkData.linkId === feature.roadLinkData.linkId;
+                return markersPick.linkData.linkId === feature.linkData.linkId;
               });
               _.each(pickAnomalousMarker, function(pickRoads){
                 pickRoadsLayer.getSource().removeFeature(pickRoads);
@@ -1121,7 +1121,7 @@
 
     eventbus.on('linkProperties:highlightReservedRoads', function(reservedOL3Features){
       var styledFeatures = _.map(reservedOL3Features,function(feature) {
-        feature.setStyle(projectLinkStyler.getProjectLinkStyle().getStyle( feature.projectLinkData, {zoomLevel: map.getView().getZoom()}));
+        feature.setStyle(projectLinkStyler.getProjectLinkStyle().getStyle( feature.linkData, {zoomLevel: map.getView().getZoom()}));
         return feature;
       });
       if (applicationModel.getSelectedLayer()==="linkProperty"){ //check if user is still in reservation form
@@ -1145,7 +1145,7 @@
     var highlightAnomalousFeaturesByFloating = function() {
       var allFeatures = roadLayer.layer.getSource().getFeatures().concat(anomalousMarkerLayer.getSource().getFeatures()).concat(floatingMarkerLayer.getSource().getFeatures());
       _.each(allFeatures, function(feature){
-        if(feature.roadLinkData.anomaly === Anomaly.NoAddressGiven.value || feature.roadLinkData.anomaly === Anomaly.GeometryChanged.value || feature.roadLinkData.roadLinkType === RoadLinkType.FloatingRoadLinkType.value)
+        if(feature.linkData.anomaly === Anomaly.NoAddressGiven.value || feature.linkData.anomaly === Anomaly.GeometryChanged.value || feature.linkData.roadLinkType === RoadLinkType.FloatingRoadLinkType.value)
           pickRoadsLayer.getSource().addFeature(feature);
       });
       pickRoadsLayer.setOpacity(1);
@@ -1157,7 +1157,7 @@
       var selectedFloatingIds = _.pluck(selectedLinkProperty.getFeaturesToKeepFloatings(), 'linkId');
 
       _.each(allFeatures, function(feature){
-        if(feature.roadLinkData.anomaly === 1 || (_.contains(selectedFloatingIds, feature.roadLinkData.linkId) && feature.roadLinkData.roadLinkType === -1))
+        if(feature.linkData.anomaly === 1 || (_.contains(selectedFloatingIds, feature.linkData.linkId) && feature.linkData.roadLinkType === -1))
           pickRoadsLayer.getSource().addFeature(feature);
       });
       pickRoadsLayer.setOpacity(1);
@@ -1183,7 +1183,7 @@
       });
 
       var olUids = _.reject(_.map(pickRoadsLayer.getSource().getFeatures(), function(pickFeature){
-        if(_.contains(FeaturesToKeepFloatings, pickFeature.roadLinkData.linkId))
+        if(_.contains(FeaturesToKeepFloatings, pickFeature.linkData.linkId))
           return pickFeature.ol_uid;
         else return undefined;
       }), function(featuresNotToKeep){
@@ -1218,7 +1218,7 @@
        * Clean from roadLayer floatings selected
        */
       var olUidsRoadLayer = _.reject(_.map(roadLayer.layer.getSource().getFeatures(), function(featureRoadLayer){
-        if(_.contains(FeaturesToKeepFloatings, featureRoadLayer.roadLinkData.linkId))
+        if(_.contains(FeaturesToKeepFloatings, featureRoadLayer.linkData.linkId))
           return featureRoadLayer.ol_uid;
         else return undefined;
       }), function(featuresNotToKeep){
@@ -1239,7 +1239,7 @@
        * Clean from floatingMarkerLayer markers from selected floatings
        */
       var olUidsFloatingLayer = _.reject(_.map(floatingMarkerLayer.getSource().getFeatures(), function(feature){
-        if(_.contains(FeaturesToKeepFloatings, feature.roadLinkData.linkId))
+        if(_.contains(FeaturesToKeepFloatings, feature.linkData.linkId))
           return feature.ol_uid;
         else return undefined;
       }), function(featuresNotToKeep){
@@ -1277,7 +1277,7 @@
       //Clean from anomalousMarkerLayer
 
       var olUidsAnomalousMarkerLayer = _.reject(_.map(anomalousMarkerLayer.getSource().getFeatures(),function(anomalousMarkerLayerFeature){
-        if(_.contains(unknownFeaturesToKeep, anomalousMarkerLayerFeature.roadLinkData.linkId)){
+        if(_.contains(unknownFeaturesToKeep, anomalousMarkerLayerFeature.linkData.linkId)){
           return anomalousMarkerLayerFeature.ol_uid;
         } else return undefined;
       }), function(featuresNotToKeep){
@@ -1357,7 +1357,7 @@
         var feature = new ol.Feature({
           geometry: new ol.geom.LineString(points)
         });
-        feature.roadLinkData = link;
+        feature.linkData = link;
         return feature;
       });
       historicRoadsLayer.getSource().addFeatures(historyFeatures);

--- a/viite-UI/src/view/LinkPropertyLayer.js
+++ b/viite-UI/src/view/LinkPropertyLayer.js
@@ -612,28 +612,28 @@
 
         _.each(geometryChangedRoadMarkers, function(geometryChangedLink) {
 
-          var newRoadLinkData = Object.assign({}, geometryChangedLink);
-          newRoadLinkData.roadClass = 99;
-          newRoadLinkData.roadLinkSource = 99;
-          newRoadLinkData.sideCode = 99;
-          newRoadLinkData.linkType = 99;
-          newRoadLinkData.constructionType = 0;
-          newRoadLinkData.roadLinkType = 0;
-          newRoadLinkData.id = 0;
-          newRoadLinkData.startAddressM = "";
-          newRoadLinkData.endAddressM = "";
-          newRoadLinkData.anomaly = Anomaly.NoAddressGiven.value;
-          newRoadLinkData.points = newRoadLinkData.newGeometry;
+          var newLinkData = Object.assign({}, geometryChangedLink);
+            newLinkData.roadClass = 99;
+            newLinkData.roadLinkSource = 99;
+            newLinkData.sideCode = 99;
+            newLinkData.linkType = 99;
+            newLinkData.constructionType = 0;
+            newLinkData.roadLinkType = 0;
+            newLinkData.id = 0;
+            newLinkData.startAddressM = "";
+            newLinkData.endAddressM = "";
+            newLinkData.anomaly = Anomaly.NoAddressGiven.value;
+            newLinkData.points = newLinkData.newGeometry;
 
-          var marker = cachedMarker.createMarker(newRoadLinkData);
+          var marker = cachedMarker.createMarker(newLinkData);
           geometryChangedLayer.getSource().addFeature(marker);
 
-          var points = _.map(newRoadLinkData.newGeometry, function(point) {
+          var points = _.map(newLinkData.newGeometry, function(point) {
             return [point.x, point.y];
           });
           var feature = new ol.Feature({ geometry: new ol.geom.LineString(points)});
-          feature.linkData = newRoadLinkData;
-          roadCollection.addTmpRoadLinkGroups(newRoadLinkData);
+          feature.linkData = newLinkData;
+          roadCollection.addTmpRoadLinkGroups(newLinkData);
           geometryChangedLayer.getSource().addFeature(feature);
         });
 

--- a/viite-UI/src/view/MapView.js
+++ b/viite-UI/src/view/MapView.js
@@ -3,7 +3,8 @@
   root.MapView = function(map, layers, instructionsPopup) {
     var isInitialized = false;
     var centerMarkerLayer = new ol.source.Vector({});
-    var enableShiftModifier = false;
+    var enableCtrlModifier = false;
+    var metaKeyCodes = LinkValues.MetaKeyCodes;
 
     var showAssetZoomDialog = function() {
       instructionsPopup.show('Zoomaa lähemmäksi, jos haluat nähdä kohteita', 2000);
@@ -92,7 +93,7 @@
       if (layerToBeHidden) layerToBeHidden.hide(map);
       layerToBeShown.show(map);
       applicationModel.setMinDirtyZoomLevel(minZoomForContent());
-      enableShiftModifier = (layer === "roadAddressProject");
+      enableCtrlModifier = (layer === "roadAddressProject");
     }, this);
 
     eventbus.on('roadAddressProject:selected', function selectLayer(id, layer, previouslySelectedLayer) {
@@ -139,12 +140,12 @@
     });
 
     $('body').on('keydown', function(evt){
-      if(evt.shiftKey && enableShiftModifier)
+      if ((evt.ctrlKey || evt.metaKey) && enableCtrlModifier)
         map.getViewport().style.cursor = "copy";
     });
 
     $('body').on('keyup', function(evt){
-      if(evt.which === 16) // shift key up
+      if (_.contains(metaKeyCodes, evt.which) && evt.originalEvent.key !== LinkValues.SelectKeyName) // ctrl key up
         map.getViewport().style.cursor = "initial";
     });
 

--- a/viite-UI/src/view/ProjectLinkLayer.js
+++ b/viite-UI/src/view/ProjectLinkLayer.js
@@ -99,7 +99,7 @@
       $('#actionButtons').html('<button class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button><button disabled id ="send-button" class="send btn btn-block btn-send">Lähetä muutosilmoitus Tierekisteriin</button>');
     };
 
-    var fireDeselectionConfirmation = function (shiftPressed, selection, clickType) {
+    var fireDeselectionConfirmation = function (ctrlPressed, selection, clickType) {
       new GenericConfirmPopup('Haluatko poistaa tien valinnan ja hylätä muutokset?', {
         successCallback: function () {
           eventbus.trigger('roadAddressProject:discardChanges');
@@ -107,9 +107,9 @@
           clearHighlights();
           if (!_.isUndefined(selection)) {
             if (clickType === 'single')
-              showSingleClickChanges(shiftPressed, selection);
+              showSingleClickChanges(ctrlPressed, selection);
             else
-              showDoubleClickChanges(shiftPressed, selection);
+              showDoubleClickChanges(ctrlPressed, selection);
           } else {
             showChangesAndSendButton();
           }
@@ -136,8 +136,8 @@
     selectSingleClick.set('name', 'selectSingleClickInteractionPLL');
 
     selectSingleClick.on('select', function (event) {
-      var shiftPressed = event.mapBrowserEvent !== undefined ?
-        event.mapBrowserEvent.originalEvent.shiftKey : false;
+      var ctrlPressed = event.mapBrowserEvent !== undefined ?
+          event.mapBrowserEvent.originalEvent.ctrlKey : false;
       removeCutterMarkers();
       var selection = _.find(event.selected.concat(selectSingleClick.getFeatures().getArray()), function (selectionTarget) {
         return (applicationModel.getSelectedTool() !== 'Cut' && !_.isUndefined(selectionTarget.linkData) && (
@@ -147,19 +147,19 @@
         );
       });
       if (isNotEditingData) {
-        showSingleClickChanges(shiftPressed, selection);
+        showSingleClickChanges(ctrlPressed, selection);
       } else {
         var selectedFeatures = event.deselected.concat(selectDoubleClick.getFeatures().getArray());
         clearHighlights();
         addFeaturesToSelection(selectedFeatures);
-        fireDeselectionConfirmation(shiftPressed, selection, 'single');
+        fireDeselectionConfirmation(ctrlPressed, selection, 'single');
       }
     });
 
-    var showSingleClickChanges = function (shiftPressed, selection) {
+    var showSingleClickChanges = function (ctrlPressed, selection) {
       if(applicationModel.getSelectedTool() === 'Cut')
         return;
-      if (shiftPressed && !_.isUndefined(selectedProjectLinkProperty.get())) {
+      if (ctrlPressed && !_.isUndefined(selectedProjectLinkProperty.get())) {
         if (!_.isUndefined(selection) && canItBeAddToSelection(selection.linkData)) {
           var clickedIds = projectCollection.getMultiProjectLinks(getSelectedId(selection.linkData));
           var previouslySelectedIds = _.map(selectedProjectLinkProperty.get(), function (selected) {
@@ -204,7 +204,7 @@
     selectDoubleClick.set('name', 'selectDoubleClickInteractionPLL');
 
     selectDoubleClick.on('select', function (event) {
-      var shiftPressed = event.mapBrowserEvent.originalEvent.shiftKey;
+      var ctrlPressed = event.mapBrowserEvent.originalEvent.ctrlKey;
       var selection = _.find(event.selected, function (selectionTarget) {
         return (applicationModel.getSelectedTool() !== 'Cut' && !_.isUndefined(selectionTarget.linkData) && (
           projectLinkStatusIn(selectionTarget.linkData, possibleStatusForSelection) ||
@@ -213,12 +213,12 @@
         );
       });
       if (isNotEditingData) {
-        showDoubleClickChanges(shiftPressed, selection);
+        showDoubleClickChanges(ctrlPressed, selection);
       } else {
         var selectedFeatures = event.deselected.concat(selectSingleClick.getFeatures().getArray());
         clearHighlights();
         addFeaturesToSelection(selectedFeatures);
-        fireDeselectionConfirmation(shiftPressed, selection, 'double');
+        fireDeselectionConfirmation(ctrlPressed, selection, 'double');
       }
     });
 
@@ -292,6 +292,9 @@
     };
 
     var canItBeAddToSelection = function(selectionData) {
+      if (selectedProjectLinkProperty.get().length === 0) {
+        return true;
+      }
       var currentlySelectedSample = _.first(selectedProjectLinkProperty.get());
       return selectionData.roadNumber === currentlySelectedSample.roadNumber &&
         selectionData.roadPartNumber === currentlySelectedSample.roadPartNumber &&
@@ -416,7 +419,7 @@
 
     var zoomDoubleClickListener = function (event) {
       _.defer(function () {
-        if (applicationModel.getSelectedTool() !== 'Cut' && !event.shiftKey && selectedProjectLinkProperty.get().length === 0 &&
+        if (applicationModel.getSelectedTool() !== 'Cut' && !event.originalEvent.ctrlKey && selectedProjectLinkProperty.get().length === 0 &&
           applicationModel.getSelectedLayer() === 'roadAddressProject' && map.getView().getZoom() <= 13) {
           map.getView().setZoom(map.getView().getZoom() + 1);
         }

--- a/viite-UI/src/view/ProjectLinkLayer.js
+++ b/viite-UI/src/view/ProjectLinkLayer.js
@@ -24,9 +24,7 @@
     var projectLinkStyler = new ProjectLinkStyler();
 
     var vectorSource = new ol.source.Vector({
-      loader: function (extent, resolution, projection) {
-        var zoom = Math.log(1024 / resolution) / Math.log(2);
-
+      loader: function () {
         var nonSuravageRoads = _.partition(projectCollection.getAll(), function (projectRoad) {
           return projectRoad.roadLinkSource === LinkGeomSource.SuravageLinkInterface.value;
         })[1];
@@ -37,7 +35,7 @@
           var feature = new ol.Feature({
             geometry: new ol.geom.LineString(points)
           });
-          feature.projectLinkData = projectLink;
+          feature.linkData = projectLink;
           feature.linkId = projectLink.linkId;
           return feature;
         });
@@ -62,7 +60,7 @@
       source: suravageRoadVector,
       name: 'suravageRoadProjectLayer',
       style: function (feature) {
-        return projectLinkStyler.getProjectLinkStyle().getStyle( feature.projectLinkData, {zoomLevel: currentZoom});
+        return projectLinkStyler.getProjectLinkStyle().getStyle( feature.linkData, {zoomLevel: currentZoom});
       },
       zIndex: RoadZIndex.SuravageLayer.value
     });
@@ -77,11 +75,11 @@
       source: vectorSource,
       name: layerName,
       style: function(feature) {
-        var status = feature.projectLinkData.status;
+        var status = feature.linkData.status;
         if (status === LinkStatus.NotHandled.value || status === LinkStatus.Terminated.value || status  === LinkStatus.New.value || status === LinkStatus.Transfer.value || status === LinkStatus.Unchanged.value || status === LinkStatus.Numbering.value) {
-          return projectLinkStyler.getProjectLinkStyle().getStyle( feature.projectLinkData, {zoomLevel: currentZoom});
+          return projectLinkStyler.getProjectLinkStyle().getStyle( feature.linkData, {zoomLevel: currentZoom});
         } else {
-          return styler.getRoadLinkStyle().getStyle(feature.projectLinkData, currentZoom);
+          return styler.getRoadLinkStyle().getStyle(feature.linkData, currentZoom);
         }
     },
       zIndex: RoadZIndex.VectorLayer.value
@@ -128,9 +126,9 @@
       layer: [vectorLayer, suravageRoadProjectLayer],
       condition: ol.events.condition.singleClick,
       style: function (feature) {
-        if(!_.isUndefined(feature.projectLinkData))
-        if(projectLinkStatusIn(feature.projectLinkData, possibleStatusForSelection) || feature.projectLinkData.roadClass === RoadClass.NoClass.value || feature.projectLinkData.roadLinkSource == LinkGeomSource.SuravageLinkInterface.value) {
-         return projectLinkStyler.getSelectionLinkStyle().getStyle( feature.projectLinkData, {zoomLevel: currentZoom});
+        if(!_.isUndefined(feature.linkData))
+        if(projectLinkStatusIn(feature.linkData, possibleStatusForSelection) || feature.linkData.roadClass === RoadClass.NoClass.value || feature.linkData.roadLinkSource === LinkGeomSource.SuravageLinkInterface.value) {
+         return projectLinkStyler.getSelectionLinkStyle().getStyle( feature.linkData, {zoomLevel: currentZoom});
         }
       }
     });
@@ -142,10 +140,10 @@
         event.mapBrowserEvent.originalEvent.shiftKey : false;
       removeCutterMarkers();
       var selection = _.find(event.selected.concat(selectSingleClick.getFeatures().getArray()), function (selectionTarget) {
-        return (applicationModel.getSelectedTool() != 'Cut' && !_.isUndefined(selectionTarget.projectLinkData) && (
-          projectLinkStatusIn(selectionTarget.projectLinkData, possibleStatusForSelection) ||
-          (selectionTarget.projectLinkData.anomaly == Anomaly.NoAddressGiven.value && selectionTarget.projectLinkData.roadLinkType != RoadLinkType.FloatingRoadLinkType.value) ||
-          selectionTarget.projectLinkData.roadClass === RoadClass.NoClass.value || selectionTarget.projectLinkData.roadLinkSource === LinkGeomSource.SuravageLinkInterface.value )
+        return (applicationModel.getSelectedTool() !== 'Cut' && !_.isUndefined(selectionTarget.linkData) && (
+          projectLinkStatusIn(selectionTarget.linkData, possibleStatusForSelection) ||
+          (selectionTarget.linkData.anomaly === Anomaly.NoAddressGiven.value && selectionTarget.linkData.roadLinkType !== RoadLinkType.FloatingRoadLinkType.value) ||
+          selectionTarget.linkData.roadClass === RoadClass.NoClass.value || selectionTarget.linkData.roadLinkSource === LinkGeomSource.SuravageLinkInterface.value )
         );
       });
       if (isNotEditingData) {
@@ -159,15 +157,15 @@
     });
 
     var showSingleClickChanges = function (shiftPressed, selection) {
-      if(applicationModel.getSelectedTool() == 'Cut')
+      if(applicationModel.getSelectedTool() === 'Cut')
         return;
       if (shiftPressed && !_.isUndefined(selectedProjectLinkProperty.get())) {
-        if (!_.isUndefined(selection) && canItBeAddToSelection(selection.projectLinkData)) {
-          var clickedIds = projectCollection.getMultiProjectLinks(getSelectedId(selection.projectLinkData));
+        if (!_.isUndefined(selection) && canItBeAddToSelection(selection.linkData)) {
+          var clickedIds = projectCollection.getMultiProjectLinks(getSelectedId(selection.linkData));
           var previouslySelectedIds = _.map(selectedProjectLinkProperty.get(), function (selected) {
             return selected.linkId;
           });
-          if (_.contains(previouslySelectedIds, getSelectedId(selection.projectLinkData))) {
+          if (_.contains(previouslySelectedIds, getSelectedId(selection.linkData))) {
             previouslySelectedIds = _.without(previouslySelectedIds, clickedIds);
           } else {
             previouslySelectedIds = _.union(previouslySelectedIds, clickedIds);
@@ -183,10 +181,10 @@
         $('[id^=editProject]').css('visibility', 'visible');
         $('#closeProjectSpan').css('visibility', 'visible');
         if (!_.isUndefined(selection) && !selectedProjectLinkProperty.isDirty()){
-          if(!_.isUndefined(selection.projectLinkData.connectedLinkId)){
-            selectedProjectLinkProperty.openSplit(selection.projectLinkData.linkId, true);
+          if(!_.isUndefined(selection.linkData.connectedLinkId)){
+            selectedProjectLinkProperty.openSplit(selection.linkData.linkId, true);
           } else {
-            selectedProjectLinkProperty.open(getSelectedId(selection.projectLinkData), true);
+            selectedProjectLinkProperty.open(getSelectedId(selection.linkData), true);
           }
         }
         else selectedProjectLinkProperty.cleanIds();
@@ -197,8 +195,8 @@
       layer: [vectorLayer, suravageRoadProjectLayer],
       condition: ol.events.condition.doubleClick,
       style: function(feature) {
-        if(projectLinkStatusIn(feature.projectLinkData, possibleStatusForSelection) || feature.projectLinkData.roadClass === RoadClass.NoClass.value || feature.projectLinkData.roadLinkSource == LinkGeomSource.SuravageLinkInterface.value) {
-          return projectLinkStyler.getSelectionLinkStyle().getStyle( feature.projectLinkData, {zoomLevel: currentZoom});
+        if(projectLinkStatusIn(feature.linkData, possibleStatusForSelection) || feature.linkData.roadClass === RoadClass.NoClass.value || feature.linkData.roadLinkSource === LinkGeomSource.SuravageLinkInterface.value) {
+          return projectLinkStyler.getSelectionLinkStyle().getStyle( feature.linkData, {zoomLevel: currentZoom});
         }
       }
     });
@@ -208,10 +206,10 @@
     selectDoubleClick.on('select', function (event) {
       var shiftPressed = event.mapBrowserEvent.originalEvent.shiftKey;
       var selection = _.find(event.selected, function (selectionTarget) {
-        return (applicationModel.getSelectedTool() != 'Cut' && !_.isUndefined(selectionTarget.projectLinkData) && (
-          projectLinkStatusIn(selectionTarget.projectLinkData, possibleStatusForSelection) ||
-          (selectionTarget.projectLinkData.anomaly == Anomaly.NoAddressGiven.value && selectionTarget.projectLinkData.roadLinkType != RoadLinkType.FloatingRoadLinkType.value) ||
-          selectionTarget.projectLinkData.roadClass === RoadClass.NoClass.value || selectionTarget.projectLinkData.roadLinkSource === LinkGeomSource.SuravageLinkInterface.value)
+        return (applicationModel.getSelectedTool() !== 'Cut' && !_.isUndefined(selectionTarget.linkData) && (
+          projectLinkStatusIn(selectionTarget.linkData, possibleStatusForSelection) ||
+          (selectionTarget.linkData.anomaly === Anomaly.NoAddressGiven.value && selectionTarget.linkData.roadLinkType !== RoadLinkType.FloatingRoadLinkType.value) ||
+          selectionTarget.linkData.roadClass === RoadClass.NoClass.value || selectionTarget.linkData.roadLinkSource === LinkGeomSource.SuravageLinkInterface.value || (selectionTarget.getProperties().type && selectionTarget.getProperties().type === "marker"))
         );
       });
       if (isNotEditingData) {
@@ -226,14 +224,14 @@
 
     var showDoubleClickChanges = function (shiftPressed, selection) {
       if (shiftPressed && !_.isUndefined(selectedProjectLinkProperty.get())) {
-        if (!_.isUndefined(selection) && canItBeAddToSelection(selection.projectLinkData)) {
+        if (!_.isUndefined(selection) && canItBeAddToSelection(selection.linkData)) {
           var selectedLinkIds = _.map(selectedProjectLinkProperty.get(), function (selected) {
             return getSelectedId(selected);
           });
-          if (_.contains(selectedLinkIds, getSelectedId(selection.projectLinkData))) {
-            selectedLinkIds = _.without(selectedLinkIds, getSelectedId(selection.projectLinkData));
+          if (_.contains(selectedLinkIds, getSelectedId(selection.linkData))) {
+            selectedLinkIds = _.without(selectedLinkIds, getSelectedId(selection.linkData));
           } else {
-            selectedLinkIds = selectedLinkIds.concat(getSelectedId(selection.projectLinkData));
+            selectedLinkIds = selectedLinkIds.concat(getSelectedId(selection.linkData));
           }
           selectedProjectLinkProperty.openShift(selectedLinkIds);
         }
@@ -243,10 +241,10 @@
         projectCollection.setTmpDirty([]);
         projectCollection.setDirty([]);
         if (!_.isUndefined(selection) && !selectedProjectLinkProperty.isDirty()){
-          if(!_.isUndefined(selection.projectLinkData.connectedLinkId)){
-            selectedProjectLinkProperty.openSplit(selection.projectLinkData.linkId, true);
+          if(!_.isUndefined(selection.linkData.connectedLinkId)){
+            selectedProjectLinkProperty.openSplit(selection.linkData.linkId, true);
           } else {
-            selectedProjectLinkProperty.open(getSelectedId(selection.projectLinkData));
+            selectedProjectLinkProperty.open(getSelectedId(selection.linkData));
           }
         }
         else selectedProjectLinkProperty.cleanIds();
@@ -302,21 +300,8 @@
     };
 
     var clearHighlights = function(){
-      if(applicationModel.getSelectedTool() == 'Cut'){
-        if(selectDoubleClick.getFeatures().getLength() !== 0){
-          selectDoubleClick.getFeatures().clear();
-        }
-        if(selectSingleClick.getFeatures().getLength() !== 0){
-          selectSingleClick.getFeatures().clear();
-        }
-      } else {
-        if(selectDoubleClick.getFeatures().getLength() !== 0){
-          selectDoubleClick.getFeatures().clear();
-        }
-        if(selectSingleClick.getFeatures().getLength() !== 0){
-          selectSingleClick.getFeatures().clear();
-        }
-      }
+      selectDoubleClick.getFeatures().clear();
+      selectSingleClick.getFeatures().clear();
     };
 
     var clearLayers = function () {
@@ -333,18 +318,18 @@
       var featuresToHighlight = [];
       var suravageFeaturesToHighlight = [];
       _.each(vectorLayer.getSource().getFeatures(), function (feature) {
-        var canIHighlight = ((!_.isUndefined(feature.projectLinkData.linkId) && _.isUndefined(feature.projectLinkData.connectedLinkId)) ||
-        (!_.isUndefined(feature.projectLinkData.connectedLinkId) && feature.projectLinkData.status === LinkStatus.Terminated.value) ?
-          selectedProjectLinkProperty.isSelected(getSelectedId(feature.projectLinkData)) : false);
+        var canIHighlight = ((!_.isUndefined(feature.linkData.linkId) && _.isUndefined(feature.linkData.connectedLinkId)) ||
+        (!_.isUndefined(feature.linkData.connectedLinkId) && feature.linkData.status === LinkStatus.Terminated.value) ?
+          selectedProjectLinkProperty.isSelected(getSelectedId(feature.linkData)) : false);
         if (canIHighlight) {
           featuresToHighlight.push(feature);
         }
       });
       addFeaturesToSelection(featuresToHighlight);
       _.each(suravageRoadProjectLayer.getSource().getFeatures(), function (feature) {
-        var canIHighlight = (!_.isUndefined(feature.projectLinkData) && !_.isUndefined(feature.projectLinkData.linkId)) ?
+        var canIHighlight = (!_.isUndefined(feature.linkData) && !_.isUndefined(feature.linkData.linkId)) ?
 
-          selectedProjectLinkProperty.isSelected(getSelectedId(feature.projectLinkData)) : false;
+          selectedProjectLinkProperty.isSelected(getSelectedId(feature.linkData)) : false;
         if (canIHighlight) {
           suravageFeaturesToHighlight.push(feature);
         }
@@ -355,7 +340,7 @@
 
       var suravageResult = _.filter(suravageProjectDirectionMarkerLayer.getSource().getFeatures(), function (item) {
         return _.find(suravageFeaturesToHighlight, function (sf) {
-          return sf.projectLinkData.linkId === item.roadLinkData.linkId;
+          return sf.linkData.linkId === item.linkData.linkId;
         });
       });
 
@@ -405,27 +390,9 @@
       addFeaturesToSelection([cutFeature]);
     };
 
-    var addTerminatedFeature = function(terminatedLink){
-      var points = _.map(terminatedLink.geometry, function (point) {
-        return [point.x, point.y];
-      });
-      var terminatedFeature = new ol.Feature({
-        projectLinkData: terminatedLink,
-        geometry: new ol.geom.LineString(points),
-        type: 'pre-split'
-      });
-      var style = new ol.style.Style({
-        stroke: new ol.style.Stroke({color: '#c6c00f', width: 13, lineCap: 'round'}),
-        zIndex: 11
-      });
-      terminatedFeature.setStyle(style);
-      removeFeaturesByType('pre-split');
-      addFeaturesToSelection([terminatedFeature]);
-    };
-
     var removeFeaturesByType = function (match) {
-      _.each(selectSingleClick.getFeatures().getArray(), function(feature){
-        if(feature && feature.getProperties().type == match) {
+      _.each(selectSingleClick.getFeatures().getArray().concat(selectDoubleClick.getFeatures().getArray()), function(feature){
+        if(feature && feature.getProperties().type === match) {
           selectSingleClick.getFeatures().remove(feature);
         }
       });
@@ -441,7 +408,6 @@
         calibrationPointLayer.setVisible(true);
       } else {
         clearHighlights();
-        var featuresToHighlight = [];
         vectorLayer.setVisible(false);
         calibrationPointLayer.setVisible(false);
         eventbus.trigger('roadLinks:fetched');
@@ -450,8 +416,8 @@
 
     var zoomDoubleClickListener = function (event) {
       _.defer(function () {
-        if (applicationModel.getSelectedTool() != 'Cut' && !event.shiftKey && selectedProjectLinkProperty.get().length === 0 &&
-          applicationModel.getSelectedLayer() == 'roadAddressProject' && map.getView().getZoom() <= 13) {
+        if (applicationModel.getSelectedTool() !== 'Cut' && !event.shiftKey && selectedProjectLinkProperty.get().length === 0 &&
+          applicationModel.getSelectedLayer() === 'roadAddressProject' && map.getView().getZoom() <= 13) {
           map.getView().setZoom(map.getView().getZoom() + 1);
         }
       });
@@ -482,20 +448,20 @@
 
     var displayRoadAddressInfo = function (event, pixel) {
 
-      var featureAtPixel = map.forEachFeatureAtPixel(pixel, function (feature, vectorLayer) {
+      var featureAtPixel = map.forEachFeatureAtPixel(pixel, function (feature) {
         return feature;
       });
 
       //Ignore if target feature is marker
-      if (isDefined(featureAtPixel) && (isDefined(featureAtPixel.roadLinkData) || isDefined(featureAtPixel.projectLinkData))) {
+      if (isDefined(featureAtPixel) && (isDefined(featureAtPixel.linkData) || isDefined(featureAtPixel.linkData))) {
         var roadData;
         var coordinate = map.getEventCoordinate(event.originalEvent);
 
-        if (isDefined(featureAtPixel.projectLinkData)) {
-          roadData = featureAtPixel.projectLinkData;
+        if (isDefined(featureAtPixel.linkData)) {
+          roadData = featureAtPixel.linkData;
         }
         else {
-          roadData = featureAtPixel.roadLinkData;
+          roadData = featureAtPixel.linkData;
         }
         //TODO roadData !== null is there for test having no info ready (race condition where hover often loses) should be somehow resolved
         if (infoContent !== null) {
@@ -528,7 +494,7 @@
     map.addInteraction(selectDoubleClick);
 
     var mapMovedHandler = function (mapState) {
-      if(applicationModel.getSelectedTool() == 'Cut' && selectSingleClick.getFeatures().getArray().length > 0)
+      if(applicationModel.getSelectedTool() === 'Cut' && selectSingleClick.getFeatures().getArray().length > 0)
           return;
       var projectId = _.isUndefined(projectCollection.getCurrentProject()) ? undefined : projectCollection.getCurrentProject().project.id;
       if (mapState.zoom !== currentZoom) {
@@ -537,7 +503,7 @@
       if (mapState.zoom < minimumContentZoomLevel()) {
         vectorSource.clear();
         eventbus.trigger('map:clearLayers');
-      } else if (mapState.selectedLayer == layerName) {
+      } else if (mapState.selectedLayer === layerName) {
         projectCollection.fetch(map.getView().calculateExtent(map.getSize()).join(','), currentZoom + 1, projectId, projectCollection.getPublishableStatus());
         handleRoadsVisibility();
       }
@@ -608,7 +574,7 @@
       vectorSource.addFeatures(features);
     };
 
-    var show = function (map) {
+    var show = function() {
       vectorLayer.setVisible(true);
     };
 
@@ -624,7 +590,7 @@
     var removeCutterMarkers = function() {
       var featuresToRemove = [];
       _.each(selectSingleClick.getFeatures().getArray(), function(feature){
-        if(feature.getProperties().type == 'cutter')
+        if(feature.getProperties().type === 'cutter')
           featuresToRemove.push(feature);
       });
       _.each(featuresToRemove, function(ft){
@@ -635,7 +601,6 @@
     var SuravageCutter = function(suravageLayer, collection, eventListener) {
       var scissorFeatures = [];
       var CUT_THRESHOLD = 20;
-      var suravageSource = suravageLayer.getSource();
       var self = this;
 
       var moveTo = function(x, y) {
@@ -656,7 +621,7 @@
 
       var removeFeaturesByType = function (match) {
         _.each(selectSingleClick.getFeatures().getArray(), function(feature){
-          if(feature && feature.getProperties().type == match) {
+          if(feature && feature.getProperties().type === match) {
             selectSingleClick.getFeatures().remove(feature);
           }
         });
@@ -721,7 +686,7 @@
       var findNearestSuravageLink = function(point) {
 
         var possibleSplit = _.filter(vectorSource.getFeatures().concat(suravageRoadProjectLayer.getSource().getFeatures()), function(feature){
-          return !_.isUndefined(feature.projectLinkData) && (feature.projectLinkData.roadLinkSource === LinkGeomSource.SuravageLinkInterface.value);
+          return !_.isUndefined(feature.linkData) && (feature.linkData.roadLinkSource === LinkGeomSource.SuravageLinkInterface.value);
         });
         return _.chain(possibleSplit)
             .map(function(feature) {
@@ -765,14 +730,14 @@
           selectSingleClick.getFeatures().clear();
           return;
         }
-        var nearestSuravage = nearest.feature.projectLinkData;
+        var nearestSuravage = nearest.feature.linkData;
         nearestSuravage.points = _.isUndefined(nearestSuravage.originalGeometry) ? nearestSuravage.points : nearestSuravage.originalGeometry;
         if (!_.isUndefined(nearestSuravage.connectedLinkId)) {
           nearest.feature.geometry = pointsToLineString(nearestSuravage.originalGeometry);
         }
         selectedProjectLinkProperty.setNearestPoint({x: nearest.point[0], y: nearest.point[1]});
         selectedProjectLinkProperty.preSplitSuravageLink(nearestSuravage);
-        projectCollection.setTmpDirty([nearest.feature.projectLinkData]);
+        projectCollection.setTmpDirty([nearest.feature.linkData]);
       };
     };
 
@@ -832,7 +797,7 @@
       projectCollection.fetch(map.getView().calculateExtent(map.getSize()).join(','), currentZoom + 1, undefined, projectCollection.getPublishableStatus());
     });
 
-    var redraw = function () {
+    me.redraw = function () {
       var ids = {};
       _.each(selectedProjectLinkProperty.get(), function (sel) {
         ids[sel.linkId] = true;
@@ -868,17 +833,17 @@
         var feature = new ol.Feature({
           geometry: new ol.geom.LineString(points)
         });
-          feature.projectLinkData = projectLink;
+          feature.linkData = projectLink;
           suravageFeatures.push(feature);
       });
 
-      cachedMarker = new LinkPropertyMarker(selectedProjectLinkProperty);
+      cachedMarker = new ProjectLinkMarker(selectedProjectLinkProperty);
       var suravageDirectionRoadMarker = _.filter(suravageProjectRoads, function (projectLink) {
         return projectLink.roadLinkType !== RoadLinkType.FloatingRoadLinkType.value && projectLink.anomaly !== Anomaly.NoAddressGiven.value && projectLink.anomaly !== Anomaly.GeometryChanged.value && (projectLink.sideCode === SideCode.AgainstDigitizing.value || projectLink.sideCode === SideCode.TowardsDigitizing.value);
       });
 
       _.each(suravageDirectionRoadMarker, function (directionLink) {
-        var marker = cachedMarker.createMarker(directionLink);
+        var marker = cachedMarker.createProjectMarker(directionLink);
         if (map.getView().getZoom() > zoomlevels.minZoomForDirectionalMarkers) {
           suravageProjectDirectionMarkerLayer.getSource().addFeature(marker);
           selectSingleClick.getFeatures().push(marker);
@@ -904,12 +869,12 @@
         var feature = new ol.Feature({
           geometry: new ol.geom.LineString(points)
         });
-        feature.projectLinkData = projectLink;
+        feature.linkData = projectLink;
         feature.linkId = projectLink.linkId;
         features.push(feature);
       });
 
-      cachedMarker = new LinkPropertyMarker(selectedProjectLinkProperty);
+      cachedMarker = new ProjectLinkMarker(selectedProjectLinkProperty);
       var directionRoadMarker = _.filter(projectLinks, function (projectLink) {
         return projectLink.roadLinkType !== RoadLinkType.FloatingRoadLinkType.value && projectLink.anomaly !== Anomaly.NoAddressGiven.value && projectLink.anomaly !== Anomaly.GeometryChanged.value && (projectLink.sideCode === SideCode.AgainstDigitizing.value || projectLink.sideCode === SideCode.TowardsDigitizing.value);
       });
@@ -923,8 +888,16 @@
       _.each(featuresToRemove, function (feature) {
         selectSingleClick.getFeatures().remove(feature);
       });
+      featuresToRemove = [];
+      _.each(selectDoubleClick.getFeatures().getArray(), function (feature) {
+          if (feature.getProperties().type && feature.getProperties().type === "marker")
+              featuresToRemove.push(feature);
+      });
+      _.each(featuresToRemove, function (feature) {
+          selectDoubleClick.getFeatures().remove(feature);
+      });
       _.each(directionRoadMarker, function (directionLink) {
-        var marker = cachedMarker.createMarker(directionLink);
+        var marker = cachedMarker.createProjectMarker(directionLink);
         if (map.getView().getZoom() > zoomlevels.minZoomForDirectionalMarkers) {
           directionMarkerLayer.getSource().addFeature(marker);
           selectSingleClick.getFeatures().push(marker);
@@ -940,15 +913,15 @@
       }
 
       var partitioned = _.partition(features, function (feature) {
-        return (!_.isUndefined(feature.projectLinkData.linkId) && _.contains(_.pluck(editedLinks, 'id'), feature.projectLinkData.linkId));
+        return (!_.isUndefined(feature.linkData.linkId) && _.contains(_.pluck(editedLinks, 'id'), feature.linkData.linkId));
       });
       features = [];
       _.each(partitioned[0], function (feature) {
-        var editedLink = (!_.isUndefined(feature.projectLinkData.linkId) && _.contains(_.pluck(editedLinks, 'id'), feature.projectLinkData.linkId));
+        var editedLink = (!_.isUndefined(feature.linkData.linkId) && _.contains(_.pluck(editedLinks, 'id'), feature.linkData.linkId));
         if (editedLink) {
-          if (_.contains(toBeTerminatedLinkIds, feature.projectLinkData.linkId)) {
-            feature.projectLinkData.status = LinkStatus.Terminated.value;
-            var termination = projectLinkStyler.getProjectLinkStyle().getStyle( feature.projectLinkData, {zoomLevel: currentZoom});
+          if (_.contains(toBeTerminatedLinkIds, feature.linkData.linkId)) {
+            feature.linkData.status = LinkStatus.Terminated.value;
+            var termination = projectLinkStyler.getProjectLinkStyle().getStyle( feature.linkData, {zoomLevel: currentZoom});
             feature.setStyle(termination);
             features.push(feature);
           }
@@ -979,16 +952,16 @@
       projectCollection.getProjectsWithLinksById(projId);
     });
 
-    eventbus.on('roadAddressProject:fetched', function (newSelection) {
+    eventbus.on('roadAddressProject:fetched', function () {
       applicationModel.removeSpinner();
-      redraw();
+      me.redraw();
       _.defer(function () {
         highlightFeatures();
       });
     });
 
     eventbus.on('roadAddress:projectLinksEdited', function () {
-      redraw();
+      me.redraw();
     });
 
     eventbus.on('roadAddressProject:projectLinkSaved', function (projectId, isPublishable) {

--- a/viite-UI/src/view/ProjectLinkLayer.js
+++ b/viite-UI/src/view/ProjectLinkLayer.js
@@ -649,7 +649,7 @@
           return [point.x, point.y];
         });
         var terminatedFeature = new ol.Feature({
-          projectLinkData: terminatedLink,
+          linkData: terminatedLink,
           geometry: new ol.geom.LineString(points),
           type: 'pre-split'
         });

--- a/viite-UI/src/view/RoadLayer3.js
+++ b/viite-UI/src/view/RoadLayer3.js
@@ -14,7 +14,7 @@
             });
             var feature =  new ol.Feature({ geometry: new ol.geom.LineString(points)
             });
-            feature.roadLinkData = roadLink;
+            feature.linkData = roadLink;
             return feature;
           });
           loadFeatures(features);
@@ -24,7 +24,7 @@
     });
 
     function vectorLayerStyle(feature) {
-      return styler.generateStyleByFeature(feature.roadLinkData, currentZoom);
+      return styler.generateStyleByFeature(feature.linkData, currentZoom);
     }
 
     var loadFeatures = function (features) {

--- a/viite-UI/src/view/Styler.js
+++ b/viite-UI/src/view/Styler.js
@@ -87,8 +87,8 @@
       }
     };
 
-    var generateUnderLineColor = function(roadLinkData, opacityMultiplier, middleLineWidth) {
-      if (roadLinkData.blackUnderline)
+    var generateUnderLineColor = function(linkData, opacityMultiplier, middleLineWidth) {
+      if (linkData.blackUnderline)
         return {color: 'rgba(30, 30, 30,' + opacityMultiplier + ')', width: middleLineWidth + 7};
       else return {color: undefined, width: undefined};
     };
@@ -211,17 +211,17 @@
 
     /**
      * Method evoked by feature that will determine what kind of style said feature will have.
-     * @param roadLinkData The roadLink details of a feature
+     * @param linkData The roadLink details of a feature
      * @param currentZoom The value of the current application zoom.
      * @returns {*[ol.style.Style, ol.style.Style, ol.style.Style]} And array of ol.style.Style, the first is for the gray line,
      * the second is for the border and the third is for the line itself.
      */
-    var generateStyleByFeature = function (roadLinkData, currentZoom, notSelection) {
-      var strokeWidth = strokeWidthByZoomLevel(currentZoom, roadLinkData.roadLinkType, roadLinkData.anomaly,
-        roadLinkData.roadLinkSource, notSelection, roadLinkData.constructionType);
+    var generateStyleByFeature = function (linkData, currentZoom, notSelection) {
+      var strokeWidth = strokeWidthByZoomLevel(currentZoom, linkData.roadLinkType, linkData.anomaly,
+          linkData.roadLinkSource, notSelection, linkData.constructionType);
       // Gray line behind all of the styles present in the layer.
-      var underLineColor = generateStrokeColor(99, roadLinkData.anomaly, roadLinkData.constructionType,
-        roadLinkData.roadLinkType, roadLinkData.gapTransfering, roadLinkData.roadLinkSource, roadLinkData.id);
+      var underLineColor = generateStrokeColor(99, linkData.anomaly, linkData.constructionType,
+          linkData.roadLinkType, linkData.gapTransfering, linkData.roadLinkSource, linkData.id);
       // If the line we need to generate is a dashed line, middleLineColor will be the white one sitting behind the
       // dashed/colored line and above the border and grey lines
       var middleLineColor;
@@ -229,19 +229,19 @@
       var lineCap;
       var borderCap;
       var middleLineCap;
-      var lineColor = generateStrokeColor(roadLinkData.roadClass, roadLinkData.anomaly, roadLinkData.constructionType,
-        roadLinkData.roadLinkType, roadLinkData.gapTransfering, roadLinkData.roadLinkSource, roadLinkData.id);
-      if (roadLinkData.roadClass >= 7 && roadLinkData.roadClass <= 10) {
+      var lineColor = generateStrokeColor(linkData.roadClass, linkData.anomaly, linkData.constructionType,
+          linkData.roadLinkType, linkData.gapTransfering, linkData.roadLinkSource, linkData.id);
+      if (linkData.roadClass >= 7 && linkData.roadClass <= 10) {
         borderColor = lineColor;
-        middleLineColor = generateStrokeColor(98, roadLinkData.anomaly, roadLinkData.constructionType, roadLinkData.roadLinkType,
-          roadLinkData.gapTransfering, roadLinkData.roadLinkSource, roadLinkData.id);
+        middleLineColor = generateStrokeColor(98, linkData.anomaly, linkData.constructionType, linkData.roadLinkType,
+            linkData.gapTransfering, linkData.roadLinkSource, linkData.id);
         lineCap = 'butt';
         middleLineCap = 'butt';
         borderCap = 'round';
-      } else if (roadLinkData.roadClass == 99 && roadLinkData.constructionType == 1) {
+      } else if (linkData.roadClass === 99 && linkData.constructionType === 1) {
         borderColor = lineColor;
-        middleLineColor = generateStrokeColor(97, roadNormalType, roadNormalType, roadLinkData.roadLinkType,
-          roadLinkData.gapTransfering, roadLinkData.roadLinkSource, roadLinkData.id);
+        middleLineColor = generateStrokeColor(97, roadNormalType, roadNormalType, linkData.roadLinkType,
+            linkData.gapTransfering, linkData.roadLinkSource, linkData.id);
         lineCap = 'butt';
         middleLineCap = 'butt';
         borderCap = 'round';
@@ -274,7 +274,7 @@
         lineCap: lineCap
       });
 
-      var roadTypeDetails = generateUnderLineColor(roadLinkData, opacityMultiplier, middleLineWidth);
+      var roadTypeDetails = generateUnderLineColor(linkData, opacityMultiplier, middleLineWidth);
       var roadTypeLine = new ol.style.Stroke({
         width: roadTypeDetails.width,
         color: roadTypeDetails.color,
@@ -282,11 +282,11 @@
       });
 
       //Dash lines
-      if (_.contains(dashedLinesRoadClasses, roadLinkData.roadClass)) {
+      if (_.contains(dashedLinesRoadClasses, linkData.roadClass)) {
         line.setLineDash([10, 10]);
       }
 
-      if (roadLinkData.roadClass == 99 && roadLinkData.constructionType == 1) {
+      if (linkData.roadClass == 99 && linkData.constructionType == 1) {
         line.setLineDash([10, 10]);
       }
 
@@ -306,7 +306,7 @@
       var roadTypeStyle = new ol.style.Style({
         stroke: roadTypeLine
       });
-      var zIndex = determineZIndex(roadLinkData.roadLinkType, roadLinkData.anomaly, roadLinkData.roadLinkSource);
+      var zIndex = determineZIndex(linkData.roadLinkType, linkData.anomaly, linkData.roadLinkSource);
       underlineStyle.setZIndex(zIndex - 1);
       borderStyle.setZIndex(zIndex);
       middleLineStyle.setZIndex(zIndex + 1);

--- a/viite-UI/test/TestHelpers.js
+++ b/viite-UI/test/TestHelpers.js
@@ -251,7 +251,7 @@ define(['RoadAddressTestData', 'RoadLinkTestData', 'UserRolesTestData', 'RoadAdd
     var getFeaturesRoadLinkData = function(map, layerName){
       var features =  getFeatures(map, layerName);
       return _.chain(features).map(function(feature){
-        return feature.roadLinkData;
+        return feature.linkData;
       }).filter(function(rlData) {
         return !_.isUndefined(rlData);
       }).value();
@@ -260,7 +260,7 @@ define(['RoadAddressTestData', 'RoadLinkTestData', 'UserRolesTestData', 'RoadAdd
     var getFeatureByLinkId = function(map, layerName, linkId){
       var features = getFeatures(map, layerName);
       return _.find(features, function(feature){
-        return (layerName == "roadAddressProject" ? feature.projectLinkData.linkId === linkId : feature.roadLinkData.linkId === linkId);
+        return (feature.linkData.linkId === linkId);
       });
     };
 

--- a/viite-UI/test/TestHelpers.js
+++ b/viite-UI/test/TestHelpers.js
@@ -89,7 +89,7 @@ define(['RoadAddressTestData', 'RoadLinkTestData', 'UserRolesTestData', 'RoadAdd
 
     var fakeBackend = function(zoomLevel, generatedData, latitude, longitude, projectDefinition) {
       var data = getSimulatedData(projectDefinition);
-      return new Backend().withRoadLinkData(generatedData, selectTestData('roadAddressAfterSave'))
+      return new Backend().withLinkData(generatedData, selectTestData('roadAddressAfterSave'))
         .withUserRolesData(UserRolesTestData.userData())
         .withStartupParameters({ lon: longitude, lat: latitude, zoom: zoomLevel || 10, deploy_date: "" })
         .withFloatingAdjacents(data.floatingAdjacents)
@@ -248,7 +248,7 @@ define(['RoadAddressTestData', 'RoadLinkTestData', 'UserRolesTestData', 'RoadAdd
       return layer.getSource().getFeatures();
     };
 
-    var getFeaturesRoadLinkData = function(map, layerName){
+    var getFeaturesLinkData = function(map, layerName){
       var features =  getFeatures(map, layerName);
       return _.chain(features).map(function(feature){
         return feature.linkData;
@@ -264,10 +264,10 @@ define(['RoadAddressTestData', 'RoadLinkTestData', 'UserRolesTestData', 'RoadAdd
       });
     };
 
-    var getRoadLinkDataByLinkId = function (map, layerName, linkId){
-      var roadLinkDatas = getFeaturesRoadLinkData(map, layerName);
-      return _.find(roadLinkDatas, function (roadLinkData){
-        return roadLinkData.linkId === linkId;
+    var getLinkDataByLinkId = function (map, layerName, linkId){
+      var linkDatas = getFeaturesLinkData(map, layerName);
+      return _.find(linkDatas, function (linkData){
+        return linkData.linkId === linkId;
       });
     };
 
@@ -331,9 +331,9 @@ define(['RoadAddressTestData', 'RoadLinkTestData', 'UserRolesTestData', 'RoadAdd
       getLayerByName: getLayerByName,
       selectTestData: selectTestData,
       getFeatures: getFeatures,
-      getFeaturesRoadLinkData: getFeaturesRoadLinkData,
+      getFeaturesLinkData: getFeaturesLinkData,
       getFeatureByLinkId: getFeatureByLinkId,
-      getRoadLinkDataByLinkId: getRoadLinkDataByLinkId,
+      getLinkDataByLinkId: getLinkDataByLinkId,
       selectSingleFeatureByInteraction: selectSingleFeatureByInteraction,
       selectTool: selectTool,
       clickCancelButton: clickCancelButton

--- a/viite-UI/test/integration-tests.html
+++ b/viite-UI/test/integration-tests.html
@@ -47,6 +47,7 @@
 <script type="text/javascript" src="../src/router.js"></script>
 
 <script type="text/javascript" src="../src/map/LinkPropertyMarker.js"></script>
+<script type="text/javascript" src="../src/map/ProjectLinkMarker.js"></script>
 <script type="text/javascript" src="../src/map/CalibrationPointMarker.js"></script>
 
 <script type="text/javascript" src="../src/utils/eventbus.js"></script>

--- a/viite-UI/test/integration-tests/FloatingRoadAddressSpec.js
+++ b/viite-UI/test/integration-tests/FloatingRoadAddressSpec.js
@@ -105,7 +105,7 @@ define(['chai', 'eventbus', 'TestHelpers'], function(chai, eventbus, testHelpers
       });
 
       it('Verify that the simulated road addresses are simulated',function(){
-        var simulatedFeatures = testHelpers.getFeaturesRoadLinkData(openLayersMap, testHelpers.getSimulatedRoadsLayerName());
+        var simulatedFeatures = testHelpers.getFeaturesLinkData(openLayersMap, testHelpers.getSimulatedRoadsLayerName());
         expect(simulatedFeatures.length).to.be.above(0);
         var featuresIds = _.chain(simulatedFeatures).map(function(sf){
           return sf.id;
@@ -124,14 +124,14 @@ define(['chai', 'eventbus', 'TestHelpers'], function(chai, eventbus, testHelpers
       });
 
       it('Verify that the previous unknown link is now no longer unknown and there is only one feature', function(){
-        var features= testHelpers.getFeaturesRoadLinkData(openLayersMap, testHelpers.getRoadLayerName());
-        var roadLinkData = _.filter(features, function(rld){
+        var features= testHelpers.getFeaturesLinkData(openLayersMap, testHelpers.getRoadLayerName());
+        var linkData = _.filter(features, function(rld){
           return rld.linkId === unknownRoadLinkId;
         });
-        expect(roadLinkData.length).to.equals(1);
-        expect(_.first(roadLinkData).anomaly).to.equals(0);
-        expect(_.first(roadLinkData).id).to.not.equals(-1000);
-        expect(_.first(roadLinkData).roadLinkType).to.not.equals(-1);
+        expect(linkData.length).to.equals(1);
+        expect(_.first(linkData).anomaly).to.equals(0);
+        expect(_.first(linkData).id).to.not.equals(-1000);
+        expect(_.first(linkData).roadLinkType).to.not.equals(-1);
       });
     });
   });

--- a/viite-UI/test/integration-tests/FloatingRoadAddressSpec.js
+++ b/viite-UI/test/integration-tests/FloatingRoadAddressSpec.js
@@ -83,7 +83,7 @@ define(['chai', 'eventbus', 'TestHelpers'], function(chai, eventbus, testHelpers
         expect(unknownFeatureFromPickLayer).to.be.undefined;
         var unknownFeatureFromGreenLayer = testHelpers.getFeatureByLinkId(openLayersMap, testHelpers.getGreenRoadLayerName(),unknownRoadLinkId);
         expect(unknownFeatureFromGreenLayer).to.not.be.undefined;
-        expect(unknownFeatureFromGreenLayer.roadLinkData.linkId).to.be.equal(unknownRoadLinkId);
+        expect(unknownFeatureFromGreenLayer.linkData.linkId).to.be.equal(unknownRoadLinkId);
       });
     });
 

--- a/viite-UI/test/integration-tests/RoadAddressProjectSpec.js
+++ b/viite-UI/test/integration-tests/RoadAddressProjectSpec.js
@@ -84,14 +84,14 @@ define(['chai', 'eventbus', 'TestHelpers'], function(chai, eventbus, testHelpers
         var featureFromProjectLayerTerminated = testHelpers.getFeatureByLinkId(openLayersMap, testHelpers.getRoadAddressProjectLayerName(), 1717361);
         var featureFromProjectLayerNotReserved = testHelpers.getFeatureByLinkId(openLayersMap, testHelpers.getRoadAddressProjectLayerName(), 499896971);
         expect(featureFromProjectLayerNotHandled).to.not.be.undefined;
-        expect(featureFromProjectLayerNotHandled.projectLinkData.linkId).to.be.equal(1717275);
-        expect(featureFromProjectLayerNotHandled.projectLinkData.status).to.be.equal(0);
+        expect(featureFromProjectLayerNotHandled.linkData.linkId).to.be.equal(1717275);
+        expect(featureFromProjectLayerNotHandled.linkData.status).to.be.equal(0);
         expect(featureFromProjectLayerTerminated).to.not.be.undefined;
-        expect(featureFromProjectLayerTerminated.projectLinkData.linkId).to.be.equal(1717361);
-        expect(featureFromProjectLayerTerminated.projectLinkData.status).to.be.equal(1);
+        expect(featureFromProjectLayerTerminated.linkData.linkId).to.be.equal(1717361);
+        expect(featureFromProjectLayerTerminated.linkData.status).to.be.equal(1);
         expect(featureFromProjectLayerNotReserved).to.not.be.undefined;
-        expect(featureFromProjectLayerNotReserved.projectLinkData.linkId).to.be.equal(499896971);
-        expect(featureFromProjectLayerNotReserved.projectLinkData.status).to.be.equal(99);
+        expect(featureFromProjectLayerNotReserved.linkData.linkId).to.be.equal(499896971);
+        expect(featureFromProjectLayerNotReserved.linkData.status).to.be.equal(99);
       });
 
     });
@@ -108,7 +108,7 @@ define(['chai', 'eventbus', 'TestHelpers'], function(chai, eventbus, testHelpers
       it('Check if there form inputs are empty', function(){
           var feature = testHelpers.getFeatureByLinkId(openLayersMap, testHelpers.getRoadAddressProjectLayerName(), 499897070);
           expect(feature).to.not.be.undefined;
-          expect(feature.projectLinkData.linkId).to.be.equal(499897070);
+          expect(feature.linkData.linkId).to.be.equal(499897070);
           expect($('#dropdown_0').val('New').is(':disabled')).to.be.false;
           $('#dropDown_0').val('New').change();
           expect($('#tie')).to.not.be.undefined;

--- a/viite-UI/test_data/RoadLinkTestData.js
+++ b/viite-UI/test_data/RoadLinkTestData.js
@@ -1,6 +1,6 @@
 (function(testData) {
   testData.generate = function() {
-    var roadLinkData =
+    var linkData =
     [{
       "linkId": 1,
       "administrativeClass": "Private",
@@ -534,6 +534,6 @@
       }]
     }];
 
-    return _.map(roadLinkData, function(roadLink) { return [roadLink]; });
+    return _.map(linkData, function(roadLink) { return [roadLink]; });
   };
 }(window.RoadLinkTestData = window.RoadLinkTestData || {}));

--- a/viite-UI/tmpl/index.html
+++ b/viite-UI/tmpl/index.html
@@ -70,6 +70,7 @@
 <script type="text/javascript" src="src/router.js"></script>
 
 <script type="text/javascript" src="src/map/LinkPropertyMarker.js"></script>
+<script type="text/javascript" src="src/map/ProjectLinkMarker.js"></script>
 <script type="text/javascript" src="src/map/CalibrationPointMarker.js"></script>
 
 <script type="text/javascript" src="src/utils/eventbus.js"></script>


### PR DESCRIPTION
Adding markers of project link layer to single and double click interactions.

Refactoring of LinkPropertyLayer markers and ProjectLinkLayer markers.
Refactoring on roadLinkData and projectLinkData handling. Now is always called linkData and we don't need to validate it by name, since they are from different layers