### PR TITLE
VIITE-1394 new validation to check the previous road part outside of the project

### DIFF
--- a/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
+++ b/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
@@ -583,6 +583,20 @@ class ViiteApi(val roadLinkService: RoadLinkService, val vVHClient: VVHClient,
     }
   }
 
+  get("/project/links/:projectId") {
+    val id: Long = params.get("projectId") match {
+      case Some(s) if s != "" && s.toLong != 0 => s.toLong
+      case _ => 0L
+    }
+    time(logger, s"GET request for /project/links/$id)") {
+      if (id == 0)
+        BadRequest("Missing mandatory 'projectId' parameter")
+      else{
+        projectService.getProjectLinks(id)
+      }
+    }
+  }
+
   delete("/project/trid/:projectId") {
     val projectId = params("projectId").toLong
     time(logger, s"DELETE request for /project/trid/$projectId") {
@@ -1020,7 +1034,7 @@ class ViiteApi(val roadLinkService: RoadLinkService, val vVHClient: VVHClient,
       "newEly" -> reservedRoadPart.newEly,
       "newLength" -> reservedRoadPart.newLength,
       "newDiscontinuity" -> reservedRoadPart.newDiscontinuity.map(_.description),
-      "linkId" -> reservedRoadPart.startingLinkId,
+      "startingLinkId" -> reservedRoadPart.startingLinkId,
       "isDirty" -> reservedRoadPart.isDirty
     )
   }

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -740,6 +740,12 @@ class ProjectService(roadAddressService: RoadAddressService, roadLinkService: Ro
     }
   }
 
+  def getProjectLinks(projectId: Long): Seq[ProjectLink] = {
+    withDynTransaction {
+      ProjectDAO.getProjectLinks(projectId)
+    }
+  }
+
   def getProjectLinksWithSuravage(roadAddressService: RoadAddressService, projectId: Long, boundingRectangle: BoundingRectangle,
                                   roadNumberLimits: Seq[(Int, Int)], municipalities: Set[Int], everything: Boolean = false,
                                   publicRoads: Boolean = false): Seq[ProjectAddressLink] = {

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectValidator.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectValidator.scala
@@ -489,9 +489,11 @@ object ProjectValidator {
         val allProjectLinks = ProjectDAO.getProjectLinks(project.id)
         if (allProjectLinks.exists(link => link.roadNumber == road && link.roadPartNumber == previousRoadPartNumber.get))
           return None
-        val previousRoadPartEnd: RoadAddress = RoadAddressDAO.fetchByRoadPart(road, previousRoadPartNumber.get, fetchOnlyEnd = true).head
-        if (previousRoadPartEnd.discontinuity == EndOfRoad)
-          return outsideOfProjectError(project.id, alterMessage(ValidationErrorList.DoubleEndOfRoad, roadAndPart = Some(Seq((previousRoadPartEnd.roadNumber, previousRoadPartEnd.roadPartNumber)))))(List(previousRoadPartEnd))
+        val previousRoadPartEnd: Option[RoadAddress] = RoadAddressDAO.fetchByRoadPart(road, previousRoadPartNumber.get, fetchOnlyEnd = true).headOption
+        if (previousRoadPartEnd.nonEmpty) {
+          if (previousRoadPartEnd.get.discontinuity == EndOfRoad)
+            return outsideOfProjectError(project.id, alterMessage(ValidationErrorList.DoubleEndOfRoad, roadAndPart = Some(Seq((previousRoadPartEnd.get.roadNumber, previousRoadPartEnd.get.roadPartNumber)))))(List(previousRoadPartEnd.get))
+        }
       }
       None
     }

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectDAO.scala
@@ -565,7 +565,7 @@ object ProjectDAO {
   }
 
   def fetchReservedRoadParts(projectId: Long): Seq[ReservedRoadPart] = {
-    time(logger, "Fetch reserved road parts") {
+    time(logger, s"Fetch reserved road parts for project: $projectId") {
       val sql =
         s"""
         SELECT id, road_number, road_part_number, length, length_new,
@@ -599,9 +599,9 @@ object ProjectDAO {
             ) gr"""
       Q.queryNA[(Long, Long, Long, Option[Long], Option[Long], Option[Long], Option[Long], Option[Long],
         Option[Long], Option[Long])](sql).list.map {
-        case (id, road, part, length, newLength, ely, newEly, discontinuity, newDiscontinuity, linkId) =>
+        case (id, road, part, length, newLength, ely, newEly, discontinuity, newDiscontinuity, startingLinkId) =>
           ReservedRoadPart(id, road, part, length, discontinuity.map(Discontinuity.apply), ely, newLength,
-            newDiscontinuity.map(Discontinuity.apply), newEly, linkId)
+            newDiscontinuity.map(Discontinuity.apply), newEly, startingLinkId)
       }
     }
   }

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadAddressDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadAddressDAO.scala
@@ -801,6 +801,19 @@ object RoadAddressDAO {
     Q.queryNA[Int](query).firstOption
   }
 
+  def fetchPreviousRoadPartNumber(roadNumber: Long, current: Long) : Option[Long] = {
+    val query =
+      s"""
+          SELECT * FROM (
+            SELECT ra.road_part_number
+            FROM road_address ra
+            WHERE road_number = $roadNumber AND road_part_number < $current AND valid_to IS NULL
+            ORDER BY road_part_number ASC
+          ) WHERE ROWNUM < 2
+      """
+    Q.queryNA[Long](query).firstOption
+  }
+
   def update(roadAddress: RoadAddress) : Unit = {
     update(roadAddress, None)
   }

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/package.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/package.scala
@@ -97,8 +97,8 @@ package object viite {
   val RoadNotEndingInElyBorderMessage = "JATKUU-koodi virheellinen. Tieosa ei pääty ELY-rajalle."
   val RoadContinuesInAnotherElyMessage = "JATKUU-koodi %s on virheellinen, koska tie jatkuu toisessa ELY:ssa. "
   val MinorDiscontinuousWhenRoadConnectingRoundabout = "Tieosalla on lievä epäjatkuvuus. Määrittele Jatkuvuuskoodi oikein kyseiselle linkille."
-  val WrongDiscontinuityWhenAdjacentToTerminatedRoad = "Tekemäsi tieosoitemuutoksen vuoksi projektin ulkopuoliselle tieosalle täytyy muuttaa jatkuvuuskoodi Tien loppu. Muuta jatkuvuuskoodiksi Tien loppu (1) tieosoitteelle: %s."
-  val DoubleEndOfRoadMessage = "Tekemäsi tieosoitemuutoksen vuoksi projektin ulkopuolisen tieosan jatkuvuuskoodia Tien loppu tulee muuttaa. Tarkasta ja muuta tieosoitteen %s jatkuvuuskoodi."
+  val WrongDiscontinuityWhenAdjacentToTerminatedRoad = "Tekemäsi tieosoitemuutoksen vuoksi projektin ulkopuoliselle tieosalle täytyy muuttaa jatkuvuuskoodi Tien loppu. Muuta jatkuvuuskoodiksi Tien loppu (1) tieosoitteelle %s."
+  val DoubleEndOfRoadMessage = "Tekemäsi tieosoitemuutoksen vuoksi projektin ulkopuolisen tieosan jatkuvuuskoodia" + s""" "${EndOfRoad.description}" """ + s"(${EndOfRoad.value}) tulee muuttaa. Tarkasta ja muuta tieosoitteen %s jatkuvuuskoodi."
   val roadNameWasNotSavedInProject = "Projektin tienimityksiä ei ole tallennettu, koska ne ovat jo olemassa. Tien numerot: "
   val RoadNotAvailableMessage = s"TIE %d OSA %d on jo olemassa projektin alkupäivänä %s, tarkista tiedot"
   val RampsMinBound = 20001

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/package.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/package.scala
@@ -98,6 +98,7 @@ package object viite {
   val RoadContinuesInAnotherElyMessage = "JATKUU-koodi %s on virheellinen, koska tie jatkuu toisessa ELY:ssa. "
   val MinorDiscontinuousWhenRoadConnectingRoundabout = "Tieosalla on lievä epäjatkuvuus. Määrittele Jatkuvuuskoodi oikein kyseiselle linkille."
   val WrongDiscontinuityWhenAdjacentToTerminatedRoad = "Tekemäsi tieosoitemuutoksen vuoksi projektin ulkopuoliselle tieosalle täytyy muuttaa jatkuvuuskoodi Tien loppu. Muuta jatkuvuuskoodiksi Tien loppu (1) tieosoitteelle: %s."
+  val DoubleEndOfRoadMessage = "Tekemäsi tieosoitemuutoksen vuoksi projektin ulkopuolisen tieosan jatkuvuuskoodia Tien loppu tulee muuttaa. Tarkasta ja muuta tieosoitteen %s jatkuvuuskoodi."
   val roadNameWasNotSavedInProject = "Projektin tienimityksiä ei ole tallennettu, koska ne ovat jo olemassa. Tien numerot: "
   val RoadNotAvailableMessage = s"TIE %d OSA %d on jo olemassa projektin alkupäivänä %s, tarkista tiedot"
   val RampsMinBound = 20001

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectValidatorSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectValidatorSpec.scala
@@ -365,7 +365,6 @@ class ProjectValidatorSpec extends FunSuite with Matchers {
       val errors = ProjectValidator.checkRemovedEndOfRoadParts(updProject)
       errors should have size 1
       errors.head.validationError.value should be(TerminationContinuity.value)
-      errors.head.validationError.message should be("Tekemäsi tieosoitemuutoksen vuoksi projektin ulkopuoliselle tieosalle täytyy muuttaa jatkuvuuskoodi Tien loppu. Muuta jatkuvuuskoodiksi Tien loppu (1) tieosoitteelle: (19999,1).")
       val projectLinks = ProjectDAO.getProjectLinks(id, Some(LinkStatus.Terminated)).map(_.copy(discontinuity = EndOfRoad, status = LinkStatus.UnChanged))
       ProjectDAO.updateProjectLinksToDB(projectLinks, "U")
       val updProject2 = ProjectDAO.getRoadAddressProjectById(project.id).get

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectValidatorSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectValidatorSpec.scala
@@ -629,7 +629,13 @@ class ProjectValidatorSpec extends FunSuite with Matchers {
 
   test("There should be a validation error when there is a road end on previous road part outside of project") {
     runWithRollback {
-
+      RoadAddressDAO.create(Seq(RoadAddress(NewRoadAddress, 1999L, 1L, RoadType.PublicRoad, Track.Combined, Discontinuity.EndOfRoad,
+        0L, 10L, Some(DateTime.now()), None, None, 0L, 39399L, 0.0, 10.0, TowardsDigitizing, 0L, (Some(CalibrationPoint(39399L, 0.0, 0L)), Some(CalibrationPoint(39399L, 10.0, 10L))),
+        floating = false, Seq(Point(0.0, 40.0), Point(0.0, 50.0)), LinkGeomSource.ComplimentaryLinkInterface, 8L, NoTermination, 0)))
+      val (project, projectLinks) = util.setUpProjectWithLinks(LinkStatus.New, Seq(10L, 20L),  roads = Seq((1999L, 2L, "Test road")), discontinuity = Discontinuity.EndOfRoad)
+      val errors = ProjectValidator.checkRoadContinuityCodes(project, projectLinks)
+      errors should have size 1
+      errors.head.validationError.value should be(DoubleEndOfRoad.value)
     }
   }
 

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectValidatorSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectValidatorSpec.scala
@@ -627,4 +627,10 @@ class ProjectValidatorSpec extends FunSuite with Matchers {
     }
   }
 
+  test("There should be a validation error when there is a road end on previous road part outside of project") {
+    runWithRollback {
+
+    }
+  }
+
 }

--- a/viite-UI/src/model/ProjectCollection.js
+++ b/viite-UI/src/model/ProjectCollection.js
@@ -28,7 +28,7 @@
     };
 
     this.getProjectLinks = function() {
-      return _.flatten(fetchedProjectLinks);
+      return backend.getProjectLinksById(currentProject.project.id);
     };
 
     this.getAll = function () {
@@ -56,15 +56,15 @@
     };
 
     this.getProjectLink = function (ids) {
-      var links = _.filter(_.flatten(fetchedProjectLinks), function (projectLink){
+      return _.filter(projectLinks(), function (projectLink){
         if (projectLink.getData().id > 0) {
           return _.contains(ids, projectLink.getData().id);
         } else {
           return _.contains(ids, projectLink.getData().linkId);
         }
       });
-      return links;
     };
+
 
     this.fetch = function(boundingBox, zoom, projectId, isPublishable) {
       var id = projectId;

--- a/viite-UI/src/utils/backend-utils.js
+++ b/viite-UI/src/utils/backend-utils.js
@@ -35,6 +35,12 @@
       };
     });
 
+    this.getProjectLinksById = _.throttle(function (projectId, callback) {
+        return $.getJSON('api/viite/project/links/' + projectId, function (data) {
+            return _.isFunction(callback) && callback(data);
+        });
+    }, 1000);
+
     this.revertChangesRoadlink = _.throttle(function (data, success, errorCallback) {
         $.ajax({
             contentType: "application/json",
@@ -237,7 +243,7 @@
       if (loadingProject) {
         loadingProject.abort();
       }
-      loadingProject= $.getJSON('api/viite/roadlinks/roadaddress/project/all/projectId/' + id, function (data) {
+      loadingProject = $.getJSON('api/viite/roadlinks/roadaddress/project/all/projectId/' + id, function (data) {
         return _.isFunction(callback) && callback(data);
       });
       return loadingProject;

--- a/viite-UI/src/view/ProjectEditForm.js
+++ b/viite-UI/src/view/ProjectEditForm.js
@@ -551,18 +551,20 @@
 
       rootElement.on('click', '.projectErrorButton', function (event) {
         eventbus.trigger('projectCollection:clickCoordinates', event, map);
-        var errorIndex = event.currentTarget.id;
-        if(projectCollection.getProjectErrors()[errorIndex].errorMessage !== ""){
-          if (projectCollection.getProjectLinks().includes(event.currentTarget.linkId)) {
-              var ids = projectCollection.getProjectErrors()[errorIndex].ids;
-              selectedProjectLinkProperty.openWithErrorMessage(ids[0], projectCollection.getProjectErrors()[errorIndex].errorMessage);
-          } else {
-              new ModalConfirm("Sinun täytyy varata tieosa projektille, jotta voit korjata sen.");
-          }
+        var error = projectCollection.getProjectErrors()[event.currentTarget.id];
+        if (error.errorMessage !== "") {
+          projectCollection.getProjectLinks().then( function(projectLinks) {
+            var projectLinkIds = projectLinks.map( function(link) {
+              return link.linkId;
+            });
+            if (error.linkIds.every(link => projectLinkIds.indexOf(link) > -1)) {
+                selectedProjectLinkProperty.openWithErrorMessage(error.ids[0], error.errorMessage);
+            } else {
+                new ModalConfirm("Sinun täytyy varata tieosa projektille, jotta voit korjata sen.");
+            }
+          });
         }
-
       });
-
     };
     bindEvents();
   };

--- a/viite-UI/src/view/ProjectEditForm.js
+++ b/viite-UI/src/view/ProjectEditForm.js
@@ -553,8 +553,12 @@
         eventbus.trigger('projectCollection:clickCoordinates', event, map);
         var errorIndex = event.currentTarget.id;
         if(projectCollection.getProjectErrors()[errorIndex].errorMessage !== ""){
-          var ids = projectCollection.getProjectErrors()[errorIndex].ids;
-          selectedProjectLinkProperty.openWithErrorMessage(ids[0], projectCollection.getProjectErrors()[errorIndex].errorMessage);
+          if (projectCollection.getProjectLinks().includes(event.currentTarget.linkId)) {
+              var ids = projectCollection.getProjectErrors()[errorIndex].ids;
+              selectedProjectLinkProperty.openWithErrorMessage(ids[0], projectCollection.getProjectErrors()[errorIndex].errorMessage);
+          } else {
+              new ModalConfirm("Sinun täytyy varata tieosa projektille, jotta voit korjata sen.");
+          }
         }
 
       });


### PR DESCRIPTION
Added new validation: Viite checks if there is end of road discontinuity on the previous road parts which are not in the project. Side note: Let's try to keep function names as describing as possible. I used a lot of time debugging code because of few functions didn't do what i expected them to do by their names.