### PR TITLE
VIITE-1410 UUSI action with invalid road number has unwanted behavior

### DIFF
--- a/viite-UI/src/model/ProjectCollection.js
+++ b/viite-UI/src/model/ProjectCollection.js
@@ -200,6 +200,8 @@
           if (response.success) {
             dirtyProjectLinkIds = [];
             publishableProject = response.publishable;
+            console.log("async");
+            console.log(response.projectErrors);
             projectErrors = response.projectErrors;
             eventbus.trigger('projectLink:revertedChanges');
           } else {

--- a/viite-UI/src/model/ProjectCollection.js
+++ b/viite-UI/src/model/ProjectCollection.js
@@ -202,13 +202,10 @@
             publishableProject = response.publishable;
             projectErrors = response.projectErrors;
             eventbus.trigger('projectLink:revertedChanges');
-          }
-          else if (response.status == INTERNAL_SERVER_ERROR_500 || response.status == BAD_REQUEST_400) {
-            eventbus.trigger('roadAddress:projectLinksUpdateFailed', error.status);
-            new ModalConfirm(response.errorMessage);
-            applicationModel.removeSpinner();
-          }
-          else{
+          } else {
+            if (response.status == INTERNAL_SERVER_ERROR_500 || response.status == BAD_REQUEST_400) {
+              eventbus.trigger('roadAddress:projectLinksUpdateFailed', error.status);
+            }
             new ModalConfirm(response.errorMessage);
             applicationModel.removeSpinner();
           }
@@ -250,7 +247,6 @@
           backend.createProjectLinks(dataJson, function(successObject) {
             if (!successObject.success) {
               new ModalConfirm(successObject.errorMessage);
-              eventbus.trigger("roadAddressProject:roadCreationFailed", successObject.errorMessage);
               applicationModel.removeSpinner();
             } else {
               publishableProject = successObject.publishable;
@@ -260,16 +256,15 @@
               eventbus.trigger('roadAddress:projectLinksUpdated', successObject);
             }
           });
-        }
-        else {
+        } else {
           backend.updateProjectLinks(dataJson, function (successObject) {
-            if (!successObject.success) {
-              new ModalConfirm(successObject.errorMessage);
-              applicationModel.removeSpinner();
-            } else {
+            if (successObject.success) {
               publishableProject = successObject.publishable;
               projectErrors = successObject.projectErrors;
               eventbus.trigger('roadAddress:projectLinksUpdated', successObject);
+            } else {
+              new ModalConfirm(successObject.errorMessage);
+              applicationModel.removeSpinner();
             }
           });
         }
@@ -296,7 +291,6 @@
           return true;
         }
       };
-
       var newAndOtherLinks = _.partition(changedLinks, function(l) { return l.id === 0;});
       var newLinks = newAndOtherLinks[0];
       var otherLinks = newAndOtherLinks[1];
@@ -316,9 +310,9 @@
 
       var projectId = projectInfo.id;
       var coordinates = applicationModel.getUserGeoLocation();
-        var roadAddressProjectForm = $('#roadAddressProjectForm');
-        var endDistance = $('#endDistance')[0];
-        var dataJson = {
+      var roadAddressProjectForm = $('#roadAddressProjectForm');
+      var endDistance = $('#endDistance')[0];
+      var dataJson = {
         ids: ids,
         linkIds: linkIds,
         linkStatus: statusCode,
@@ -335,10 +329,9 @@
         roadName: roadAddressProjectForm.find('#roadName')[0].value
       };
 
-      if(dataJson.trackCode === Track.Unknown.value){
+      if (dataJson.trackCode === Track.Unknown.value) {
         new ModalConfirm("Tarkista ajoratakoodi");
         applicationModel.removeSpinner();
-        return false;
       }
 
       var changedLink = _.chain(changedLinks).uniq().sortBy(function(cl){
@@ -346,7 +339,7 @@
       }).last().value();
       var isNewRoad = changedLink.status == LinkStatus.New.value;
 
-      if(isNewRoad && !validUserGivenAddrMValues(_.first(dataJson.ids || dataJson.linkIds), dataJson.userDefinedEndAddressM)){
+      if (isNewRoad && !validUserGivenAddrMValues(_.first(dataJson.ids || dataJson.linkIds), dataJson.userDefinedEndAddressM)) {
         new GenericConfirmPopup("Antamasi pituus eroaa yli 5% prosenttia geometrian pituudesta, haluatko varmasti tallentaa tämän pituuden?", {
           successCallback: function () {
             createOrUpdate(dataJson);
@@ -356,10 +349,9 @@
             eventbus.trigger('roadAddress:projectLinksUpdated');
           }
         });
-      } else{
+      } else {
         createOrUpdate(dataJson);
       }
-      return true;
     };
 
     this.preSplitProjectLinks = function(suravage, nearestPoint){
@@ -456,26 +448,22 @@
         coordinates:coordinates
       };
 
-      if(dataJson.trackCode === Track.Unknown.value){
+      if (dataJson.trackCode === Track.Unknown.value) {
         new ModalConfirm("Tarkista ajoratakoodi");
-        applicationModel.removeSpinner();
-        return false;
       }
 
       backend.saveProjectLinkSplit(dataJson, linkId, function(successObject) {
-        if (!successObject.success) {
-          new ModalConfirm(successObject.reason);
-          applicationModel.removeSpinner();
-        } else {
+        if (successObject.success) {
           projectErrors = successObject.projectErrors;
           eventbus.trigger('projectLink:projectLinksSplitSuccess');
           eventbus.trigger('roadAddress:projectLinksUpdated', successObject);
-          applicationModel.removeSpinner();
-      }}, function(failureObject) {
+        } else {
+          new ModalConfirm(successObject.reason);
+        }
+      }, function(failureObject) {
           new ModalConfirm(failureObject.reason);
-          applicationModel.removeSpinner();
       });
-      return true;
+      applicationModel.removeSpinner();
     };
 
     this.createProject = function (data, resolution) {

--- a/viite-UI/src/model/ProjectCollection.js
+++ b/viite-UI/src/model/ProjectCollection.js
@@ -200,8 +200,6 @@
           if (response.success) {
             dirtyProjectLinkIds = [];
             publishableProject = response.publishable;
-            console.log("async");
-            console.log(response.projectErrors);
             projectErrors = response.projectErrors;
             eventbus.trigger('projectLink:revertedChanges');
           } else {

--- a/viite-UI/src/view/ProjectEditForm.js
+++ b/viite-UI/src/view/ProjectEditForm.js
@@ -321,19 +321,19 @@
         var statusDropdown_0 =$('#dropdown_0').val();
         var statusDropdown_1 = $('#dropdown_1').val();
 
-        var object_0 = _.find(LinkStatus, function(obj){
+        var objectDropdown_0 = _.find(LinkStatus, function(obj){
           return obj.description === statusDropdown_0;
         });
-        var object_1 = _.find(LinkStatus, function(obj){
+        var objectDropdown_1 = _.find(LinkStatus, function(obj){
           return obj.description === statusDropdown_1;
         });
 
-        if (object_0.value === LinkStatus.Revert.value) {
+        if (objectDropdown_0.value === LinkStatus.Revert.value) {
           projectCollection.revertChangesRoadlink(selectedProjectLink);
-        } else if (!_.isUndefined(object_1)) {
-          projectCollection.saveCutProjectLinks(projectCollection.getTmpDirty(), object_0.value, object_1.value);
+        } else if (!_.isUndefined(objectDropdown_1)) {
+          projectCollection.saveCutProjectLinks(projectCollection.getTmpDirty(), objectDropdown_0.value, objectDropdown_1.value);
         } else {
-          projectCollection.saveProjectLinks(projectCollection.getTmpDirty(), object_0.value);
+          projectCollection.saveProjectLinks(projectCollection.getTmpDirty(), objectDropdown_0.value);
         }
       };
 

--- a/viite-UI/src/view/ProjectEditForm.js
+++ b/viite-UI/src/view/ProjectEditForm.js
@@ -317,59 +317,29 @@
       };
 
       var saveChanges = function(){
-        var successSavingChanges = true;
-        var currentProject = projectCollection.getCurrentProject();
         //TODO revert dirtyness if others than ACTION_TERMINATE is choosen, because now after Lakkautus, the link(s) stay always in black color
         var statusDropdown_0 =$('#dropdown_0').val();
         var statusDropdown_1 = $('#dropdown_1').val();
-        switch (statusDropdown_0){
-          case LinkStatus.Unchanged.description : {
-            if(!_.isUndefined(statusDropdown_1) && statusDropdown_1 == LinkStatus.New.description){
-              successSavingChanges = projectCollection.saveCutProjectLinks(projectCollection.getTmpDirty(), LinkStatus.Unchanged.value, LinkStatus.New.value);
-            }
-            else if(_.isUndefined(statusDropdown_1)){
-              successSavingChanges = projectCollection.saveProjectLinks(projectCollection.getTmpDirty(), LinkStatus.Unchanged.value);
-            }
-            break;
-          }
-          case LinkStatus.New.description : {
-            if(!_.isUndefined(statusDropdown_1) && statusDropdown_1 == LinkStatus.Unchanged.description){
-              successSavingChanges = projectCollection.saveCutProjectLinks(projectCollection.getTmpDirty(), LinkStatus.New.value, LinkStatus.Unchanged.value);
-            }
 
-            else if(!_.isUndefined(statusDropdown_1) && statusDropdown_1 == LinkStatus.Transfer.description){
-              successSavingChanges = projectCollection.saveCutProjectLinks(projectCollection.getTmpDirty(), LinkStatus.New.value, LinkStatus.Transfer.value);
-            }
-            else if(_.isUndefined(statusDropdown_1)) {
-              successSavingChanges = projectCollection.saveProjectLinks(projectCollection.getTmpDirty(), LinkStatus.New.value);
-            }
-            break;
-          }
-          case LinkStatus.Transfer.description : {
-            if(!_.isUndefined(statusDropdown_1) && statusDropdown_1 == LinkStatus.New.description){
-              successSavingChanges = projectCollection.saveCutProjectLinks(projectCollection.getTmpDirty(), LinkStatus.Unchanged.value, LinkStatus.New.value);
-            }
-            else if(_.isUndefined(statusDropdown_1)){
-              successSavingChanges = projectCollection.saveProjectLinks(projectCollection.getTmpDirty(), LinkStatus.Transfer.value);
-            }
-            break;
-          }
-          case LinkStatus.Numbering.description : {
-            successSavingChanges = projectCollection.saveProjectLinks(projectCollection.getTmpDirty(), LinkStatus.Numbering.value); break;
-          }
-          case LinkStatus.Terminated.description: {
-            successSavingChanges = projectCollection.saveProjectLinks(projectCollection.getTmpDirty(), LinkStatus.Terminated.value); break;
-          }
-          case LinkStatus.Revert.description : {
-            projectCollection.revertChangesRoadlink(selectedProjectLink); break;
-          }
-        }
+        var object_0 = _.find(LinkStatus, function(obj){
+          return obj.description === statusDropdown_0;
+        });
+        var object_1 = _.find(LinkStatus, function(obj){
+          return obj.description === statusDropdown_1;
+        });
 
-        if(successSavingChanges){
-          selectedProjectLinkProperty.setDirty(false);
-          rootElement.html(emptyTemplate(currentProject.project));
-          formCommon.toggleAdditionalControls();
+        console.log(projectCollection.getProjectErrors());
+        if (object_0.value === LinkStatus.Revert.value) {
+          console.log("revert");
+          projectCollection.revertChangesRoadlink(selectedProjectLink);
+        } else if (!_.isUndefined(object_1)) {
+          console.log("save cut");
+          projectCollection.saveCutProjectLinks(projectCollection.getTmpDirty(), object_0.value, object_1.value);
+        } else {
+          console.log("save");
+          projectCollection.saveProjectLinks(projectCollection.getTmpDirty(), object_0.value);
         }
+        console.log(projectCollection.getProjectErrors());
       };
 
       var cancelChanges = function() {

--- a/viite-UI/src/view/ProjectEditForm.js
+++ b/viite-UI/src/view/ProjectEditForm.js
@@ -328,18 +328,13 @@
           return obj.description === statusDropdown_1;
         });
 
-        console.log(projectCollection.getProjectErrors());
         if (object_0.value === LinkStatus.Revert.value) {
-          console.log("revert");
           projectCollection.revertChangesRoadlink(selectedProjectLink);
         } else if (!_.isUndefined(object_1)) {
-          console.log("save cut");
           projectCollection.saveCutProjectLinks(projectCollection.getTmpDirty(), object_0.value, object_1.value);
         } else {
-          console.log("save");
           projectCollection.saveProjectLinks(projectCollection.getTmpDirty(), object_0.value);
         }
-        console.log(projectCollection.getProjectErrors());
       };
 
       var cancelChanges = function() {

--- a/viite-UI/src/view/ProjectLinkLayer.js
+++ b/viite-UI/src/view/ProjectLinkLayer.js
@@ -821,7 +821,7 @@
       projectCollection.fetch(map.getView().calculateExtent(map.getSize()).join(','), currentZoom + 1, undefined, projectCollection.getPublishableStatus());
     });
 
-    var redraw = function () {
+    me.redraw = function () {
       var ids = {};
       _.each(selectedProjectLinkProperty.get(), function (sel) {
         ids[sel.linkId] = true;
@@ -978,7 +978,7 @@
 
     eventbus.on('roadAddressProject:fetched', function () {
       applicationModel.removeSpinner();
-      redraw();
+      me.redraw();
       _.defer(function () {
         highlightFeatures();
         if (selectedProjectLinkProperty.isSplit()) {
@@ -988,7 +988,7 @@
     });
 
     eventbus.on('roadAddress:projectLinksEdited', function () {
-      redraw();
+      me.redraw();
     });
 
     eventbus.on('roadAddressProject:projectLinkSaved', function (projectId, isPublishable) {

--- a/viite-UI/src/view/ProjectLinkLayer.js
+++ b/viite-UI/src/view/ProjectLinkLayer.js
@@ -303,21 +303,8 @@
     };
     
     var clearHighlights = function () {
-      if (applicationModel.getSelectedTool() == 'Cut') {
-        if (selectDoubleClick.getFeatures().getLength() !== 0) {
-          selectDoubleClick.getFeatures().clear();
-        }
-        if (selectSingleClick.getFeatures().getLength() !== 0) {
-          selectSingleClick.getFeatures().clear();
-        }
-      } else {
-        if (selectDoubleClick.getFeatures().getLength() !== 0) {
-          selectDoubleClick.getFeatures().clear();
-        }
-        if (selectSingleClick.getFeatures().getLength() !== 0) {
-          selectSingleClick.getFeatures().clear();
-        }
-      }
+      selectDoubleClick.getFeatures().clear();
+      selectSingleClick.getFeatures().clear();
     };
 
     var clearLayers = function () {
@@ -834,7 +821,7 @@
       projectCollection.fetch(map.getView().calculateExtent(map.getSize()).join(','), currentZoom + 1, undefined, projectCollection.getPublishableStatus());
     });
 
-    me.redraw = function () {
+    var redraw = function () {
       var ids = {};
       _.each(selectedProjectLinkProperty.get(), function (sel) {
         ids[sel.linkId] = true;
@@ -991,7 +978,7 @@
 
     eventbus.on('roadAddressProject:fetched', function () {
       applicationModel.removeSpinner();
-      me.redraw();
+      redraw();
       _.defer(function () {
         highlightFeatures();
         if (selectedProjectLinkProperty.isSplit()) {
@@ -1001,7 +988,7 @@
     });
 
     eventbus.on('roadAddress:projectLinksEdited', function () {
-      me.redraw();
+      redraw();
     });
 
     eventbus.on('roadAddressProject:projectLinkSaved', function (projectId, isPublishable) {


### PR DESCRIPTION
Now, when user gives invalid road number for new road (there's already a road with the number), Viite doesn't clear the edit form. It keeps the road information so the user can change the road number and save again with right road number. I also made the code less repeating. 