### PR TITLE
VIITE-1430 wrong values on change table for split

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/ProjectDeltaCalculator.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/ProjectDeltaCalculator.scala
@@ -3,7 +3,6 @@ package fi.liikennevirasto.viite.process
 import fi.liikennevirasto.digiroad2.GeometryUtils
 import fi.liikennevirasto.digiroad2.util.Track.RightSide
 import fi.liikennevirasto.digiroad2.util.{RoadAddressException, Track}
-import fi.liikennevirasto.viite.dao.Discontinuity.MinorDiscontinuity
 import fi.liikennevirasto.viite.dao.LinkStatus._
 import fi.liikennevirasto.viite.dao.{ProjectLink, _}
 import org.joda.time.DateTime
@@ -43,9 +42,11 @@ object ProjectDeltaCalculator {
           case Transfer =>
             val termAddress = connectedLink.map(l => (l.startAddrMValue, l.endAddrMValue))
             termAddress.map { case (start, end) =>
-              address.copy(startAddrMValue = end,
-                endAddrMValue = if (end == address.endAddrMValue) start else address.endAddrMValue, startMValue = pl.startMValue,
-                endMValue = pl.endMValue, geometry = geom)
+              address.copy(startAddrMValue = if(start == address.startAddrMValue) end else address.startAddrMValue,
+                endAddrMValue = if (end == address.endAddrMValue) start else address.endAddrMValue,
+                startMValue = pl.startMValue,
+                endMValue = pl.endMValue,
+                geometry = geom)
             }.getOrElse(address)
           case Terminated =>
             address.copy(startAddrMValue = pl.startAddrMValue, endAddrMValue = pl.endAddrMValue, startMValue = pl.startMValue,

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/DiscontinuityTrackCalculatorStrategy.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/DiscontinuityTrackCalculatorStrategy.scala
@@ -2,11 +2,10 @@ package fi.liikennevirasto.viite.process.strategy
 
 import fi.liikennevirasto.digiroad2.util.Track
 import fi.liikennevirasto.viite.dao.CalibrationPointDAO.UserDefinedCalibrationPoint
-import fi.liikennevirasto.viite.dao.Discontinuity.MinorDiscontinuity
-import fi.liikennevirasto.viite.dao.{Discontinuity, LinkStatus, ProjectLink}
+import fi.liikennevirasto.viite.dao.Discontinuity.{Discontinuous, MinorDiscontinuity}
+import fi.liikennevirasto.viite.dao.{Discontinuity, ProjectLink}
 
-
-class DiscontinuityTrackCalculatorStrategy extends TrackCalculatorStrategy {
+class DiscontinuityTrackCalculatorStrategy(discontinuity: Discontinuity) extends TrackCalculatorStrategy {
 
   protected def getUntilDiscontinuity(seq: Seq[ProjectLink], discontinuity: Discontinuity): (Seq[ProjectLink], Seq[ProjectLink]) = {
     val continuousProjectLinks = seq.takeWhile(pl => pl.discontinuity != discontinuity)
@@ -18,13 +17,12 @@ class DiscontinuityTrackCalculatorStrategy extends TrackCalculatorStrategy {
   }
 
   override def applicableStrategy(headProjectLink: ProjectLink, projectLink: ProjectLink): Boolean = {
-    projectLink.discontinuity == MinorDiscontinuity &&
-      (projectLink.track == Track.LeftSide || projectLink.track == Track.RightSide)
+    projectLink.discontinuity == discontinuity
   }
 
   override def assignTrackMValues(startAddress: Option[Long], leftProjectLinks: Seq[ProjectLink], rightProjectLinks: Seq[ProjectLink], userDefinedCalibrationPoint: Map[Long, UserDefinedCalibrationPoint]): TrackCalculatorResult = {
-    val (left, restLeft) = getUntilDiscontinuity(leftProjectLinks, MinorDiscontinuity)
-    val (right, restRight) = getUntilDiscontinuity(rightProjectLinks, MinorDiscontinuity)
+    val (left, restLeft) = getUntilDiscontinuity(leftProjectLinks, discontinuity)
+    val (right, restRight) = getUntilDiscontinuity(rightProjectLinks, discontinuity)
 
     (left.last.discontinuity, right.last.discontinuity) match {
       case (MinorDiscontinuity, MinorDiscontinuity) => //If both sides have a minor discontinuity

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/TrackCalculatorStrategy.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/TrackCalculatorStrategy.scala
@@ -4,6 +4,7 @@ import fi.liikennevirasto.digiroad2.GeometryUtils
 import fi.liikennevirasto.digiroad2.util.RoadAddressException
 import fi.liikennevirasto.viite.NewRoadAddress
 import fi.liikennevirasto.viite.dao.CalibrationPointDAO.UserDefinedCalibrationPoint
+import fi.liikennevirasto.viite.dao.Discontinuity.{Discontinuous, MinorDiscontinuity}
 import fi.liikennevirasto.viite.dao.{CalibrationCode, LinkStatus, ProjectLink, RoadAddressDAO}
 import fi.liikennevirasto.viite.process.{ProjectSectionMValueCalculator, TrackAddressingFactors}
 import fi.liikennevirasto.viite.util.CalibrationPointsUtils
@@ -11,8 +12,12 @@ import fi.liikennevirasto.viite.util.CalibrationPointsUtils
 
 object TrackCalculatorContext {
 
-  private lazy val discontinuityTrackCalculatorStrategy: DiscontinuityTrackCalculatorStrategy = {
-    new DiscontinuityTrackCalculatorStrategy
+  private lazy val minorDiscontinuityStrategy: DiscontinuityTrackCalculatorStrategy = {
+    new DiscontinuityTrackCalculatorStrategy(MinorDiscontinuity)
+  }
+
+  private lazy val discontinuousStrategy: DiscontinuityTrackCalculatorStrategy  = {
+    new DiscontinuityTrackCalculatorStrategy(Discontinuous)
   }
 
   private lazy val linkStatusChangeTrackCalculatorStrategy: LinkStatusChangeTrackCalculatorStrategy = {
@@ -23,7 +28,8 @@ object TrackCalculatorContext {
     new DefaultTrackCalculatorStrategy
   }
 
-  private val strategies = Seq(discontinuityTrackCalculatorStrategy, linkStatusChangeTrackCalculatorStrategy)
+
+  private val strategies = Seq(minorDiscontinuityStrategy, discontinuousStrategy, linkStatusChangeTrackCalculatorStrategy)
 
   def getNextStrategy(projectLinks: Seq[ProjectLink]): Option[(Long, TrackCalculatorStrategy)] = {
     val head = projectLinks.head

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/util/ProjectLinkSplitter.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/util/ProjectLinkSplitter.scala
@@ -1,5 +1,6 @@
 package fi.liikennevirasto.viite.util
 
+import fi.liikennevirasto.digiroad2.asset.SideCode.{AgainstDigitizing, TowardsDigitizing}
 import fi.liikennevirasto.digiroad2.asset.{LinkGeomSource, SideCode}
 import fi.liikennevirasto.digiroad2.linearasset.{PolyLine, RoadLink}
 import fi.liikennevirasto.digiroad2.util.Track
@@ -166,7 +167,8 @@ object ProjectLinkSplitter {
       val splitT = templateLink.copy(
         endMValue = templateM,
         geometryLength = templateM,
-        endAddrMValue = Math.max(splitAddressM, adjustedTemplate.addrAt(adjustedTemplate.startMValue)),
+        startAddrMValue = splitAddressM,
+        endAddrMValue = adjustedTemplate.endAddrMValue,
         status = LinkStatus.Terminated,
         connectedLinkId = Some(suravage.linkId))
       (splitA, splitB, splitT)

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectValidatorSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectValidatorSpec.scala
@@ -621,11 +621,11 @@ class ProjectValidatorSpec extends FunSuite with Matchers {
     runWithRollback {
       val ra = Seq(
         RoadAddress(NewRoadAddress, 19999L, 1L, RoadType.PublicRoad, Track.Combined, Discontinuity.Continuous,
-          0L, 10L, Some(DateTime.now()), None, None, 0L, 39398L, 0.0, 10.0, TowardsDigitizing, 0L,
+          0L, 10L, Some(DateTime.now()), None, None, 39398L, 0.0, 10.0, TowardsDigitizing, 0L,
           (Some(CalibrationPoint(39398L, 0.0, 0L)), Some(CalibrationPoint(39398L, 10.0, 10L))),
           floating = false, Seq(Point(10.0, 30.0), Point(10.0, 40.0)), LinkGeomSource.ComplimentaryLinkInterface, 8L, NoTermination, 0),
         RoadAddress(NewRoadAddress, 19999L, 1L, RoadType.PublicRoad, Track.Combined, Discontinuity.Continuous,
-          10L, 20L, Some(DateTime.now()), None, None, 0L, 39399L, 0.0, 10.0, TowardsDigitizing, 0L,
+          10L, 20L, Some(DateTime.now()), None, None, 39399L, 0.0, 10.0, TowardsDigitizing, 0L,
           (Some(CalibrationPoint(39399L, 0.0, 0L)), Some(CalibrationPoint(39399L, 10.0, 10L))),
           floating = false, Seq(Point(10.0, 40.0), Point(10.0, 50.0)), LinkGeomSource.ComplimentaryLinkInterface, 8L, NoTermination, 0))
       val siirto = RoadAddressDAO.create(Set(ra.head), Some("U"))

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/ProjectSectionCalculatorSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/ProjectSectionCalculatorSpec.scala
@@ -554,7 +554,7 @@ class ProjectSectionCalculatorSpec extends FunSuite with Matchers {
     }
   }
 
-  test("validate if there is a calibration point when has MinorDiscontinuity at end of address and start of next one") {
+  test("validate if there is a calibration point when has MinorDiscontinuity at end of address and start of next one with 2 tracks (Left and Right)") {
     runWithRollback{
       // Left track = 85.308 meters
       val idRoad0 = 0L //   L>
@@ -588,7 +588,94 @@ class ProjectSectionCalculatorSpec extends FunSuite with Matchers {
       (ordered.filter(_.track == Track.LeftSide).flatMap(_.calibrationPoints._1) ++ ordered.filter(_.track == Track.LeftSide).flatMap(_.calibrationPoints._2)) should have size 4
       (ordered.filter(_.track == Track.RightSide).flatMap(_.calibrationPoints._1) ++ ordered.filter(_.track == Track.RightSide).flatMap(_.calibrationPoints._2)) should have size 4
     }
+  }
 
+  test("validate if there is a calibration point when has Discontinuous at end of address and start of next one with 2 tracks (Left and Right)") {
+    runWithRollback{
+      // Left track = 85.308 meters
+      val idRoad0 = 0L //   L>
+      val idRoad1 = 1L //   L>
+      val idRoad2 = 2L //   L>
+      val idRoad3 = 3L //   L>
+      // Right track = 83.154 meters
+      val idRoad4 = 4L //   R>
+      val idRoad5 = 5L //   R>
+      val projectLink0 = toProjectLink(rap, LinkStatus.New)(RoadAddress(idRoad0, 5, 1, RoadType.Unknown, Track.LeftSide, Continuous,
+        0L, 0L, Some(DateTime.parse("1901-01-01")), Some(DateTime.parse("1902-01-01")), Option("tester"), idRoad0, 0.0, 0.0, SideCode.TowardsDigitizing, 0, (None, None), floating = false,
+        Seq(Point(20.0, 10.0), Point(28, 15)), LinkGeomSource.NormalLinkInterface, 8, NoTermination, 0))
+      val projectLink1 = toProjectLink(rap, LinkStatus.New)(RoadAddress(idRoad1, 5, 1, RoadType.Unknown, Track.LeftSide, Discontinuous,
+        0L, 0L, Some(DateTime.parse("1901-01-01")), Some(DateTime.parse("1902-01-01")), Option("tester"), idRoad1, 0.0, 0.0, SideCode.TowardsDigitizing, 0, (None, None), floating = false,
+        Seq(Point(28, 15), Point(41, 18)), LinkGeomSource.NormalLinkInterface, 8, NoTermination, 0))
+      val projectLink2 = toProjectLink(rap, LinkStatus.New)(RoadAddress(idRoad2, 5, 1, RoadType.Unknown, Track.LeftSide, Continuous,
+        0L, 0L, Some(DateTime.parse("1901-01-01")), Some(DateTime.parse("1902-01-01")), Option("tester"), idRoad2, 0.0, 0.0, SideCode.TowardsDigitizing, 0, (None, None), floating = false,
+        Seq(Point(42, 19), Point(75, 29.2)), LinkGeomSource.NormalLinkInterface, 8, NoTermination, 0))
+      val projectLink3 = toProjectLink(rap, LinkStatus.New)(RoadAddress(idRoad3, 5, 1, RoadType.Unknown, Track.LeftSide, Continuous,
+        0L, 0L, Some(DateTime.parse("1901-01-01")), Some(DateTime.parse("1902-01-01")), Option("tester"), idRoad3, 0.0, 0.0, SideCode.TowardsDigitizing, 0, (None, None), floating = false,
+        Seq(Point(103.0, 15.0),Point(75, 29.2)), LinkGeomSource.NormalLinkInterface, 8, NoTermination, 0))
+      val projectLink4 = toProjectLink(rap, LinkStatus.New)(RoadAddress(idRoad4, 5, 1, RoadType.Unknown, Track.RightSide, Discontinuous,
+        0L, 0L, Some(DateTime.parse("1901-01-01")), Some(DateTime.parse("1902-01-01")), Option("tester"), idRoad4, 0.0, 0.0, SideCode.TowardsDigitizing, 0, (None, None), floating = false,
+        Seq(Point(20.0, 10.0), Point(42, 11)), LinkGeomSource.NormalLinkInterface, 8, NoTermination, 0))
+      val projectLink5 = toProjectLink(rap, LinkStatus.New)(RoadAddress(idRoad5, 5, 1, RoadType.Unknown, Track.RightSide, Continuous,
+        0L, 0L, Some(DateTime.parse("1901-01-01")), Some(DateTime.parse("1902-01-01")), Option("tester"), idRoad5, 0.0, 0.0, SideCode.TowardsDigitizing, 0, (None, None), floating = false,
+        Seq(Point(42, 11), Point(103, 15)), LinkGeomSource.NormalLinkInterface, 8, NoTermination, 0))
+      val list = List(projectLink0, projectLink1, projectLink2, projectLink3, projectLink4, projectLink5)
+      val ordered = ProjectSectionCalculator.assignMValues(list)
+      // check left and right track - should have 4 calibration points: start, end, discontinuity and next one after discontinuity
+      (ordered.filter(_.track == Track.LeftSide).flatMap(_.calibrationPoints._1) ++ ordered.filter(_.track == Track.LeftSide).flatMap(_.calibrationPoints._2)) should have size 4
+      (ordered.filter(_.track == Track.RightSide).flatMap(_.calibrationPoints._1) ++ ordered.filter(_.track == Track.RightSide).flatMap(_.calibrationPoints._2)) should have size 4
+    }
+  }
+
+  test("validate if there is a calibration point when has MinorDiscontinuity at end of address and start of next one with track Combined") {
+    runWithRollback{
+      // Combined track = 85.308 meters with MinorDiscontinuity
+      val idRoad0 = 0L //   C>
+      val idRoad1 = 1L //   C>
+      val idRoad2 = 2L //   C>
+      val idRoad3 = 3L //   C>
+      val projectLink0 = toProjectLink(rap, LinkStatus.New)(RoadAddress(idRoad0, 5, 1, RoadType.PublicRoad, Track.Combined, Continuous,
+        0L, 0L, Some(DateTime.parse("1901-01-01")), Some(DateTime.parse("1902-01-01")), Option("tester"), idRoad0, 0.0, 0.0, SideCode.TowardsDigitizing, 0, (None, None), floating = false,
+        Seq(Point(20.0, 10.0), Point(28, 15)), LinkGeomSource.NormalLinkInterface, 8, NoTermination, 0))
+      val projectLink1 = toProjectLink(rap, LinkStatus.New)(RoadAddress(idRoad1, 5, 1, RoadType.PublicRoad, Track.Combined, MinorDiscontinuity,
+        0L, 0L, Some(DateTime.parse("1901-01-01")), Some(DateTime.parse("1902-01-01")), Option("tester"), idRoad1, 0.0, 0.0, SideCode.TowardsDigitizing, 0, (None, None), floating = false,
+        Seq(Point(28, 15), Point(41, 18)), LinkGeomSource.NormalLinkInterface, 8, NoTermination, 0))
+      val projectLink2 = toProjectLink(rap, LinkStatus.New)(RoadAddress(idRoad2, 5, 1, RoadType.PublicRoad, Track.Combined, Continuous,
+        0L, 0L, Some(DateTime.parse("1901-01-01")), Some(DateTime.parse("1902-01-01")), Option("tester"), idRoad2, 0.0, 0.0, SideCode.TowardsDigitizing, 0, (None, None), floating = false,
+        Seq(Point(42, 19), Point(75, 29.2)), LinkGeomSource.NormalLinkInterface, 8, NoTermination, 0))
+      val projectLink3 = toProjectLink(rap, LinkStatus.New)(RoadAddress(idRoad3, 5, 1, RoadType.PublicRoad, Track.Combined, Continuous,
+        0L, 0L, Some(DateTime.parse("1901-01-01")), Some(DateTime.parse("1902-01-01")), Option("tester"), idRoad3, 0.0, 0.0, SideCode.TowardsDigitizing, 0, (None, None), floating = false,
+        Seq(Point(103.0, 15.0),Point(75, 29.2)), LinkGeomSource.NormalLinkInterface, 8, NoTermination, 0))
+      val list = List(projectLink0, projectLink1, projectLink2, projectLink3)
+      val ordered = ProjectSectionCalculator.assignMValues(list)
+      // check combined track - should have 4 calibration points: start, end, minor discontinuity and next one after discontinuity
+      (ordered.filter(_.track == Track.Combined).flatMap(_.calibrationPoints._1) ++ ordered.filter(_.track == Track.Combined).flatMap(_.calibrationPoints._2)) should have size 4
+    }
+  }
+
+  test("validate if there is a calibration point when has Discontinuous at end of address and start of next one with track Combined") {
+    runWithRollback{
+      // Combined track = 85.308 meters with Discontinuous
+      val idRoad0 = 0L //   C>
+      val idRoad1 = 1L //   C>
+      val idRoad2 = 2L //   C>
+      val idRoad3 = 3L //   C>
+      val projectLink0 = toProjectLink(rap, LinkStatus.New)(RoadAddress(idRoad0, 5, 1, RoadType.PublicRoad, Track.Combined, Continuous,
+        0L, 0L, Some(DateTime.parse("1901-01-01")), Some(DateTime.parse("1902-01-01")), Option("tester"), idRoad0, 0.0, 0.0, SideCode.TowardsDigitizing, 0, (None, None), floating = false,
+        Seq(Point(20.0, 10.0), Point(28, 15)), LinkGeomSource.NormalLinkInterface, 8, NoTermination, 0))
+      val projectLink1 = toProjectLink(rap, LinkStatus.New)(RoadAddress(idRoad1, 5, 1, RoadType.PublicRoad, Track.Combined, Discontinuous,
+        0L, 0L, Some(DateTime.parse("1901-01-01")), Some(DateTime.parse("1902-01-01")), Option("tester"), idRoad1, 0.0, 0.0, SideCode.TowardsDigitizing, 0, (None, None), floating = false,
+        Seq(Point(28, 15), Point(41, 18)), LinkGeomSource.NormalLinkInterface, 8, NoTermination, 0))
+      val projectLink2 = toProjectLink(rap, LinkStatus.New)(RoadAddress(idRoad2, 5, 1, RoadType.PublicRoad, Track.Combined, Continuous,
+        0L, 0L, Some(DateTime.parse("1901-01-01")), Some(DateTime.parse("1902-01-01")), Option("tester"), idRoad2, 0.0, 0.0, SideCode.TowardsDigitizing, 0, (None, None), floating = false,
+        Seq(Point(42, 19), Point(75, 29.2)), LinkGeomSource.NormalLinkInterface, 8, NoTermination, 0))
+      val projectLink3 = toProjectLink(rap, LinkStatus.New)(RoadAddress(idRoad3, 5, 1, RoadType.PublicRoad, Track.Combined, Continuous,
+        0L, 0L, Some(DateTime.parse("1901-01-01")), Some(DateTime.parse("1902-01-01")), Option("tester"), idRoad3, 0.0, 0.0, SideCode.TowardsDigitizing, 0, (None, None), floating = false,
+        Seq(Point(103.0, 15.0),Point(75, 29.2)), LinkGeomSource.NormalLinkInterface, 8, NoTermination, 0))
+      val list = List(projectLink0, projectLink1, projectLink2, projectLink3)
+      val ordered = ProjectSectionCalculator.assignMValues(list)
+      // check combined track - should have 4 calibration points: start, end, discontinuity and next one after discontinuity
+      (ordered.filter(_.track == Track.Combined).flatMap(_.calibrationPoints._1) ++ ordered.filter(_.track == Track.Combined).flatMap(_.calibrationPoints._2)) should have size 4
+    }
   }
 
   test("When projects links ends on a right and left track section calculator for new + transfer should have the same end address") {

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/ProjectSectionCalculatorSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/ProjectSectionCalculatorSpec.scala
@@ -52,16 +52,16 @@ class ProjectSectionCalculatorSpec extends FunSuite with Matchers {
       val idRoad1 = 1L
       val idRoad2 = 2L
       val idRoad3 = 3L
-      val projectLink0 = toProjectLink(rap, LinkStatus.New)(RoadAddress(idRoad0, 5, 1, RoadType.Unknown, Track.Combined, Discontinuous,
+      val projectLink0 = toProjectLink(rap, LinkStatus.New)(RoadAddress(idRoad0, 5, 1, RoadType.Unknown, Track.Combined, Continuous,
         0L, 0L, Some(DateTime.parse("1901-01-01")), Some(DateTime.parse("1902-01-01")), Option("tester"), 12345L, 0.0, 9.8, SideCode.TowardsDigitizing,
         0, (None, None), floating = false, Seq(Point(0.0, 0.0), Point(0.0, 9.8)), LinkGeomSource.NormalLinkInterface, 8, NoTermination, 0))
-      val projectLink1 = toProjectLink(rap, LinkStatus.New)(RoadAddress(idRoad1, 5, 1, RoadType.Unknown, Track.Combined, Discontinuous,
+      val projectLink1 = toProjectLink(rap, LinkStatus.New)(RoadAddress(idRoad1, 5, 1, RoadType.Unknown, Track.Combined, Continuous,
         0L, 0L, Some(DateTime.parse("1901-01-01")), Some(DateTime.parse("1902-01-01")), Option("tester"), 12346L, 0.0, 9.8, SideCode.TowardsDigitizing,
         0, (None, None), floating = false, Seq(Point(0.0, 30.0), Point(0.0, 39.8)), LinkGeomSource.NormalLinkInterface, 8, NoTermination, 0))
-      val projectLink2 = toProjectLink(rap, LinkStatus.New)(RoadAddress(idRoad2, 5, 1, RoadType.Unknown, Track.Combined, Discontinuous,
+      val projectLink2 = toProjectLink(rap, LinkStatus.New)(RoadAddress(idRoad2, 5, 1, RoadType.Unknown, Track.Combined, Continuous,
         0L, 0L, Some(DateTime.parse("1901-01-01")), Some(DateTime.parse("1902-01-01")), Option("tester"), 12347L, 0.0, 9.8, SideCode.TowardsDigitizing,
         0, (None, None), floating = false, Seq(Point(0.0, 20.2), Point(0.0, 30.0)), LinkGeomSource.NormalLinkInterface, 8, NoTermination, 0))
-      val projectLink3 = toProjectLink(rap, LinkStatus.New)(RoadAddress(idRoad3, 5, 1, RoadType.Unknown, Track.Combined, Discontinuous,
+      val projectLink3 = toProjectLink(rap, LinkStatus.New)(RoadAddress(idRoad3, 5, 1, RoadType.Unknown, Track.Combined, Continuous,
         0L, 0L, Some(DateTime.parse("1901-01-01")), Some(DateTime.parse("1902-01-01")), Option("tester"), 12348L, 0.0, 10.4, SideCode.TowardsDigitizing,
         0, (None, None), floating = false, Seq(Point(0.0, 9.8), Point(0.0, 20.2)), LinkGeomSource.NormalLinkInterface, 8, NoTermination, 0))
 

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/util/ProjectLinkSplitterSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/util/ProjectLinkSplitterSpec.scala
@@ -261,7 +261,7 @@ class ProjectLinkSplitterSpec extends FunSuite with Matchers with BeforeAndAfter
     splitB.endAddrMValue should be (splitA.startAddrMValue)
     splitA.geometry.head should be (template.geometry.last)
     Seq(splitA, splitB).foreach { l =>
-      l.startAddrMValue == terminatedLink.endAddrMValue || l.status == LinkStatus.UnChanged should be (true)
+      l.startAddrMValue == terminatedLink.startAddrMValue || l.status == LinkStatus.UnChanged should be (true)
       l.linkGeomSource should be (LinkGeomSource.SuravageLinkInterface)
       l.status == LinkStatus.New || l.status == LinkStatus.UnChanged || l.status == LinkStatus.Transfer should be (true)
       l.roadNumber should be (template.roadNumber)
@@ -330,8 +330,8 @@ class ProjectLinkSplitterSpec extends FunSuite with Matchers with BeforeAndAfter
     val (splitA, splitB) = if(splitResult.splitA.status == New) (splitResult.splitB, splitResult.splitA) else (splitResult.splitA, splitResult.splitB)
     val terminatedLink = splitResult.terminatedProjectLink
     terminatedLink.status should be (LinkStatus.Terminated)
-    terminatedLink.startAddrMValue should be (template.startAddrMValue)
-    terminatedLink.endAddrMValue should be (splitA.startAddrMValue)
+    terminatedLink.startAddrMValue should be (splitA.startAddrMValue)
+    terminatedLink.endAddrMValue should be (template.endAddrMValue)
     splitA.endAddrMValue should be (template.endAddrMValue)
     GeometryUtils.areAdjacent(terminatedLink.geometry, splitB.geometry) should be (true)
     GeometryUtils.areAdjacent(terminatedLink.geometry, splitA.geometry) should be (true)


### PR DESCRIPTION
Fix to ProjectLinkSplitter to terminated cases on splitting
Fix to start address of transfer on split delta calculation
Changes in strategy logics to accept Track.Combined values and multiple types of discontinuities