### PR TITLE
VIITE-1525_wrong_aet_values_after_siirto_and_uusi_actions

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/LinkStatusChangeTrackCalculatorStrategy.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/LinkStatusChangeTrackCalculatorStrategy.scala
@@ -9,6 +9,8 @@ class LinkStatusChangeTrackCalculatorStrategy extends TrackCalculatorStrategy {
 
   val AdjustmentToleranceMeters = 3L
 
+  override def getStrategyAddress(projectLink: ProjectLink): Long = projectLink.startAddrMValue
+
   override def applicableStrategy(headProjectLink: ProjectLink, projectLink: ProjectLink): Boolean = {
     //Will be applied if the link status changes FROM or TO a status equal "NEW" or "TERMINATED" and track is Left or Right
     projectLink.status != headProjectLink.status &&

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/TrackCalculatorStrategy.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/TrackCalculatorStrategy.scala
@@ -39,11 +39,8 @@ object TrackCalculatorContext {
     val head = projectLinks.head
     projectLinks.flatMap {
       pl =>
-        strategies.find(strategy => strategy.applicableStrategy(head, pl)) match {
-          case Some(strategy) => Some(pl.endAddrMValue, strategy)
-          case _ => None
-        }
-    }.headOption
+        strategies.filter(strategy => strategy.applicableStrategy(head, pl)).map(strategy => (strategy.getStrategyAddress(pl), strategy))
+    }.sortBy(_._1).headOption
   }
 
   def getStrategy(leftProjectLinks: Seq[ProjectLink], rightProjectLinks: Seq[ProjectLink]): TrackCalculatorStrategy = {
@@ -220,6 +217,8 @@ trait TrackCalculatorStrategy {
       setOnSideCalibrationPoints(calculatorResult.rightProjectLinks, roadAddressCalibrationPoints, userDefinedCalibrationPoint)
     )
   }
+
+  def getStrategyAddress(projectLink: ProjectLink): Long = projectLink.endAddrMValue
 
   def applicableStrategy(headProjectLink: ProjectLink, projectLink: ProjectLink): Boolean = false
 


### PR DESCRIPTION
Strategy is now responsible of defining what addrMValue should use, start or end.