### PR TITLE
VIITE-1171 - Adding history to unchanged addresses 

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -1800,10 +1800,9 @@ class ProjectService(roadAddressService: RoadAddressService, roadLinkService: Ro
       pl.linkGeometryTimeStamp, pl.toCalibrationPoints(), floating = NoFloating, geom, pl.linkGeomSource, pl.ely, terminated = NoTermination, source.map(_.commonHistoryId).getOrElse(0))
     pl.status match {
       case UnChanged =>
-        if(source.get.roadType == roadAddress.roadType && source.get.discontinuity == roadAddress.discontinuity && source.get.ely == roadAddress.ely){
+        if (source.get.roadType == roadAddress.roadType && source.get.discontinuity == roadAddress.discontinuity && source.get.ely == roadAddress.ely) {
           roadAddress.copy(startDate = source.get.startDate, endDate = source.get.endDate, floating = floatingReason)
-        }
-        else{
+        } else {
           roadAddress.copy(startDate = Some(project.startDate), floating = floatingReason)
         }
       case Transfer | Numbering =>
@@ -1833,10 +1832,9 @@ class ProjectService(roadAddressService: RoadAddressService, roadLinkService: Ro
         None
       // unchanged will get end_date if the road_type, discontinuity or ely code changes, otherwise we keep the same end_date
       case UnChanged =>
-        if(roadAddress.roadType == pl.roadType && roadAddress.ely == pl.ely && roadAddress.discontinuity == pl.discontinuity){
+        if (roadAddress.roadType == pl.roadType && roadAddress.ely == pl.ely && roadAddress.discontinuity == pl.discontinuity) {
           None
-        }
-        else {
+        } else {
           Some(roadAddress.copy(endDate = Some(project.startDate)))
         }
       case Transfer | Numbering =>

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
@@ -2030,6 +2030,46 @@ class ProjectServiceSpec extends FunSuite with Matchers with BeforeAndAfter {
     }
   }
 
+  test("Check creation of new RoadAddress History entries and start date is correct on history and current") {
+    var count = 0
+    val roadLink = RoadLink(5170939L, Seq(Point(535605.272, 6982204.22, 85.90899999999965))
+      , 540.3960283713503, State, 99, TrafficDirection.AgainstDigitizing, UnknownLinkType, Some("25.06.2015 03:00:00"), Some("vvh_modified"), Map("MUNICIPALITYCODE" -> BigInt.apply(749)),
+      InUse, NormalLinkInterface)
+    runWithRollback {
+      val countCurrentProjects = projectService.getRoadAddressAllProjects
+      val id = 0
+      val addresses = List(ReservedRoadPart(5: Long, 5: Long, 207: Long, Some(5L), Some(Discontinuity.apply("jatkuva")), Some(8L), newLength = None, newDiscontinuity = None, newEly = None))
+      val roadAddressProject = RoadAddressProject(id, ProjectState.apply(1), "TestProject", "TestUser", DateTime.now(), "TestUser", DateTime.parse("2019-01-01"), DateTime.now(), "Some additional info", Seq(), None)
+      val savedProject = projectService.createRoadLinkProject(roadAddressProject)
+      mockForProject(savedProject.id, RoadAddressDAO.fetchByRoadPart(5, 207).map(toProjectLink(savedProject)))
+      projectService.saveProject(savedProject.copy(reservedParts = addresses))
+      val countAfterInsertProjects = projectService.getRoadAddressAllProjects
+      count = countCurrentProjects.size + 1
+      countAfterInsertProjects.size should be(count)
+      projectService.allLinksHandled(savedProject.id) should be(false)
+      val projectLinks = ProjectDAO.getProjectLinks(savedProject.id)
+      val partitioned = projectLinks.partition(_.roadPartNumber == 207)
+      val linkIds207 = partitioned._1.map(_.linkId)
+      reset(mockRoadLinkService)
+      when(mockRoadLinkService.getRoadLinksHistoryFromVVH(any[Set[Long]])).thenReturn(Seq())
+      when(mockRoadLinkService.getRoadLinksByLinkIdsFromVVH(any[Set[Long]], any[Boolean])).thenAnswer(
+        toMockAnswer(projectLinks, roadLink)
+      )
+      projectService.updateProjectLinks(savedProject.id, Set(), linkIds207, LinkStatus.UnChanged, "-", 0, 0, 0, Option.empty[Int], roadType = 5)
+      projectService.allLinksHandled(savedProject.id) should be(true)
+      projectService.updateRoadAddressWithProjectLinks(ProjectState.Saved2TR, savedProject.id)
+
+      val roadsAfterChanges = RoadAddressDAO.fetchByLinkId(projectLinks.map(_.linkId).toSet, false, true)
+      roadsAfterChanges.size should be(52)
+      val (currentRoads, historyRoads) = roadsAfterChanges.partition(x => x.startDate.nonEmpty && x.endDate.isEmpty)
+      val endedAddress = roadsAfterChanges.filter(x => x.endDate.nonEmpty)
+      endedAddress.size should be(26)
+      currentRoads.forall(link => link.startDate.get == DateTime.parse("2019-01-01")) should be (true)
+      historyRoads.forall(link => link.endDate.get == DateTime.parse("2019-01-01")) should be (true)
+
+    }
+  }
+
   test("Check creation of new RoadAddress History entries with endDate = projectDate") {
     var count = 0
     val roadLink = RoadLink(5170939L, Seq(Point(535605.272, 6982204.22, 85.90899999999965))


### PR DESCRIPTION
Saving history links when we have changes in addresses and using the unchanged operation in project