### PR TITLE
VIITE-1561 added checks to fix the validations

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectValidator.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectValidator.scala
@@ -436,7 +436,7 @@ object ProjectValidator {
   def checkProjectElyCodes(project: RoadAddressProject, projectLinks: Seq[ProjectLink]): Seq[ValidationErrorDetails] = {
 
     /**
-      * Check the project links edges for adjacent road addresses that must have a different ely then a adjacent one
+      * Check the project links edges for adjacent road addresses that must have a different ely than a adjacent one
       *
       * @param project             - the current project
       * @param groupedProjectLinks - project links, grouped by road number and road part number
@@ -462,13 +462,7 @@ object ProjectValidator {
       groupedProjectLinks.flatMap(group => {
         val projectLinks = group._2.filter(_.discontinuity == Discontinuity.ChangingELYCode)
         val problemRoads = if (projectLinks.nonEmpty) {
-          val (startRoad, endRoad) = if (projectLinks.size == 1) {
-            (projectLinks.head, projectLinks.head)
-          } else {
-            (projectLinks.head, projectLinks.last)
-          }
-
-          val roadsValidation = evaluateBorderCheck(startRoad, endRoad, secondCheck = false)
+          val roadsValidation = evaluateBorderCheck(projectLinks.head, projectLinks.last, secondCheck = false)
           roadsValidation.filterNot(_.isEmpty).getOrElse(Seq())
         } else {
           Seq.empty[BaseRoadAddress]
@@ -495,8 +489,8 @@ object ProjectValidator {
         * @return An optional value with eventual Validation error details
         */
       def error(validationError: ValidationError)(pl: Seq[BaseRoadAddress]): Option[ValidationErrorDetails] = {
-        val grouppedByDiscontinuity = pl.groupBy(_.discontinuity)
-        val (gLinkIds, gPoints, gDiscontinuity) = grouppedByDiscontinuity.flatMap(g => {
+        val groupedByDiscontinuity = pl.groupBy(_.discontinuity)
+        val (gLinkIds, gPoints, gDiscontinuity) = groupedByDiscontinuity.flatMap(g => {
           val links = g._2
           val zoomPoint = GeometryUtils.midPointGeometry(links.minBy(_.endAddrMValue).geometry)
           links.map(l => (l.id, zoomPoint, l.discontinuity))
@@ -516,11 +510,7 @@ object ProjectValidator {
       val validationProblems = groupedProjectLinks.flatMap(group => {
         val projectLinks = group._2
         val problemRoads = if (projectLinks.nonEmpty) {
-          val (startRoad, endRoad) = if (projectLinks.size == 1) {
-            (projectLinks.head, projectLinks.head)
-          } else {
-            (projectLinks.head, projectLinks.last)
-          }
+          val (startRoad, endRoad) = (projectLinks.head, projectLinks.last)
           val validationResult = if (startRoad.discontinuity.value != Discontinuity.ChangingELYCode.value) evaluateBorderCheck(startRoad, endRoad, secondCheck = true) else Option.empty[Seq[ProjectLink]]
           validationResult.filterNot(_.isEmpty).getOrElse(Seq())
 
@@ -574,10 +564,8 @@ object ProjectValidator {
       if (roadAddresses.nonEmpty) {
         val filtered = roadAddresses.filterNot(ra => ra.roadNumber == startRoad.roadNumber && ra.roadPartNumber == startRoad.roadPartNumber &&
           !GeometryUtils.areAdjacent(ra.geometry, startRoad.geometry) && !GeometryUtils.areAdjacent(ra.geometry, endRoad.geometry))
-        val diffEly = filtered.find(_.ely != startRoad.ely)
-        if (!secondCheck && diffEly.isEmpty) {
-          Option(Seq(endRoad))
-        } else if (secondCheck && diffEly.isDefined) {
+        val diffEly = filtered.find(ra => ra.ely != startRoad.ely && (ra.roadNumber == startRoad.roadNumber || !secondCheck))
+        if ((!secondCheck && diffEly.isEmpty) || (secondCheck && diffEly.nonEmpty)) {
           Option(Seq(endRoad))
         } else Option.empty[Seq[ProjectLink]]
       } else Option.empty[Seq[ProjectLink]]


### PR DESCRIPTION
Previous Tomi PR: 
Fixed road address find so that right road(s) are found. Now discontinuity End of Road is right for ELY border when the same road (same road number) doesn't continue in the next ELY. I'm not sure if the gruntfile.js was supposed to include in the pull request or not but it's there anyway.