### PR TITLE
Changes in Integration API to use created_time instead of valid_from

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadNameDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadNameDAO.scala
@@ -140,7 +140,7 @@ object RoadNameDAO {
         SELECT * FROM road_names
         WHERE road_number IN (
             SELECT DISTINCT road_number FROM road_names
-            WHERE valid_to IS NULL AND valid_from >= TO_DATE('${sinceString}', 'RRRR-MM-dd')
+            WHERE valid_to IS NULL AND CREATED_TIME >= TO_DATE('${sinceString}', 'RRRR-MM-dd')
           ) AND valid_to IS NULL
         ORDER BY road_number, start_date desc"""
       queryList(query)


### PR DESCRIPTION
This commit is a request from TR side, because they need to fetch the names changes since created_date instead of valid_from