### PR TITLE
VIITE-1573_move_current_blackunderline_logic_to_frontend

### DIFF
--- a/viite-UI/src/utils/LinkValues.js
+++ b/viite-UI/src/utils/LinkValues.js
@@ -120,6 +120,16 @@
         IndicatorLayer:             {value: 99}
     };
 
+    root.RoadType = {
+        PublicRoad:                     {value:1, description:"Yleinen tie"},
+        FerryRoad:                      {value:2, description:"Lauttaväylä yleisellä tiellä"},
+        MunicipalityStreetRoad:         {value:3, description:"Kunnan katuosuus"},
+        PublicUnderConstructionRoad:    {value:4, description:"Yleisen tien työmaa"},
+        PrivateRoadType:                {value:5, description:"Yksityistie"},
+        UnknownOwnerRoad:               {value:9, description:"Omistaja selvittämättä"},
+        Unknown:                        {value:99, description:"OEi määritelty"}
+    };
+
     /*
     The meta key codes are browser dependant, in proper:
         Firefox: 224
@@ -135,6 +145,8 @@
     root.UnknownRoadId = 0;
 
     root.NewRoadId = -1000;
+
+    root.BlackUnderlineRoadTyes = [root.RoadType.MunicipalityStreetRoad.value, root.RoadType.PrivateRoadType.value];
 
 })(window.LinkValues = window.LinkValues || {});
 

--- a/viite-UI/src/utils/LinkValues.js
+++ b/viite-UI/src/utils/LinkValues.js
@@ -127,7 +127,7 @@
         PublicUnderConstructionRoad:    {value:4, description:"Yleisen tien työmaa"},
         PrivateRoadType:                {value:5, description:"Yksityistie"},
         UnknownOwnerRoad:               {value:9, description:"Omistaja selvittämättä"},
-        Unknown:                        {value:99, description:"OEi määritelty"}
+        Unknown:                        {value:99, description:"Ei määritelty"}
     };
 
     /*

--- a/viite-UI/src/utils/LinkValues.js
+++ b/viite-UI/src/utils/LinkValues.js
@@ -146,7 +146,7 @@
 
     root.NewRoadId = -1000;
 
-    root.BlackUnderlineRoadTyes = [root.RoadType.MunicipalityStreetRoad.value, root.RoadType.PrivateRoadType.value];
+    root.BlackUnderlineRoadTypes = [root.RoadType.MunicipalityStreetRoad.value, root.RoadType.PrivateRoadType.value];
 
 })(window.LinkValues = window.LinkValues || {});
 

--- a/viite-UI/src/view/Styler.js
+++ b/viite-UI/src/view/Styler.js
@@ -97,7 +97,7 @@
     };
 
       var generateUnderLineColor = function (linkData, opacityMultiplier, middleLineWidth) {
-        if (_.contains(LinkValues.BlackUnderlineRoadTyes,linkData.roadTypeId))
+        if (_.contains(LinkValues.BlackUnderlineRoadTypes,linkData.roadTypeId))
           return {color: 'rgba(30, 30, 30,' + opacityMultiplier + ')', width: middleLineWidth + 7};
         else
           return {color: undefined, width: undefined};
@@ -326,7 +326,7 @@
       lineStyle.setZIndex(zIndex + 2);
       roadTypeStyle.setZIndex(zIndex - 2);
       var style = [borderStyle, middleLineStyle, lineStyle];
-      if (_.contains(LinkValues.BlackUnderlineRoadTyes,linkData.roadTypeId))
+      if (_.contains(LinkValues.BlackUnderlineRoadTypes,linkData.roadTypeId))
         style.push(roadTypeStyle);
       return style;
     };

--- a/viite-UI/src/view/Styler.js
+++ b/viite-UI/src/view/Styler.js
@@ -97,7 +97,7 @@
     };
 
       var generateUnderLineColor = function (linkData, opacityMultiplier, middleLineWidth) {
-        if (linkData.blackUnderline)
+        if (_.contains(LinkValues.BlackUnderlineRoadTyes,linkData.roadTypeId))
           return {color: 'rgba(30, 30, 30,' + opacityMultiplier + ')', width: middleLineWidth + 7};
         else
           return {color: undefined, width: undefined};
@@ -326,7 +326,7 @@
       lineStyle.setZIndex(zIndex + 2);
       roadTypeStyle.setZIndex(zIndex - 2);
       var style = [borderStyle, middleLineStyle, lineStyle];
-      if (linkData.blackUnderline)
+      if (_.contains(LinkValues.BlackUnderlineRoadTyes,linkData.roadTypeId))
         style.push(roadTypeStyle);
       return style;
     };


### PR DESCRIPTION
Removed mentions of blackUnderline and replaced for a roadTypeId test.