### PR TITLE
Viite 1566 disable selection from legend and mapdiv

### DIFF
--- a/viite-UI/components/ol.css
+++ b/viite-UI/components/ol.css
@@ -37,7 +37,6 @@
 .ol-viewport .ol-unselectable {
   -webkit-touch-callout: none;
   -webkit-user-select: none;
-  -khtml-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;

--- a/viite-UI/src/less/core/forms.less
+++ b/viite-UI/src/less/core/forms.less
@@ -20,9 +20,6 @@ input[type="search"] {
   .box-sizing(border-box);
 }
 
-
-
-
 // Position radios and checkboxes better
 input[type="radio"],
 input[type="checkbox"] {

--- a/viite-UI/src/less/core/forms.less
+++ b/viite-UI/src/less/core/forms.less
@@ -20,6 +20,9 @@ input[type="search"] {
   .box-sizing(border-box);
 }
 
+
+
+
 // Position radios and checkboxes better
 input[type="radio"],
 input[type="checkbox"] {
@@ -130,6 +133,14 @@ input[type="checkbox"]:focus {
 // Checkboxes and radios
 //
 // Indent the labels to position radios/checkboxes as hanging controls.
+
+.no-copy {
+  -webkit-user-select: none;  /* Chrome all / Safari all */
+  -moz-user-select: none;     /* Firefox all */
+  -ms-user-select: none;      /* IE 10+ */
+  user-select: none;          /* Likely future */
+}
+
 
 .radio,
 .checkbox {

--- a/viite-UI/src/view/navigationpanel/RoadLinkBox.js
+++ b/viite-UI/src/view/navigationpanel/RoadLinkBox.js
@@ -7,7 +7,7 @@
     var expandedTemplate = _.template('' +
       '<div class="panel <%= className %>">' +
         '<header class="panel-header expanded"><%- title %></header>' +
-        '<div class="legend-container"></div>' +
+        '<div class="legend-container no-copy"></div>' +
       '</div>');
 
     var administrativeClassLegend = $('' +
@@ -30,7 +30,7 @@
         '</div>' +
       '</div>');
 
-    var roadClassLegend = $('<div id="legendDiv" class="panel-section panel-legend linear-asset-legend road-class-legend"></div>');
+    var roadClassLegend = $('<div id="legendDiv" class="panel-section panel-legend linear-asset-legend road-class-legend no-copy"></div>');
 
     var floatingLegend = $('' +
       '<div class="legend-entry">' +

--- a/viite-UI/tmpl/index.html
+++ b/viite-UI/tmpl/index.html
@@ -24,7 +24,7 @@
 </header>
 <div class="container">
     <div id="contentMap">
-        <div id="mapdiv">
+        <div id="mapdiv" class="no-copy">
             <div id="popup" class="ol-viite-roadaddress-popup">
                 <div id="popup-content"></div>
             </div>


### PR DESCRIPTION
Disables selection from legend and mapdiv. issue was that occasionally user would select elements and when he tries to move on the map browser gets confused about what user wants to do (move map or drag elements).