### PR TITLE
VIITE-1597 - Peruuta should not let floating be highlighted

### DIFF
--- a/viite-UI/src/view/LinkPropertyLayer.js
+++ b/viite-UI/src/view/LinkPropertyLayer.js
@@ -927,6 +927,7 @@
       simulatedRoadsLayer.getSource().clear();
       me.eventListener.listenToOnce(eventbus, 'roadLinks:fetched', function(){
         applicationModel.removeSpinner();
+        geometryChangedLayer.setVisible(true);
       });
     };
 


### PR DESCRIPTION
Made it so geometryChangedLayer visibility status after a 'roadLinks:fetched' event called after the refreshViewAfterClosingFloating method is set to visible.