### PR TITLE
VIITE-1626 - Unnecessary clicking before selecting the link/ Turhia klikkauksia linkkiä valittaessa

### DIFF
--- a/viite-UI/src/model/ProjectCollection.js
+++ b/viite-UI/src/model/ProjectCollection.js
@@ -257,7 +257,6 @@
               publishableProject = successObject.publishable;
               projectErrors = successObject.projectErrors;
               eventbus.trigger('projectLink:projectLinksCreateSuccess');
-              eventbus.trigger('roadAddress:projectLinksCreateSuccess');
               eventbus.trigger('roadAddress:projectLinksUpdated', successObject);
             }
           });

--- a/viite-UI/src/view/ProjectLinkLayer.js
+++ b/viite-UI/src/view/ProjectLinkLayer.js
@@ -173,7 +173,7 @@
           selectedProjectLinkProperty.openShift(selectedLinkIds);
         }
         highlightFeatures();
-      } else if (!_.isUndefined(selection) && !selectedProjectLinkProperty.isDirty()) {
+      } else if (!_.isUndefined(selection) && selectedProjectLinkProperty.isDirty()) {
         selectedProjectLinkProperty.clean();
         projectCollection.setTmpDirty([]);
         projectCollection.setDirty([]);


### PR DESCRIPTION
Removed a duplicated trigger event.
Inverted a condition in order to enter in the open part of the single click select.