### PR TITLE
Viite 1601 v2 problems with new two track road

### DIFF
--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/GeometryUtils.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/GeometryUtils.scala
@@ -427,4 +427,19 @@ object GeometryUtils {
     val sourcePoint = geom.minBy(p => p.distance2DTo(referencePoint))
     geom.map(p => p.minus(sourcePoint))
   }
+
+  /**
+    * Measure summed distance between two geometries: head-to-head + tail-to-head vs. head-to-tail + tail-to-head
+    * The measurement is taken after the geometries are reduced to the origin point.
+    * @param geom1 Geometry 1
+    * @param geom2 Goemetry 2
+    * @return h2h distance, h2t distance sums
+    */
+
+  def distancesBetweenEndPointsInOrigin(geom1: Seq[Point], geom2: Seq[Point]): (Double, Double) = {
+    val movedGeom1 = GeometryUtils.moveGeomToOrigin(geom1)
+    val movedGeom2 = GeometryUtils.moveGeomToOrigin(geom2)
+    (movedGeom1.head.distance2DTo(movedGeom2.head) + movedGeom1.last.distance2DTo(movedGeom2.last),
+      movedGeom1.last.distance2DTo(movedGeom2.head) + movedGeom1.head.distance2DTo(movedGeom2.last))
+  }
 }

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectDAO.scala
@@ -4,7 +4,7 @@ import java.sql.Timestamp
 import java.util.Date
 
 import com.github.tototoshi.slick.MySQLJodaSupport._
-import fi.liikennevirasto.digiroad2.Point
+import fi.liikennevirasto.digiroad2.{Point, Vector3d}
 import fi.liikennevirasto.digiroad2.asset.{LinkGeomSource, SideCode}
 import fi.liikennevirasto.digiroad2.dao.Sequences
 import fi.liikennevirasto.digiroad2.linearasset.PolyLine
@@ -119,6 +119,14 @@ case class ProjectLink(id: Long, roadNumber: Long, roadPartNumber: Long, track: 
   lazy val startingPoint = if (sideCode == SideCode.AgainstDigitizing) geometry.last else geometry.head
   lazy val endPoint = if (sideCode == SideCode.AgainstDigitizing) geometry.head else geometry.last
   lazy val isSplit: Boolean = connectedLinkId.nonEmpty || connectedLinkId.contains(0L)
+
+  def getEndPoints(direction: Vector3d) = {
+    if(sideCode == SideCode.Unknown) {
+      Seq((geometry.head, geometry.last), (geometry.last, geometry.head)).minBy(ps => direction.dot(ps._1.toVector - ps._2.toVector))
+    } else {
+      (startingPoint, endPoint)
+    }
+  }
 
   def copyWithGeometry(newGeometry: Seq[Point]) = {
     this.copy(geometry = newGeometry)

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/RoadAddressMapper.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/RoadAddressMapper.scala
@@ -185,7 +185,7 @@ trait RoadAddressMapper {
     * @param geom2 Geometry two
     */
   def isDirectionMatch(geom1: Seq[Point], geom2: Seq[Point]): Boolean = {
-    val x = distancesBetweenEndPointsInOrigin(geom1, geom2)
+    val x = GeometryUtils.distancesBetweenEndPointsInOrigin(geom1, geom2)
     x._1 < x._2
   }
 
@@ -204,21 +204,6 @@ trait RoadAddressMapper {
   def distancesBetweenEndPoints(geom1: Seq[Point], geom2: Seq[Point]) = {
     (geom1.head.distance2DTo(geom2.head) + geom1.last.distance2DTo(geom2.last),
       geom1.last.distance2DTo(geom2.head) + geom1.head.distance2DTo(geom2.last))
-  }
-
-  /**
-    * Measure summed distance between two geometries: head-to-head + tail-to-head vs. head-to-tail + tail-to-head
-    * The measurement is taken after the geometries are reduced to the origin point.
-    * @param geom1 Geometry 1
-    * @param geom2 Goemetry 2
-    * @return h2h distance, h2t distance sums
-    */
-
-  def distancesBetweenEndPointsInOrigin(geom1: Seq[Point], geom2: Seq[Point]): (Double, Double) = {
-    val movedGeom1 = GeometryUtils.moveGeomToOrigin(geom1)
-    val movedGeom2 = GeometryUtils.moveGeomToOrigin(geom2)
-    (movedGeom1.head.distance2DTo(movedGeom2.head) + movedGeom1.last.distance2DTo(movedGeom2.last),
-      movedGeom1.last.distance2DTo(movedGeom2.head) + movedGeom1.head.distance2DTo(movedGeom2.last))
   }
 
   def minDistanceBetweenEndPoints(geom1: Seq[Point], geom2: Seq[Point]) = {

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/DefaultSectionCalculatorStrategy.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/DefaultSectionCalculatorStrategy.scala
@@ -102,7 +102,14 @@ class DefaultSectionCalculatorStrategy extends RoadAddressSectionCalculatorStrat
     else {
       // Get left track non-connected points and find the closest to right track starting point
       val leftLinks = newLinks.filter(_.track != Track.RightSide) ++ oldLinks.filter(_.track != Track.RightSide)
-      val leftPoints = TrackSectionOrder.findOnceConnectedLinks(leftLinks).keys
+      val leftPoints = if (leftLinks.size == 1){
+        leftLinks.flatMap(l => {
+          val (p1, p2) = GeometryUtils.geometryEndpoints(l.geometry)
+          Seq(p1 -> l, p2 -> l)
+        }).groupBy(_._1).mapValues(_.map(_._2).toSeq.distinct).keys
+      } else {
+        TrackSectionOrder.findOnceConnectedLinks(leftLinks).keys
+      }
 
 
       val (d1, d2) = GeometryUtils.distancesBetweenEndPointsInOrigin(rightPoints.toSeq, leftPoints.toSeq)

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/DefaultSectionCalculatorStrategy.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/DefaultSectionCalculatorStrategy.scala
@@ -22,8 +22,9 @@ class DefaultSectionCalculatorStrategy extends RoadAddressSectionCalculatorStrat
       k -> (groupedProjectLinks.getOrElse(k, Seq()), groupedOldLinks.getOrElse(k, Seq())))
     group.flatMap { case (part, (projectLinks, oldLinks)) =>
       try {
-        val (right, left) = TrackSectionOrder.orderProjectLinksTopologyByGeometry(
-          findStartingPoints(projectLinks, oldLinks, userCalibrationPoints), projectLinks ++ oldLinks)
+        val currStartPoints = findStartingPoints(projectLinks, oldLinks, userCalibrationPoints)
+        val (right, left) = TrackSectionOrder.orderProjectLinksTopologyByGeometry(currStartPoints, projectLinks ++ oldLinks)
+
         val ordSections = TrackSectionOrder.createCombinedSections(right, left)
 
         // TODO: userCalibrationPoints to Long -> Seq[UserDefinedCalibrationPoint] in method params
@@ -94,18 +95,36 @@ class DefaultSectionCalculatorStrategy extends RoadAddressSectionCalculatorStrat
                          calibrationPoints: Seq[UserDefinedCalibrationPoint]): (Point, Point) = {
     val rightStartPoint = findStartingPoint(newLinks.filter(_.track != Track.LeftSide), oldLinks.filter(_.track != Track.LeftSide),
       calibrationPoints)
+    val rightLinks = newLinks.filter(_.track != Track.LeftSide) ++ oldLinks.filter(_.track != Track.LeftSide)
+    val rightPoints = TrackSectionOrder.findOnceConnectedLinks(rightLinks).keys
     if ((oldLinks ++ newLinks).exists(l => GeometryUtils.areAdjacent(l.geometry, rightStartPoint) && l.track == Track.Combined))
       (rightStartPoint, rightStartPoint)
     else {
       // Get left track non-connected points and find the closest to right track starting point
       val leftLinks = newLinks.filter(_.track != Track.RightSide) ++ oldLinks.filter(_.track != Track.RightSide)
       val leftPoints = TrackSectionOrder.findOnceConnectedLinks(leftLinks).keys
+
+
+      val (d1, d2) = GeometryUtils.distancesBetweenEndPointsInOrigin(rightPoints.toSeq, leftPoints.toSeq)
+      val  isRightHeadAdjacentToRightStartPoint= GeometryUtils.areAdjacent(rightPoints.head, rightStartPoint)
+     val possiblePoints = if(d1 > d2) {
+        if(isRightHeadAdjacentToRightStartPoint)
+          (rightStartPoint, leftPoints.last)
+        else
+          (rightStartPoint, leftPoints.head)
+      } else {
+        if(isRightHeadAdjacentToRightStartPoint)
+          (rightStartPoint, leftPoints.head)
+        else
+          (rightStartPoint, leftPoints.last)
+      }
+
       if (leftPoints.isEmpty)
         throw new InvalidAddressDataException("Missing left track starting points")
-      val leftStartPoint = leftPoints.minBy(lp => (lp - rightStartPoint).length())
-      (rightStartPoint, leftStartPoint)
+      possiblePoints
     }
   }
+
 
 
   /**
@@ -123,12 +142,6 @@ class DefaultSectionCalculatorStrategy extends RoadAddressSectionCalculatorStrat
       link.flatMap(pl => GeometryUtils.calculatePointFromLinearReference(pl.geometry, calibrationPoint.segmentMValue))
     }
 
-    //First it will return the subtraction between endPoint - startPoint of all the points variable
-    //Then it will sum all the results of the previous operation as a vector (v1 is the accumulated result, v2 is the next item to sum
-    def calculateDirectionVector(projectLinkSeq: Seq[ProjectLink]): Vector3d = {
-      projectLinkSeq.map(pl => (pl.startingPoint, pl.endPoint)).map(p => p._2 - p._1).fold(Vector3d(0, 0, 0)) { case (v1, v2) => v1 + v2 }.normalize2D()
-    }
-
     // Pick the one with calibration point set to zero: or any old link with lowest address: or new links by direction
     calibrationPoints.find(_.addressMValue == 0).flatMap(calibrationPointToPoint).getOrElse(
       oldLinks.filter(_.status == LinkStatus.UnChanged).sortBy(_.startAddrMValue).headOption.map(_.startingPoint).getOrElse {
@@ -136,24 +149,19 @@ class DefaultSectionCalculatorStrategy extends RoadAddressSectionCalculatorStrat
         if (remainLinks.isEmpty)
           throw new InvalidAddressDataException("Missing right track starting project links")
         //Grab all the endpoints of the links
-        val points = remainLinks.map(pl => (pl.startingPoint, pl.endPoint))
-        //TODO: ORIGINAL Direction calculation
-        val direction = points.map(p => p._2 - p._1).fold(Vector3d(0, 0, 0)) { case (v1, v2) => v1 + v2 }.normalize2D()
-        /*TODO: VIITE-1601 direction calculation
-        val direction = remainLinks.exists(_.sideCode != SideCode.Unknown) match {
-          case true =>
-            //We use the points that already have a side code defined as the basis to find the direction vector
-            calculateDirectionVector(remainLinks.filter(_.sideCode != SideCode.Unknown))
-          case _ =>
-            calculateDirectionVector(remainLinks)
+        val direction = if(remainLinks.exists(_.sideCode != SideCode.Unknown)) {
+          remainLinks.filter(_.sideCode != SideCode.Unknown).map(p => p.endPoint - p.startingPoint).fold(Vector3d(0, 0, 0)) { case (v1, v2) => v1 + v2 }.normalize2D()
+        } else {
+          Vector3d(1,1,0)
         }
-        */
+
+        val points = remainLinks.map(pl => pl.getEndPoints(direction) )
+
         // Approximate estimate of the mid point: averaged over count, not link length
-        // Calculation is done by summing the direction of the vector multiplied by 0.5 to the start point
         val midPoint = points.map(p => p._1 + (p._2 - p._1).scale(0.5)).foldLeft(Vector3d(0, 0, 0)) { case (x, p) =>
           (p - Point(0, 0)).scale(1.0 / points.size) + x
         }
-        TrackSectionOrder.findOnceConnectedLinks(remainLinks).keys.minBy(p => direction.dot(p.toVector - midPoint))
+       TrackSectionOrder.findOnceConnectedLinks(remainLinks).keys.minBy(p => direction.dot(p.toVector - midPoint))
       }
 
     )

--- a/viite-UI/src/view/ProjectLinkLayer.js
+++ b/viite-UI/src/view/ProjectLinkLayer.js
@@ -731,7 +731,8 @@
       if (map.getView().getZoom() > zoomlevels.minZoomForDirectionalMarkers) {
         var addMarkersToLayer = function(links, layer) {
           var directionMarkers = _.filter(links, function (projectLink) {
-            return projectLink.id !== 0 || (projectLink.id === 0 && projectLink.anomaly === Anomaly.NoAddressGiven.value) || (projectLink.id === 0 && projectLink.roadLinkType === RoadLinkType.FloatingRoadLinkType.value);
+            var acceptedLinks = projectLink.id !== 0 || (projectLink.id === 0 && projectLink.anomaly === Anomaly.NoAddressGiven.value) || (projectLink.id === 0 && projectLink.roadLinkType === RoadLinkType.FloatingRoadLinkType.value);
+            return acceptedLinks && projectLink.sideCode !== 99;
           });
           _.each(directionMarkers, function (directionLink) {
             marker = cachedMarker.createProjectMarker(directionLink);


### PR DESCRIPTION
So basically this is an experiment/prof of concept. The main change here are:
A: the initial calculation of the directional vector in the case of having NO other links whose side code is already defined (Not unknown, value = 99).

The endpoints are now defined by the closest target  to a supplied direction vector between the 1st geometry point - last geometry point or the last geometry point - 1st geometry point.

The calculation of the starting point for project recalculation when dealing with 2 tracks (Left, Right). It is now determined by temporarily moving both track geometry to the origin (0.0, 0.0, 0.0) and calculating the distance between the endpoints from/to each track (similar to the logic applied in the defloater tool).


