### PR TITLE
VIITE-1373_removed_future_date_since_original_start_date

### DIFF
--- a/viite-UI/src/utils/date-utils.js
+++ b/viite-UI/src/utils/date-utils.js
@@ -23,6 +23,10 @@
     return addPicker(jQuery(element));
   };
 
+    dateutil.addFinnishDatePickerWithStartDate = function (element, startDate) {
+        return addPickerWithStartDate(jQuery(element), startDate);
+    };
+
   dateutil.addNullableFinnishDatePicker = function (element, onSelect) {
     var elem = jQuery(element);
     var resetButton = jQuery("<div class='pikaday-footer'><div class='deselect-button'>Ei tietoa</div></div>");
@@ -88,6 +92,13 @@
         return dateutil.addFinnishDatePicker(fromElement);
     };
 
+    dateutil.addSingleDatePickerWithStartDate = function (fromElement, startDate) {
+        var fromDateString = function (s) {
+            return s ? moment(s, dateutil.FINNISH_DATE_FORMAT) : null;
+        };
+        var from = fromDateString(fromElement.val());
+        return dateutil.addFinnishDatePickerWithStartDate(fromElement, startDate);
+    };
   dateutil.removeDatePickersFromDom = function () {
     jQuery('.pika-single.is-bound.is-hidden').remove();
   };
@@ -111,6 +122,27 @@
     jqueryElement.attr('placeholder', FINNISH_HINT_TEXT);
     return picker;
   }
+
+    function addPickerWithStartDate(jqueryElement, startDate, onDraw, onSelect) {
+        var picker = new Pikaday({
+            field: jqueryElement.get(0),
+            format: FINNISH_DATE_FORMAT,
+            firstDay: 1,
+            yearRange: [1950, 2050],
+            onDraw: onDraw,
+            onSelect: onSelect,
+            i18n: FINNISH_PIKADAY_I18N,
+            defaultDate: moment(startDate, FINNISH_DATE_FORMAT).toDate()
+        });
+        jqueryElement.keypress(function (e) {
+            if (e.which === 13) { // hide on enter key press
+                picker.hide();
+                jqueryElement.blur();
+            }
+        });
+        jqueryElement.attr('placeholder', FINNISH_HINT_TEXT);
+        return picker;
+    }
 
   dateutil.extractLatestModifications = function (elementsWithModificationTimestamps) {
     var newest = _.max(elementsWithModificationTimestamps, function (s) {

--- a/viite-UI/src/view/RoadNamingToolWindow.js
+++ b/viite-UI/src/view/RoadNamingToolWindow.js
@@ -75,11 +75,11 @@
             });
         };
 
-        var retroactivelyAddDatePickers = function () {
+        var retroactivelyAddDatePickers = function (originalStartDate) {
             var inputs = $('.form-control[data-fieldName=startDate]:not([placeholder])');
             inputs.each(function (index, input) {
                 if (input.dataset.roadid == newId) {
-                    var datePicker = dateutil.addSingleDatePicker($(input));
+                    var datePicker = _.isUndefined(originalStartDate) ? dateutil.addSingleDatePicker($(input)) : dateutil.addSingleDatePickerWithStartDate($(input), originalStartDate);
                 }
             });
             $('.pika-single.is-bound').css("width", "auto");
@@ -123,7 +123,7 @@
             if (year % 400 === 0 || (year % 100 !== 0 && year % 4 === 0))
                 monthLength[1] = 29;
 
-            var dateValidation = (dates.futureDateSinceCurrent.isAfter(dates.fieldDate) || dates.futureDateSinceOriginal.isAfter(dates.fieldDate)) && dates.pastDate.isSameOrBefore(dates.fieldDate);
+            var dateValidation = dates.futureDateSinceCurrent.isAfter(dates.fieldDate) && dates.pastDate.isSameOrBefore(dates.fieldDate);
             var sizeValidation = splitDateString.length === 3 && _.last(splitDateString).length === 4;
             var dayValidation = day > 0 && day <= monthLength[month - 1];
             var monthValidation = month > 0 && month <= 12;
@@ -247,7 +247,7 @@
                         var newEndDateInput = $('.form-control[data-roadId=' + newId + '][data-fieldName=endDate]');
                         newEndDateInput.val(FINNISH_HINT_TEXT);
                         newEndDateInput.prop("readonly", true);
-                        retroactivelyAddDatePickers();
+                        retroactivelyAddDatePickers(originalStartDate);
                         toggleSaveButton();
                         $('.form-control').on("input", editEvent);
                         $('.date-picker-input').on("change", editEvent);

--- a/viite-UI/src/view/navigationpanel/ProjectListModel.js
+++ b/viite-UI/src/view/navigationpanel/ProjectListModel.js
@@ -220,7 +220,7 @@
           $('[id*="open-project"]').click(function (event) {
             var button = $(this);
             if (parseInt(button.attr("data-projectStatus")) === projectStatus.SendingToTR.value) {
-              new GenericConfirmPopup("Avaamalla tämän projektin sen tila muuttuu Keskeneräiseksi. Haluatko varmasti avata sen?", {
+              new GenericConfirmPopup("Projektin muokkaaminen ei ole mahdollista, koska sitä lähetetään Tierekisteriin. Haluatko avata sen?", {
                 successCallback: function () {
                   triggerOpening(event, button);
                 },


### PR DESCRIPTION
Removed the check of the date + 5 years when dealing with the original date on the link, the +5 years should ALWAYS be from the sysdate.
Added the ability to focus the calendar on the original start date.