### PR TITLE
VIITE-1758 Starting calibration point is missing in last project link

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/TrackCalculatorStrategy.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/TrackCalculatorStrategy.scala
@@ -200,8 +200,8 @@ trait TrackCalculatorStrategy {
               setCalibrationPoint(pl, userCalibrationPoint.get(pl.id), raStartCP, raEndCP, RoadAddressSource)
           }
 
-          Seq(setCalibrationPoint(pls.head, userCalibrationPoint.get(pls.head.id), true, false, ProjectLinkSource)) ++ pls.init.tail ++
-            Seq(setCalibrationPoint(pls.last, userCalibrationPoint.get(pls.last.id), false, true, ProjectLinkSource))
+          Seq(setCalibrationPoint(pls.head, userCalibrationPoint.get(pls.head.id), true, pls.tail.head.calibrationPoints._1.isDefined, ProjectLinkSource)) ++ pls.init.tail ++
+            Seq(setCalibrationPoint(pls.last, userCalibrationPoint.get(pls.last.id), pls.init.last.calibrationPoints._2.isDefined, true, ProjectLinkSource))
       }
   }
 


### PR DESCRIPTION
1. Previous Link should have calibration point at end if next one have one calibration point at beginning
2. Next Link should have calibration point at beginning if previous one have one calibration point at end