### PR TITLE
VIITE-1775 - Käännetty-check boxin ruksi puuttuu kääntö-projektissa /Käännetty - selected check box is missing in reversing project

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/ProjectSectionCalculator.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/ProjectSectionCalculator.scala
@@ -30,22 +30,11 @@ object ProjectSectionCalculator {
     logger.info(s"Starting MValue assignment for ${projectLinks.size} links")
     val others = projectLinks.filterNot(_.status == LinkStatus.Terminated)
     val (newLinks, nonTerminatedLinks) = others.partition(l => l.status == LinkStatus.New)
-    //This will reset the side codes if we only have one only track code on all project links (that are not combined)
-    val (rightSide, otherSides) = others.partition(nl => nl.track == Track.RightSide)
-    val (leftSide, combinedAndUnknown) = otherSides.partition(nl => nl.track == Track.LeftSide)
-    //Should we have rightSide tracks only or leftSideTracks only then RESET the sideCodes of the "new"
-    val processedNewLinks = if (rightSide.nonEmpty && leftSide.isEmpty || rightSide.isEmpty && leftSide.nonEmpty) {
-      logger.info(s"Only one track code detected, resetting side codes.")
-      (rightSide ++ leftSide).map(p => p.copy(sideCode = SideCode.Unknown)) ++ combinedAndUnknown
-    } else {
-      logger.info(s"Found both tracks, continuing.")
-      newLinks
-    }
     try {
 
       val calculator = RoadAddressSectionCalculatorContext.getStrategy(others)
       logger.info(s"${calculator.name} strategy")
-      calculator.assignMValues(processedNewLinks, nonTerminatedLinks, userGivenCalibrationPoints)
+      calculator.assignMValues(newLinks, nonTerminatedLinks, userGivenCalibrationPoints)
 
     } finally {
       logger.info(s"Finished MValue assignment for ${projectLinks.size} links")


### PR DESCRIPTION
Removed the resetting of SideCode from the ProjectSectionCalculator, before calling a specific strategy's assignMValues