### PR TITLE
VIITE-1813 problem in SearchAPI with more than 1000 linkIds

### DIFF
--- a/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/SearchApi.scala
+++ b/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/SearchApi.scala
@@ -83,7 +83,7 @@ class SearchApi(roadAddressService: RoadAddressService) extends  ScalatraServlet
 
   post("/road_address/?") {
     time(logger, s"POST request for /road_address/?") {
-      val linkIds = (parsedBody).extract[Set[Long]]
+      val linkIds = parsedBody.extract[Set[Long]]
       roadAddressService.getRoadAddressByLinkIds(linkIds).map(roadAddressMapper)
     }
   }

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
@@ -425,7 +425,7 @@ class RoadAddressService(roadLinkService: RoadLinkService, roadwayDAO: RoadwayDA
     * @return Returns all filtered the road addresses
     */
   def getRoadAddressByLinkIds(linkIds: Set[Long]): Seq[RoadAddress] = {
-    withDynSession {
+    withDynTransaction {
       val linearLocations = linearLocationDAO.fetchRoadwayByLinkId(linkIds)
       val roadAddresses = roadwayAddressMapper.getRoadAddressesByLinearLocation(linearLocations)
       roadAddresses.filter(ra => linkIds.contains(ra.linkId)).filterNot(_.isFloating)


### PR DESCRIPTION
VIITE-1813 changing session to transaction because of the use of MassQuery