### PR TITLE
VIITE-1812 minor discontinuities on roundabout

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/package.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/package.scala
@@ -35,7 +35,7 @@ package object viite {
   val MaxMoveDistanceBeforeFloating = 1.0
   /* Maximum amount a road start / end may move until it is turned into a floating road address */
 
-  val MaxDistanceForSearchDiscontinuityOnOppositeTrack = 10.0
+  val MaxDistanceForSearchDiscontinuityOnOppositeTrack = 20.0
 
   val MinDistanceForGeometryUpdate = 0.5
 

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/DiscontinuityTrackCalculatorStrategy.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/DiscontinuityTrackCalculatorStrategy.scala
@@ -26,7 +26,7 @@ class DiscontinuityTrackCalculatorStrategy(discontinuities: Seq[Discontinuity]) 
 
     (left.last.discontinuity, right.last.discontinuity) match {
       case (MinorDiscontinuity | ParallelLink, MinorDiscontinuity | ParallelLink) => // If both sides have a minor discontinuity
-        if (Math.abs(left.last.endAddrMValue - right.last.endAddrMValue) < MaxDistanceForSearchDiscontinuityOnOppositeTrack || (left.last.discontinuity == ParallelLink || right.last.discontinuity == ParallelLink)) {
+        if (left.last.getEndPoints._2.distance2DTo(right.last.getEndPoints._2) < MaxDistanceForSearchDiscontinuityOnOppositeTrack || (left.last.discontinuity == ParallelLink || right.last.discontinuity == ParallelLink)) {
           adjustTwoTracks(startAddress, left, right, userDefinedCalibrationPoint, restLeft, restRight)
         } else if (left.last.endAddrMValue < right.last.endAddrMValue) { // If the left side has a minor discontinuity
           val (newRight, newRestRight) = getUntilNearestAddress(rightProjectLinks, left.last)


### PR DESCRIPTION
- increasing MaxDistanceForSearchDiscontinuityOnOppositeTrack limit to 20 meters.
- Measure of distance between track endpoints is done based on geometry distances, instead of addressMValues in meters