### PR TITLE
Viite 1930 revert links

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -1200,7 +1200,7 @@ class ProjectService(roadAddressService: RoadAddressService, roadLinkService: Ro
     if (links.groupBy(l => (l.projectId, l.roadNumber, l.roadPartNumber)).keySet.size != 1)
       throw new IllegalArgumentException("Reverting links from multiple road parts at once is not allowed")
     val l = links.head
-    revertLinksByRoadParts(l.projectId, l.roadNumber, l.roadPartNumber, links.map(
+    revertLinksByRoadPart(l.projectId, l.roadNumber, l.roadPartNumber, links.map(
       link => LinkToRevert(link.id, link.linkId, link.status.value, link.geometry)), userName)
   }
 
@@ -1255,7 +1255,6 @@ class ProjectService(roadAddressService: RoadAddressService, roadLinkService: Ro
           checkAndReserve(projectDAO.fetchById(projectId).get, toReservedRoadPart(ra.roadNumber, ra.roadPartNumber, ra.ely))
           projectLinkDAO.updateProjectLinkValues(projectId, ra, updateGeom = false)
       })
-
     revertRoadName(projectId, roadNumber)
 
     if (recalculate)


### PR DESCRIPTION
- revertLinks functions renamed so, that there is no more 4 functions with similar name
- revertLinks fixed so, that it now possible to revert separate links for transferring, unchanged and termination projects
- in case of renumbering always revert the whole road part
