### PR TITLE
Viite 1964 add info to right side form

### DIFF
--- a/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
+++ b/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
@@ -21,10 +21,10 @@ import org.joda.time.DateTime
 import org.joda.time.format.{DateTimeFormat, DateTimeFormatter}
 import org.json4s._
 import org.scalatra.json.JacksonJsonSupport
-import org.scalatra.swagger.Swagger
+import org.scalatra.swagger.{Swagger, _}
 import org.scalatra.{NotFound, _}
 import org.slf4j.{Logger, LoggerFactory}
-import org.scalatra.swagger._
+
 import scala.util.parsing.json.JSON._
 import scala.util.{Left, Right}
 
@@ -1154,6 +1154,7 @@ class ViiteApi(val roadLinkService: RoadLinkService, val vVHClient: VVHClient,
       "modifiedAt" -> roadAddressLink.modifiedAt,
       "modifiedBy" -> roadAddressLink.modifiedBy,
       "municipalityCode" -> roadAddressLink.attributes.get("MUNICIPALITYCODE"),
+      "municipalityName" -> roadAddressLink.municipalityName,
       "roadNameFi" -> roadAddressLink.attributes.get("ROADNAME_FI"),
       "roadNameSe" -> roadAddressLink.attributes.get("ROADNAME_SE"),
       "roadNameSm" -> roadAddressLink.attributes.get("ROADNAME_SM"),

--- a/digiroad2-api-viite/src/test/scala/fi/liikennevirasto/digiroad2/IntegrationApiSpec.scala
+++ b/digiroad2-api-viite/src/test/scala/fi/liikennevirasto/digiroad2/IntegrationApiSpec.scala
@@ -64,7 +64,7 @@ class IntegrationApiSpec extends FunSuite with ScalatraSuite with BeforeAndAfter
     // This roadAddressLink has linearLocationId equal to zero, just to compile.
     val roadAdressLink = RoadAddressLink(63298, 0, 5171208, geometry, GeometryUtils.geometryLength(geometry), Municipality,
       UnknownLinkType, InUse, NormalLinkInterface, RoadType.MunicipalityStreetRoad, Some("Vt5"),
-      None, BigInt(0), None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), 5, 205, 1, 0, 0, 0, 6, "2015-01-01",
+      None, BigInt(0), "", None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), 5, 205, 1, 0, 0, 0, 6, "2015-01-01",
       "2015-12-31", 0.0, 0.0, SideCode.TowardsDigitizing, Some(CalibrationPoint(120, 1, 2)), None, Anomaly.None, 0)
     integrationApi.roadAddressLinksToApi(Seq(roadAdressLink)) should be(Seq(Map(
       "muokattu_viimeksi" -> "",

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/AddressLinkBuilder.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/AddressLinkBuilder.scala
@@ -25,11 +25,18 @@ trait AddressLinkBuilder {
     }
 
   lazy val municipalityRoadMaintainerMapping: Map[Long, Long] = if (OracleDatabase.isWithinSession)
+    MunicipalityDAO.getMunicipalityRoadMaintainers
+  else
+    OracleDatabase.withDynSession {
       MunicipalityDAO.getMunicipalityRoadMaintainers
-    else
-      OracleDatabase.withDynSession {
-        MunicipalityDAO.getMunicipalityRoadMaintainers
-      }
+    }
+
+  lazy  val municipalityNamesMapping: Map[Long, String] = if (OracleDatabase.isWithinSession)
+    MunicipalityDAO.getMunicipalityNames
+  else
+    OracleDatabase.withDynSession {
+      MunicipalityDAO.getMunicipalityNames
+    }
 
   def getRoadType(administrativeClass: AdministrativeClass, linkType: LinkType): RoadType = {
     (administrativeClass, linkType) match {

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/AddressLinkBuilder.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/AddressLinkBuilder.scala
@@ -31,7 +31,7 @@ trait AddressLinkBuilder {
       MunicipalityDAO.getMunicipalityRoadMaintainers
     }
 
-  lazy  val municipalityNamesMapping: Map[Long, String] = if (OracleDatabase.isWithinSession)
+  lazy val municipalityNamesMapping: Map[Long, String] = if (OracleDatabase.isWithinSession)
     MunicipalityDAO.getMunicipalityNames
   else
     OracleDatabase.withDynSession {

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectAddressLinkBuilder.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectAddressLinkBuilder.scala
@@ -26,7 +26,7 @@ object ProjectAddressLinkBuilder extends AddressLinkBuilder {
 
     ProjectAddressLink(pl.id, pl.linkId, pl.geometry,
       pl.geometryLength, fi.liikennevirasto.digiroad2.asset.Unknown, linkType, ConstructionType.UnknownConstructionType,
-      pl.linkGeomSource, pl.roadType, pl.roadName, pl.roadName, 0L, None, Some("vvh_modified"),
+      pl.linkGeomSource, pl.roadType, pl.roadName, pl.roadName, 0L, "", None, Some("vvh_modified"),
       Map(), pl.roadNumber, pl.roadPartNumber, pl.track.value, pl.ely, pl.discontinuity.value,
       pl.startAddrMValue, pl.endAddrMValue, pl.startMValue, pl.endMValue, pl.sideCode, calibrationPoints._1,
       calibrationPoints._2, Anomaly.None, pl.status, pl.roadwayId, pl.linearLocationId,
@@ -81,7 +81,7 @@ object ProjectAddressLinkBuilder extends AddressLinkBuilder {
 
   def build(ral: RoadAddressLinkLike): ProjectAddressLink = {
     ProjectAddressLink(ral.id, ral.linkId, ral.geometry, ral.length, ral.administrativeClass, ral.linkType,
-      ral.constructionType, ral.roadLinkSource, ral.roadType, ral.VVHRoadName, ral.roadName, ral.municipalityCode, ral.modifiedAt, ral.modifiedBy,
+      ral.constructionType, ral.roadLinkSource, ral.roadType, ral.VVHRoadName, ral.roadName, ral.municipalityCode, ral.municipalityName, ral.modifiedAt, ral.modifiedBy,
       ral.attributes, ral.roadNumber, ral.roadPartNumber, ral.trackCode, ral.elyCode, ral.discontinuity,
       ral.startAddressM, ral.endAddressM, ral.startMValue, ral.endMValue, ral.sideCode, ral.startCalibrationPoint, ral.endCalibrationPoint,
       ral.anomaly, LinkStatus.Unknown, ral.id, ral.linearLocationId)
@@ -101,9 +101,11 @@ object ProjectAddressLinkBuilder extends AddressLinkBuilder {
         0L - roadLink.linkId
       else
         roadLink.linkId
+
+    val municipalityName = municipalityNamesMapping.getOrElse(municipalityCode, "")
     ProjectAddressLink(id, linkId, geom,
       length, roadLink.administrativeClass, linkType, roadLink.constructionType, roadLink.linkSource,
-      roadType, Some(roadLink.attributes.getOrElse(FinnishRoadName, roadLink.attributes.getOrElse(SwedishRoadName, "none")).toString), roadName, municipalityCode, extractModifiedAtVVH(roadLink.attributes), Some("vvh_modified"),
+      roadType, Some(roadLink.attributes.getOrElse(FinnishRoadName, roadLink.attributes.getOrElse(SwedishRoadName, "none")).toString), roadName, municipalityCode, municipalityName, extractModifiedAtVVH(roadLink.attributes), Some("vvh_modified"),
       roadLink.attributes, roadNumber, roadPartNumber, trackCode, ely, discontinuity.value,
       startAddrMValue, endAddrMValue, startMValue, endMValue, sideCode, startCalibrationPoint, endCalibrationPoint, anomaly, status, roadwayId, linearLocationId,
       reversed, connectedLinkId, originalGeometry)

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilder.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilder.scala
@@ -36,12 +36,13 @@ class RoadAddressLinkBuilder(roadwayDAO: RoadwayDAO, linearLocationDAO: LinearLo
     val VVHRoadName = getVVHRoadName(roadLink.attributes)
     val roadName = roadAddress.roadName
     val municipalityCode = roadLink.attributes.getOrElse(MunicipalityCode, 0).asInstanceOf[Number].intValue()
+    val municipalityName = municipalityNamesMapping.getOrElse(municipalityCode, "")
     val roadType = roadAddress.roadType match {
       case RoadType.Unknown => getRoadType(roadLink.administrativeClass, UnknownLinkType)
       case _ => roadAddress.roadType
     }
     RoadAddressLink(roadAddress.id, roadAddress.linearLocationId, roadLink.linkId, geom,
-      length, roadLink.administrativeClass, UnknownLinkType, roadLink.constructionType, roadLink.linkSource, roadType, VVHRoadName, roadName, municipalityCode, extractModifiedAtVVH(roadLink.attributes), Some("vvh_modified"),
+      length, roadLink.administrativeClass, UnknownLinkType, roadLink.constructionType, roadLink.linkSource, roadType, VVHRoadName, roadName, municipalityCode, municipalityName, extractModifiedAtVVH(roadLink.attributes), Some("vvh_modified"),
       roadLink.attributes, roadAddress.roadNumber, roadAddress.roadPartNumber, roadAddress.track.value, roadAddress.ely, roadAddress.discontinuity.value,
       roadAddress.startAddrMValue, roadAddress.endAddrMValue, roadAddress.startDate.map(formatter.print).getOrElse(""), roadAddress.endDate.map(formatter.print).getOrElse(""), roadAddress.startMValue, roadAddress.endMValue,
       roadAddress.sideCode,
@@ -55,7 +56,7 @@ class RoadAddressLinkBuilder(roadwayDAO: RoadwayDAO, linearLocationDAO: LinearLo
     val municipalityCode = 0
     val roadType = roadAddress.roadType
     RoadAddressLink(roadAddress.id, roadAddress.linearLocationId, roadAddress.linkId, geom,
-      length, AdministrativeClass.apply(1), LinkType.apply(99), ConstructionType.apply(0), LinkGeomSource.apply(1), roadType, Some(""), roadAddress.roadName, municipalityCode, Some(""), Some("vvh_modified"),
+      length, AdministrativeClass.apply(1), LinkType.apply(99), ConstructionType.apply(0), LinkGeomSource.apply(1), roadType, Some(""), roadAddress.roadName, municipalityCode, "", Some(""), Some("vvh_modified"),
       Map(), roadAddress.roadNumber, roadAddress.roadPartNumber, roadAddress.track.value, 0, roadAddress.discontinuity.value,
       roadAddress.startAddrMValue, roadAddress.endAddrMValue, roadAddress.startDate.map(formatter.print).getOrElse(""), roadAddress.endDate.map(formatter.print).getOrElse(""), roadAddress.startMValue, roadAddress.endMValue,
       roadAddress.sideCode,
@@ -78,13 +79,14 @@ class RoadAddressLinkBuilder(roadwayDAO: RoadwayDAO, linearLocationDAO: LinearLo
     val roadLinkRoadPartNumber = roadLink.attributes.get(RoadPartNumber).map(toIntNumber).getOrElse(0)
     val VVHRoadName = getVVHRoadName(roadLink.attributes)
     val municipalityCode = roadLink.attributes.getOrElse(MunicipalityCode, 0).asInstanceOf[Number].intValue()
+    val municipalityName = municipalityNamesMapping.getOrElse(municipalityCode, "")
     val roadType = unaddressedRoadLink.roadType match {
       case RoadType.Unknown => getRoadType(roadLink.administrativeClass, roadLink.linkType)
       case _ => unaddressedRoadLink.roadType
     }
     RoadAddressLink(0, 0, roadLink.linkId, geom,
       length, roadLink.administrativeClass, roadLink.linkType, roadLink.constructionType, roadLink.linkSource, roadType,
-      VVHRoadName, Some(""), municipalityCode, extractModifiedAtVVH(roadLink.attributes), Some("vvh_modified"),
+      VVHRoadName, Some(""), municipalityCode, municipalityName, extractModifiedAtVVH(roadLink.attributes), Some("vvh_modified"),
       roadLink.attributes, unaddressedRoadLink.roadNumber.getOrElse(roadLinkRoadNumber),
       unaddressedRoadLink.roadPartNumber.getOrElse(roadLinkRoadPartNumber), Track.Unknown.value, municipalityRoadMaintainerMapping.getOrElse(roadLink.municipalityCode, -1), Discontinuity.Continuous.value,
       0, 0, "", "", 0.0, length, SideCode.Unknown, None, None, unaddressedRoadLink.anomaly, newGeometry = Some(roadLink.geometry))
@@ -97,13 +99,14 @@ class RoadAddressLinkBuilder(roadwayDAO: RoadwayDAO, linearLocationDAO: LinearLo
     val roadLinkRoadPartNumber = roadLink.attributes.get(RoadPartNumber).map(toIntNumber).getOrElse(0)
     val VVHRoadName = getVVHRoadName(roadLink.attributes)
     val municipalityCode = roadLink.attributes.getOrElse(MunicipalityCode, 0).asInstanceOf[Number].intValue()
+    val municipalityName = municipalityNamesMapping.getOrElse(municipalityCode, "")
     val roadType = unaddressedRoadLink.roadType match {
       case RoadType.Unknown => getRoadType(roadLink.administrativeClass, UnknownLinkType)
       case _ => unaddressedRoadLink.roadType
     }
     RoadAddressLink(0, 0, roadLink.linkId, geom,
       length, roadLink.administrativeClass, UnknownLinkType, roadLink.constructionType, roadLink.linkSource, roadType,
-      VVHRoadName, Some(""), municipalityCode, extractModifiedAtVVH(roadLink.attributes), Some("vvh_modified"),
+      VVHRoadName, Some(""), municipalityCode, municipalityName, extractModifiedAtVVH(roadLink.attributes), Some("vvh_modified"),
       roadLink.attributes, unaddressedRoadLink.roadNumber.getOrElse(roadLinkRoadNumber),
       unaddressedRoadLink.roadPartNumber.getOrElse(roadLinkRoadPartNumber), Track.Unknown.value, municipalityRoadMaintainerMapping.getOrElse(roadLink.municipalityCode, -1), Discontinuity.Continuous.value,
       0, 0, "", "", 0.0, length, SideCode.Unknown, None, None, unaddressedRoadLink.anomaly, newGeometry = Some(roadLink.geometry))
@@ -147,6 +150,7 @@ class RoadAddressLinkBuilder(roadwayDAO: RoadwayDAO, linearLocationDAO: LinearLo
     val roadLinkRoadPartNumber = toLongNumber(headAddress.map(_.roadPartNumber), roadLink.attributes.get(RoadPartNumber))
     val VVHRoadName = getVVHRoadName(roadLink.attributes)
     val municipalityCode = roadLink.municipalityCode
+    val municipalityName = municipalityNamesMapping.getOrElse(municipalityCode, "")
     val roadNames = RoadNameDAO.getLatestRoadName(roadLinkRoadNumber)
 
     val roadName = if (roadNames.isEmpty) Some("") else Some(roadNames.get.roadName)
@@ -171,7 +175,7 @@ class RoadAddressLinkBuilder(roadwayDAO: RoadwayDAO, linearLocationDAO: LinearLo
     RoadAddressLink(toLongNumber(headAddress.map(_.id), Some(0)), toLongNumber(headAddress.map(_.linearLocationId), Some(0)), roadLink.linkId, geom,
       length, roadLink.administrativeClass, getLinkType(roadLink), roadLink.constructionType,
       roadLink.linkSource, getRoadType(roadLink.administrativeClass, getLinkType(roadLink)),
-      VVHRoadName, roadName, municipalityCode, extractModifiedAtVVH(roadLink.attributes), Some("vvh_modified"),
+      VVHRoadName, roadName, municipalityCode, municipalityName, extractModifiedAtVVH(roadLink.attributes), Some("vvh_modified"),
       roadLink.attributes, roadLinkRoadNumber, roadLinkRoadPartNumber, trackValue, elyCode, Discontinuity.Continuous.value,
       startAddrM, endAddrM, "", "", 0.0, length, sideCode, None, None, anomalyType)
   }

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/MunicipalityDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/MunicipalityDAO.scala
@@ -14,4 +14,8 @@ object MunicipalityDAO {
   def getMunicipalityRoadMaintainers = {
     Q.queryNA[(Long, Long)]("""SELECT id, ROAD_MAINTAINER_ID FROM MUNICIPALITY""").list.map(x => x._1 -> x._2).toMap
   }
+
+  def getMunicipalityNames = {
+    Q.queryNA[(Long, String)]("""SELECT ID, NAME_FI FROM MUNICIPALITY""").list.map(x => x._1 -> x._2).toMap
+  }
 }

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/model/ProjectAddressLink.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/model/ProjectAddressLink.scala
@@ -17,6 +17,7 @@ trait ProjectAddressLinkLike extends RoadAddressLinkLike {
 
   def roadName: Option[String]
   def municipalityCode: BigInt
+  def municipalityName: String
   def modifiedAt: Option[String]
   def modifiedBy: Option[String]
   def attributes: Map[String, Any]
@@ -45,7 +46,7 @@ trait ProjectAddressLinkLike extends RoadAddressLinkLike {
 case class ProjectAddressLink(id: Long, linkId: Long, geometry: Seq[Point],
                               length: Double, administrativeClass: AdministrativeClass,
                               linkType: LinkType, constructionType: ConstructionType,
-                              roadLinkSource: LinkGeomSource, roadType: RoadType, VVHRoadName: Option[String], roadName: Option[String], municipalityCode: BigInt, modifiedAt: Option[String], modifiedBy: Option[String],
+                              roadLinkSource: LinkGeomSource, roadType: RoadType, VVHRoadName: Option[String], roadName: Option[String], municipalityCode: BigInt, municipalityName: String, modifiedAt: Option[String], modifiedBy: Option[String],
                               attributes: Map[String, Any] = Map(), roadNumber: Long, roadPartNumber: Long, trackCode: Long, elyCode: Long, discontinuity: Long,
                               startAddressM: Long, endAddressM: Long, startMValue: Double, endMValue: Double, sideCode: SideCode,
                               startCalibrationPoint: Option[CalibrationPoint], endCalibrationPoint: Option[CalibrationPoint],

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/model/RoadAddressLink.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/model/RoadAddressLink.scala
@@ -21,6 +21,7 @@ trait RoadAddressLinkLike extends PolyLine {
 
   def roadName: Option[String]
   def municipalityCode: BigInt
+  def municipalityName: String
   def modifiedAt: Option[String]
   def modifiedBy: Option[String]
   def attributes: Map[String, Any]
@@ -42,7 +43,7 @@ trait RoadAddressLinkLike extends PolyLine {
 
 case class RoadAddressLink(id: Long, linearLocationId: Long, linkId: Long, geometry: Seq[Point],
                            length: Double, administrativeClass: AdministrativeClass,
-                           linkType: LinkType, constructionType: ConstructionType, roadLinkSource: LinkGeomSource, roadType: RoadType, VVHRoadName: Option[String], roadName: Option[String], municipalityCode: BigInt, modifiedAt: Option[String], modifiedBy: Option[String],
+                           linkType: LinkType, constructionType: ConstructionType, roadLinkSource: LinkGeomSource, roadType: RoadType, VVHRoadName: Option[String], roadName: Option[String], municipalityCode: BigInt, municipalityName: String, modifiedAt: Option[String], modifiedBy: Option[String],
                            attributes: Map[String, Any] = Map(), roadNumber: Long, roadPartNumber: Long, trackCode: Long, elyCode: Long, discontinuity: Long,
                            startAddressM: Long, endAddressM: Long, startDate: String, endDate: String, startMValue: Double, endMValue: Double, sideCode: SideCode,
                            startCalibrationPoint: Option[CalibrationPoint], endCalibrationPoint: Option[CalibrationPoint],

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceLinkSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceLinkSpec.scala
@@ -344,7 +344,7 @@ class ProjectServiceLinkSpec extends FunSuite with Matchers with BeforeAndAfter 
       val calibrationPoints2 = CalibrationPointsUtils.toCalibrationPoints(projectLink2.calibrationPoints)
 
       val p1 = ProjectAddressLink(idr1, projectLink1.linkId, projectLink1.geometry,
-        1, AdministrativeClass.apply(1), LinkType.apply(1), ConstructionType.apply(1), projectLink1.linkGeomSource, RoadType.PublicUnderConstructionRoad, Some(""), None, 111, Some(""), Some("vvh_modified"),
+        1, AdministrativeClass.apply(1), LinkType.apply(1), ConstructionType.apply(1), projectLink1.linkGeomSource, RoadType.PublicUnderConstructionRoad, Some(""), None, 111, "Heinola", Some(""), Some("vvh_modified"),
         Map(), projectLink1.roadNumber, projectLink1.roadPartNumber, 2, -1, projectLink1.discontinuity.value,
         projectLink1.startAddrMValue, projectLink1.endAddrMValue, projectLink1.startMValue, projectLink1.endMValue,
         projectLink1.sideCode,
@@ -352,7 +352,7 @@ class ProjectServiceLinkSpec extends FunSuite with Matchers with BeforeAndAfter 
         calibrationPoints1._2, Anomaly.None, projectLink1.status, 0, 0)
 
       val p2 = ProjectAddressLink(idr2, projectLink2.linkId, projectLink2.geometry,
-        1, AdministrativeClass.apply(1), LinkType.apply(1), ConstructionType.apply(1), projectLink2.linkGeomSource, RoadType.PublicUnderConstructionRoad, Some(""), None, 111, Some(""), Some("vvh_modified"),
+        1, AdministrativeClass.apply(1), LinkType.apply(1), ConstructionType.apply(1), projectLink2.linkGeomSource, RoadType.PublicUnderConstructionRoad, Some(""), None, 111, "Heinola", Some(""), Some("vvh_modified"),
         Map(), projectLink2.roadNumber, projectLink2.roadPartNumber, 2, -1, projectLink2.discontinuity.value,
         projectLink2.startAddrMValue, projectLink2.endAddrMValue, projectLink2.startMValue, projectLink2.endMValue,
         projectLink2.sideCode,
@@ -610,7 +610,7 @@ class ProjectServiceLinkSpec extends FunSuite with Matchers with BeforeAndAfter 
 
       val addProjectAddressLink552 = ProjectAddressLink(NewIdValue, 6552, geom, GeometryUtils.geometryLength(geom),
         State, Motorway, ConstructionType.InUse, LinkGeomSource.NormalLinkInterface,
-        RoadType.PublicRoad, Some("X"), None, 749, None, None, Map.empty, 19999, 1, 2L, 8L, 5L, 0L, 0L, 0.0, GeometryUtils.geometryLength(geom),
+        RoadType.PublicRoad, Some("X"), None, 749, "Siilinjärvi", None, None, Map.empty, 19999, 1, 2L, 8L, 5L, 0L, 0L, 0.0, GeometryUtils.geometryLength(geom),
         SideCode.TowardsDigitizing, None, None, Anomaly.None, LinkStatus.New, 0, 0)
       val addresses = Seq(addProjectAddressLink552)
       mockForProject(id, addresses)

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
@@ -145,7 +145,7 @@ class ProjectServiceSpec extends FunSuite with Matchers with BeforeAndAfter {
 
   private def toProjectAddressLink(ral: RoadAddressLinkLike): ProjectAddressLink = {
     ProjectAddressLink(ral.id, ral.linkId, ral.geometry, ral.length, ral.administrativeClass, ral.linkType,
-      ral.constructionType, ral.roadLinkSource, ral.roadType, ral.VVHRoadName, ral.roadName, ral.municipalityCode, ral.modifiedAt, ral.modifiedBy,
+      ral.constructionType, ral.roadLinkSource, ral.roadType, ral.VVHRoadName, ral.roadName, ral.municipalityCode, ral.municipalityName, ral.modifiedAt, ral.modifiedBy,
       ral.attributes, ral.roadNumber, ral.roadPartNumber, ral.trackCode, ral.elyCode, ral.discontinuity,
       ral.startAddressM, ral.endAddressM, ral.startMValue, ral.endMValue, ral.sideCode, ral.startCalibrationPoint, ral.endCalibrationPoint,
       ral.anomaly, LinkStatus.Unknown, ral.id, ral.linearLocationId)
@@ -713,7 +713,7 @@ class ProjectServiceSpec extends FunSuite with Matchers with BeforeAndAfter {
 
       val calibrationPoints = projectLink.toCalibrationPoints
       val p = ProjectAddressLink(idr, projectLink.linkId, projectLink.geometry,
-        1, AdministrativeClass.apply(1), LinkType.apply(1), ConstructionType.apply(1), projectLink.linkGeomSource, RoadType.PublicUnderConstructionRoad, Some(""), None, 111, Some(""), Some("vvh_modified"),
+        1, AdministrativeClass.apply(1), LinkType.apply(1), ConstructionType.apply(1), projectLink.linkGeomSource, RoadType.PublicUnderConstructionRoad, Some(""), None, 111, "Heinola", Some(""), Some("vvh_modified"),
         Map(), projectLink.roadNumber, projectLink.roadPartNumber, 2, -1, projectLink.discontinuity.value,
         projectLink.startAddrMValue, projectLink.endAddrMValue, projectLink.startMValue, projectLink.endMValue,
         projectLink.sideCode,

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/model/RoadAddressLinkPartitionerSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/model/RoadAddressLinkPartitionerSpec.scala
@@ -42,14 +42,14 @@ class RoadAddressLinkPartitionerSpec extends FunSuite with Matchers {
   )
 
   private def makeRoadAddressLink(id: Long, anomaly: Int, roadNumber: Long, roadPartNumber: Long, deltaX: Double = 0.0, deltaY: Double = 0.0) = {
-    RoadAddressLink(id, id, id, Seq(Point(id * 10.0 + deltaX, anomaly * 10.0 + deltaY), Point((id + 1) * 10.0 + deltaX, anomaly * 10.0 + deltaY)), 10.0, State, SingleCarriageway,  InUse, NormalLinkInterface, PublicRoad, Some("Vt5"), None, BigInt(0), None, None, Map(), roadNumber, roadPartNumber, 1, 1, 1, id * 10, (id + 1) * 10, "", "", 0.0, 10.0, SideCode.TowardsDigitizing, None, None, Anomaly.apply(anomaly))
+    RoadAddressLink(id, id, id, Seq(Point(id * 10.0 + deltaX, anomaly * 10.0 + deltaY), Point((id + 1) * 10.0 + deltaX, anomaly * 10.0 + deltaY)), 10.0, State, SingleCarriageway,  InUse, NormalLinkInterface, PublicRoad, Some("Vt5"), None, BigInt(0), "", None, None, Map(), roadNumber, roadPartNumber, 1, 1, 1, id * 10, (id + 1) * 10, "", "", 0.0, 10.0, SideCode.TowardsDigitizing, None, None, Anomaly.apply(anomaly))
   }
 
   test("Test partition should have specific fields (still to be defined) not empty") {
 
     val roadLinks = Seq(RoadAddressLink(0, 0, 5171208, Seq(Point(532837.14110884, 6993543.6296834), Point(533388.14110884, 6994014.1296834)),
       0.0, Municipality, UnknownLinkType, InUse, NormalLinkInterface, RoadType.MunicipalityStreetRoad,
-      Some("Vt5"), None, BigInt(0), None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), 5, 205, 1, 0, 0, 0, 1, "2015-01-01", "2016-01-01",
+      Some("Vt5"), None, BigInt(0), "", None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), 5, 205, 1, 0, 0, 0, 1, "2015-01-01", "2016-01-01",
       0.0, 0.0, SideCode.Unknown, None, None, Anomaly.None, 123))
 
     val partitionedRoadLinks = RoadAddressLinkPartitioner.partition(roadLinks)
@@ -74,11 +74,11 @@ class RoadAddressLinkPartitionerSpec extends FunSuite with Matchers {
 
     val roadLinks = Seq(RoadAddressLink(0, 0, 5171208, Seq(Point(532837.14110884, 6993543.6296834), Point(533388.14110884, 6994014.1296834)),
       0.0, Municipality, UnknownLinkType, InUse, NormalLinkInterface, RoadType.MunicipalityStreetRoad,
-      Some("Vt5"), None, BigInt(0), None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), 1, 205, 1, 0, 0, 0, 1, "2015-01-01", "2016-01-01",
+      Some("Vt5"), None, BigInt(0), "", None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), 1, 205, 1, 0, 0, 0, 1, "2015-01-01", "2016-01-01",
       0.0, 0.0, SideCode.Unknown, None, None, Anomaly.NoAddressGiven, 123),
       RoadAddressLink(0, 0, 5171208, Seq(Point(532837.14110884, 6993543.6296834), Point(533388.14110884, 6994014.1296834)),
       0.0, Municipality, UnknownLinkType, InUse, NormalLinkInterface, RoadType.MunicipalityStreetRoad,
-      Some("Vt5"), None, BigInt(0), None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), 1, 205, 1, 0, 0, 0, 1, "2015-01-01", "2016-01-01",
+      Some("Vt5"), None, BigInt(0), "", None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), 1, 205, 1, 0, 0, 0, 1, "2015-01-01", "2016-01-01",
       0.0, 0.0, SideCode.Unknown, None, None, Anomaly.None, 123)
     )
 
@@ -92,11 +92,11 @@ class RoadAddressLinkPartitionerSpec extends FunSuite with Matchers {
 
     val roadLinks = Seq(RoadAddressLink(0, 0, 5171208, Seq(Point(532837.14110884, 6993543.6296834), Point(533388.14110884, 6994014.1296834)),
       0.0, Municipality, UnknownLinkType, InUse, NormalLinkInterface, RoadType.MunicipalityStreetRoad,
-      Some("Vt5"), None, BigInt(0), None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), roadNumber1, 205, 1, 0, 0, 0, 1, "2015-01-01", "2016-01-01",
+      Some("Vt5"), None, BigInt(0), "", None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), roadNumber1, 205, 1, 0, 0, 0, 1, "2015-01-01", "2016-01-01",
       0.0, 0.0, SideCode.Unknown, None, None, Anomaly.None, 123),
       RoadAddressLink(0, 0, 5171208, Seq(Point(532837.14110884, 6993543.6296834), Point(533388.14110884, 6994014.1296834)),
       0.0, Municipality, UnknownLinkType, InUse, NormalLinkInterface, RoadType.MunicipalityStreetRoad,
-      Some("Vt5"), None, BigInt(0), None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), roadNumber2, 205, 1, 0, 0, 0, 1, "2015-01-01", "2016-01-01",
+      Some("Vt5"), None, BigInt(0), "", None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), roadNumber2, 205, 1, 0, 0, 0, 1, "2015-01-01", "2016-01-01",
       0.0, 0.0, SideCode.Unknown, None, None, Anomaly.None, 123)
     )
 
@@ -110,11 +110,11 @@ class RoadAddressLinkPartitionerSpec extends FunSuite with Matchers {
 
     val roadLinks = Seq(RoadAddressLink(0, 0, 5171208, Seq(Point(532837.14110884, 6993543.6296834), Point(533388.14110884, 6994014.1296834)),
       0.0, Municipality, UnknownLinkType, InUse, NormalLinkInterface, RoadType.MunicipalityStreetRoad,
-      Some("Vt5"), None, BigInt(0), None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), 1, roadPartNumber1, 1, 0, 0, 0, 1, "2015-01-01", "2016-01-01",
+      Some("Vt5"), None, BigInt(0), "", None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), 1, roadPartNumber1, 1, 0, 0, 0, 1, "2015-01-01", "2016-01-01",
       0.0, 0.0, SideCode.Unknown, None, None, Anomaly.None, 123),
       RoadAddressLink(0, 0, 5171208, Seq(Point(532837.14110884, 6993543.6296834), Point(533388.14110884, 6994014.1296834)),
       0.0, Municipality, UnknownLinkType, InUse, NormalLinkInterface, RoadType.MunicipalityStreetRoad,
-      Some("Vt5"), None, BigInt(0), None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), 1, roadPartNumber2, 1, 0, 0, 0, 1, "2015-01-01", "2016-01-01",
+      Some("Vt5"), None, BigInt(0), "", None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), 1, roadPartNumber2, 1, 0, 0, 0, 1, "2015-01-01", "2016-01-01",
       0.0, 0.0, SideCode.Unknown, None, None, Anomaly.None, 123)
     )
 
@@ -128,11 +128,11 @@ class RoadAddressLinkPartitionerSpec extends FunSuite with Matchers {
 
     val roadLinks = Seq(RoadAddressLink(0, 0, 5171208, Seq(Point(532837.14110884, 6993543.6296834), Point(533388.14110884, 6994014.1296834)),
       0.0, Municipality, UnknownLinkType, InUse, NormalLinkInterface, RoadType.MunicipalityStreetRoad,
-      Some("Vt5"), None, BigInt(0), None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), 1, 1, track1, 0, 0, 0, 1, "2015-01-01", "2016-01-01",
+      Some("Vt5"), None, BigInt(0), "", None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), 1, 1, track1, 0, 0, 0, 1, "2015-01-01", "2016-01-01",
       0.0, 0.0, SideCode.Unknown, None, None, Anomaly.None, 123),
       RoadAddressLink(0, 0, 5171208, Seq(Point(532837.14110884, 6993543.6296834), Point(533388.14110884, 6994014.1296834)),
       0.0, Municipality, UnknownLinkType, InUse, NormalLinkInterface, RoadType.MunicipalityStreetRoad,
-      Some("Vt5"), None, BigInt(0), None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), 1, 1, track2, 0, 0, 0, 1, "2015-01-01", "2016-01-01",
+      Some("Vt5"), None, BigInt(0), "", None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), 1, 1, track2, 0, 0, 0, 1, "2015-01-01", "2016-01-01",
       0.0, 0.0, SideCode.Unknown, None, None, Anomaly.None, 123)
     )
 
@@ -144,11 +144,11 @@ class RoadAddressLinkPartitionerSpec extends FunSuite with Matchers {
 
     val roadLinks = Seq(RoadAddressLink(0, 0, 5171208, Seq(Point(532837.14110884, 6993543.6296834), Point(533388.14110884, 6994014.1296834)),
       0.0, Municipality, UnknownLinkType, InUse, ComplementaryLinkInterface, RoadType.MunicipalityStreetRoad,
-      Some("Vt5"), None, BigInt(0), None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), 1, 1, 1, 0, 0, 0, 1, "2015-01-01", "2016-01-01",
+      Some("Vt5"), None, BigInt(0), "", None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), 1, 1, 1, 0, 0, 0, 1, "2015-01-01", "2016-01-01",
       0.0, 0.0, SideCode.Unknown, None, None, Anomaly.None, 123),
       RoadAddressLink(0, 0, 5171208, Seq(Point(532837.14110884, 6993543.6296834), Point(533388.14110884, 6994014.1296834)),
       0.0, Municipality, UnknownLinkType, InUse, NormalLinkInterface, RoadType.MunicipalityStreetRoad,
-      Some("Vt5"), None, BigInt(0), None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), 1, 1, 1, 0, 0, 0, 1, "2015-01-01", "2016-01-01",
+      Some("Vt5"), None, BigInt(0), "", None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), 1, 1, 1, 0, 0, 0, 1, "2015-01-01", "2016-01-01",
       0.0, 0.0, SideCode.Unknown, None, None, Anomaly.None, 123)
     )
 
@@ -160,11 +160,11 @@ class RoadAddressLinkPartitionerSpec extends FunSuite with Matchers {
 
     val roadLinks = Seq(RoadAddressLink(0, 0, 5171208, Seq(Point(532837.14110884, 6993543.6296834), Point(533388.14110884, 6994014.1296834)),
       0.0, Municipality, UnknownLinkType, InUse, SuravageLinkInterface, RoadType.MunicipalityStreetRoad,
-      Some("Vt5"), None, BigInt(0), None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), 1, 1, 1, 0, 0, 0, 1, "2015-01-01", "2016-01-01",
+      Some("Vt5"), None, BigInt(0), "", None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), 1, 1, 1, 0, 0, 0, 1, "2015-01-01", "2016-01-01",
       0.0, 0.0, SideCode.Unknown, None, None, Anomaly.None, 123),
       RoadAddressLink(0, 0, 5171208, Seq(Point(532837.14110884, 6993543.6296834), Point(533388.14110884, 6994014.1296834)),
       0.0, Municipality, UnknownLinkType, InUse, LinkGeomSource.Unknown, RoadType.MunicipalityStreetRoad,
-      Some("Vt5"), None, BigInt(0), None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), 1, 1, 1, 0, 0, 0, 1, "2015-01-01", "2016-01-01",
+      Some("Vt5"), None, BigInt(0), "", None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), 1, 1, 1, 0, 0, 0, 1, "2015-01-01", "2016-01-01",
       0.0, 0.0, SideCode.Unknown, None, None, Anomaly.None, 123)
     )
 
@@ -176,11 +176,11 @@ class RoadAddressLinkPartitionerSpec extends FunSuite with Matchers {
 
     val roadLinks = Seq(RoadAddressLink(0, 0, 5171208, Seq(Point(532837.14110884, 6993543.6296834), Point(533388.14110884, 6994014.1296834)),
       0.0, Municipality, UnknownLinkType, InUse, LinkGeomSource.NormalLinkInterface, RoadType.MunicipalityStreetRoad,
-      Some("Vt5"), None, BigInt(0), None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), 1, 1, 1, 0, 0, 0, 1, "2015-01-01", "2016-01-01",
+      Some("Vt5"), None, BigInt(0), "", None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), 1, 1, 1, 0, 0, 0, 1, "2015-01-01", "2016-01-01",
       0.0, 0.0, SideCode.Unknown, None, None, Anomaly.None, 123),
       RoadAddressLink(0, 0, 5171208, Seq(Point(532837.14110884, 6993543.6296834), Point(533388.14110884, 6994014.1296834)),
       0.0, Municipality, UnknownLinkType, InUse, LinkGeomSource.Unknown, RoadType.MunicipalityStreetRoad,
-      Some("Vt5"), None, BigInt(0), None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), 1, 1, 1, 0, 0, 0, 1, "2015-01-01", "2016-01-01",
+      Some("Vt5"), None, BigInt(0), "", None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), 1, 1, 1, 0, 0, 0, 1, "2015-01-01", "2016-01-01",
       0.0, 0.0, SideCode.Unknown, None, None, Anomaly.None, 123)
     )
 

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/util/ProjectLinkSplitterSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/util/ProjectLinkSplitterSpec.scala
@@ -448,7 +448,7 @@ class ProjectLinkSplitterSpec extends FunSuite with Matchers with BeforeAndAfter
       //TODO this roadAddressLink have linearLocationId equal to zero, just to compile.
       val suravageAddressLink = RoadAddressLink(Sequences.nextViitePrimaryKeySeqValue, 0, 2, Seq(Point(0, 0), Point(0, 45.3), Point(0, 123)), 123,
         AdministrativeClass.apply(1), LinkType.apply(1), ConstructionType.Planned, LinkGeomSource.SuravageLinkInterface, RoadType.PublicRoad, Some("testRoad"), None,
-        8, None, None, null, 1, 1, Track.Combined.value, 8, Discontinuity.Continuous.value, 0, 123, "", "", 0, 123, SideCode.Unknown, None, None, Anomaly.None)
+        8, "", None, None, null, 1, 1, Track.Combined.value, 8, Discontinuity.Continuous.value, 0, 123, "", "", 0, 123, SideCode.Unknown, None, None, Anomaly.None)
 
       when(mockRoadAddressService.getSuravageRoadLinkAddressesByLinkIds(any[Set[Long]])).thenReturn(Seq(suravageAddressLink))
       when(mockRoadLinkService.getRoadLinksAndComplementaryFromVVH(any[BoundingRectangle], any[Set[Int]])).thenReturn(Seq(roadLink))

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/util/package.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/util/package.scala
@@ -217,7 +217,7 @@ package object util {
 
   def toProjectAddressLink(ral: RoadAddressLinkLike): ProjectAddressLink = {
     ProjectAddressLink(ral.id, ral.linkId, ral.geometry, ral.length, ral.administrativeClass, ral.linkType,
-      ral.constructionType, ral.roadLinkSource, ral.roadType, ral.VVHRoadName, ral.roadName, ral.municipalityCode, ral.modifiedAt, ral.modifiedBy,
+      ral.constructionType, ral.roadLinkSource, ral.roadType, ral.VVHRoadName, ral.roadName, ral.municipalityCode, ral.municipalityName, ral.modifiedAt, ral.modifiedBy,
       ral.attributes, ral.roadNumber, ral.roadPartNumber, ral.trackCode, ral.elyCode, ral.discontinuity,
       ral.startAddressM, ral.endAddressM, ral.startMValue, ral.endMValue, ral.sideCode, ral.startCalibrationPoint, ral.endCalibrationPoint,
       ral.anomaly, LinkStatus.Unknown, ral.id, ral.linearLocationId)

--- a/viite-UI/src/view/LinkPropertyForm.js
+++ b/viite-UI/src/view/LinkPropertyForm.js
@@ -287,10 +287,13 @@
                 '<p class="form-control-static asset-log-info">Linkkien lukumäärä: ' + selectedLinkProperty.count() + '</p>' +
               '</div>' +
               '<div class="form-group">' +
-                '<p class="form-control-static asset-log-info">Geometrian lähde: ' + linkProperties.roadLinkSource + '</p>' +
+                '<p class="form-control-static asset-log-info">Geometrian lähde: ' + linkProperties.roadLinkSource + '; ' +
+                  'MTKID: ' + linkProperties.mmlId + '</p>' +
               '</div>' +
+              showMunicipality(selectedLinkProperty, linkProperties) +
               showLinkId(selectedLinkProperty, linkProperties) +
             '</div>' +
+            staticField('TIEN NIMI', firstSelectedLinkProperty.roadName) +
             staticField('TIENUMERO', firstSelectedLinkProperty.roadNumber) +
             staticField('TIEOSANUMERO', firstSelectedLinkProperty.roadPartNumber) +
             staticField('AJORATA', firstSelectedLinkProperty.trackCode) +
@@ -323,10 +326,13 @@
                 '<p class="form-control-static asset-log-info">Linkkien lukumäärä: ' + selectedLinkProperty.count() + '</p>' +
               '</div>' +
               '<div class="form-group">' +
-                '<p class="form-control-static asset-log-info">Geometrian lähde: ' + linkProperties.roadLinkSource + '</p>' +
+                '<p class="form-control-static asset-log-info">Geometrian lähde: ' + linkProperties.roadLinkSource + '; ' +
+                  'MTKID: ' + linkProperties.mmlId + '</p>' +
               '</div>' +
               showLinkId(selectedLinkProperty, linkProperties) +
+              showMunicipality(selectedLinkProperty, linkProperties) +
             '</div>' +
+            staticField('TIEN NIMI', firstSelectedLinkProperty.roadName) +
             staticField('TIENUMERO', firstSelectedLinkProperty.roadNumber) +
             staticField('TIEOSANUMERO', firstSelectedLinkProperty.roadPartNumber) +
             staticField('AJORATA', firstSelectedLinkProperty.trackCode) +
@@ -357,10 +363,16 @@
               '<p class="form-control-static asset-log-info">Linkkien lukumäärä: ' + selectedLinkProperty.count() + '</p>' +
             '</div>' +
             '<div class="form-group">' +
-              '<p class="form-control-static asset-log-info">Geometrian lähde: ' + linkProperties.roadLinkSource + '</p>' +
+              '<p class="form-control-static asset-log-info">Geometrian lähde: ' + linkProperties.roadLinkSource + '; ' +
+                'MTKID: ' + linkProperties.mmlId + '</p>' +
             '</div>' +
+            '<div class="form-group">' +
+              '<p id="municipality" class="form-control-static asset-log-info"></p>' +
+            '</div>' +
+            showMunicipality(selectedLinkProperty, linkProperties) +
             showLinkId(selectedLinkProperty, linkProperties) +
            '</div>' +
+            staticField('TIEN NIMI', firstSelectedLinkProperty.roadName) +
             staticField('TIENUMERO',firstSelectedLinkProperty.roadNumber) +
             staticField('TIEOSANUMERO', firstSelectedLinkProperty.roadPartNumber) +
             startAddress +
@@ -374,7 +386,7 @@
         '<footer>' + editButtons + '</footer> </div>');
     };
 
-    var showLinkId = function(selectedLinkProperty, linkProperties){
+    var showLinkId = function(selectedLinkProperty, linkProperties) {
         if (selectedLinkProperty.count () === 1) {
             return '' +
                 '<div class="form-group">' +
@@ -383,6 +395,18 @@
         } else {
             return '';
         }
+    };
+
+    var showMunicipality = function(selectedLinkProperty, linkProperties) {
+      // TODO add the case for same municipality in all the lnks
+      if (selectedLinkProperty.count() === 1) {
+        return '' +
+          '<div class="form-group">' +
+            '<p class="form-control-static asset-log-info">Kunta: ' + linkProperties.municipalityName + '</p>' +
+          '</div>';
+      } else {
+        return '';
+      }
     };
 
     var additionalSourceEventTriggering = function(rootElement, floatingToAdd, value, id) {

--- a/viite-UI/src/view/LinkPropertyForm.js
+++ b/viite-UI/src/view/LinkPropertyForm.js
@@ -273,6 +273,8 @@
       var roadTypes = selectedLinkProperty.count() === 1 ? staticField('TIETYYPPI', firstSelectedLinkProperty.roadTypeId) : roadTypeDynamicField();
       var startAddress = selectedLinkProperty.count() === 1 ? staticField('ALKUETÄISYYS', firstSelectedLinkProperty.startAddressM) : staticField('ALKUETÄISYYS', linkProperties.startAddressM);
       var endAddress = selectedLinkProperty.count() === 1 ? staticField('LOPPUETÄISYYS', firstSelectedLinkProperty.endAddressM) : staticField('LOPPUETÄISYYS', linkProperties.endAddressM);
+      var mtkId = selectedLinkProperty.count() === 1 ? '; MTKID: ' + linkProperties.mmlId : '';
+      var roadName = firstSelectedLinkProperty.roadName ? staticField('TIEN NIMI', firstSelectedLinkProperty.roadName) : '';
       return _.template('' +
         '<header>' +
           title() +
@@ -287,13 +289,12 @@
                 '<p class="form-control-static asset-log-info">Linkkien lukumäärä: ' + selectedLinkProperty.count() + '</p>' +
               '</div>' +
               '<div class="form-group">' +
-                '<p class="form-control-static asset-log-info">Geometrian lähde: ' + linkProperties.roadLinkSource + '; ' +
-                  'MTKID: ' + linkProperties.mmlId + '</p>' +
+                '<p class="form-control-static asset-log-info">Geometrian lähde: ' + linkProperties.roadLinkSource + mtkId + '</p>' +
               '</div>' +
-              showMunicipality(selectedLinkProperty, linkProperties) +
+              showMunicipality() +
               showLinkId(selectedLinkProperty, linkProperties) +
             '</div>' +
-            staticField('TIEN NIMI', firstSelectedLinkProperty.roadName) +
+            roadName +
             staticField('TIENUMERO', firstSelectedLinkProperty.roadNumber) +
             staticField('TIEOSANUMERO', firstSelectedLinkProperty.roadPartNumber) +
             staticField('AJORATA', firstSelectedLinkProperty.trackCode) +
@@ -312,6 +313,8 @@
       var startAddress = selectedLinkProperty.count() === 1 ? staticField('ALKUETÄISYYS', firstSelectedLinkProperty.startAddressM) : measureDynamicField('ALKUETÄISYYS', 'startAddressM');
       var endAddress = selectedLinkProperty.count() === 1 ? staticField('LOPPUETÄISYYS', firstSelectedLinkProperty.endAddressM) : measureDynamicField('LOPPUETÄISYYS', 'endAddressM');
       var roadTypes = selectedLinkProperty.count() === 1 ? staticField('TIETYYPPI', firstSelectedLinkProperty.roadTypeId) : roadTypeDynamicField();
+      var mtkId = selectedLinkProperty.count() === 1 ? '; MTKID: ' + linkProperties.mmlId : '';
+      var roadName = firstSelectedLinkProperty.roadName ? staticField('TIEN NIMI', firstSelectedLinkProperty.roadName) : '';
       return _.template('' +
         '<header>' +
           title() +
@@ -326,13 +329,12 @@
                 '<p class="form-control-static asset-log-info">Linkkien lukumäärä: ' + selectedLinkProperty.count() + '</p>' +
               '</div>' +
               '<div class="form-group">' +
-                '<p class="form-control-static asset-log-info">Geometrian lähde: ' + linkProperties.roadLinkSource + '; ' +
-                  'MTKID: ' + linkProperties.mmlId + '</p>' +
+                '<p class="form-control-static asset-log-info">Geometrian lähde: ' + linkProperties.roadLinkSource + mtkId + '</p>' +
               '</div>' +
+              showMunicipality() +
               showLinkId(selectedLinkProperty, linkProperties) +
-              showMunicipality(selectedLinkProperty, linkProperties) +
             '</div>' +
-            staticField('TIEN NIMI', firstSelectedLinkProperty.roadName) +
+            roadName +
             staticField('TIENUMERO', firstSelectedLinkProperty.roadNumber) +
             staticField('TIEOSANUMERO', firstSelectedLinkProperty.roadPartNumber) +
             staticField('AJORATA', firstSelectedLinkProperty.trackCode) +
@@ -349,6 +351,8 @@
       var startAddress = selectedLinkProperty.count() === 1 ? staticField('ALKUETÄISYYS', firstSelectedLinkProperty.startAddressM) : measureDynamicField('ALKUETÄISYYS', 'startAddressM');
       var endAddress = selectedLinkProperty.count() === 1 ? staticField('LOPPUETÄISYYS', firstSelectedLinkProperty.endAddressM) : measureDynamicField('LOPPUETÄISYYS', 'endAddressM');
       var roadTypes = selectedLinkProperty.count() === 1 ? staticField('TIETYYPPI', firstSelectedLinkProperty.roadTypeId) : roadTypeDynamicField();
+      var mtkId = selectedLinkProperty.count() === 1 ? '; MTKID: ' + linkProperties.mmlId : '';
+      var roadName = firstSelectedLinkProperty.roadName ? staticField('TIEN NIMI', firstSelectedLinkProperty.roadName) : '';
       return _.template('<div style="display: none" id="floatingEditModeForm">' +
         '<header>' +
           title() +
@@ -363,16 +367,15 @@
               '<p class="form-control-static asset-log-info">Linkkien lukumäärä: ' + selectedLinkProperty.count() + '</p>' +
             '</div>' +
             '<div class="form-group">' +
-              '<p class="form-control-static asset-log-info">Geometrian lähde: ' + linkProperties.roadLinkSource + '; ' +
-                'MTKID: ' + linkProperties.mmlId + '</p>' +
+              '<p class="form-control-static asset-log-info">Geometrian lähde: ' + linkProperties.roadLinkSource + mtkId + '</p>' +
             '</div>' +
             '<div class="form-group">' +
               '<p id="municipality" class="form-control-static asset-log-info"></p>' +
             '</div>' +
-            showMunicipality(selectedLinkProperty, linkProperties) +
+            showMunicipality() +
             showLinkId(selectedLinkProperty, linkProperties) +
            '</div>' +
-            staticField('TIEN NIMI', firstSelectedLinkProperty.roadName) +
+            roadName +
             staticField('TIENUMERO',firstSelectedLinkProperty.roadNumber) +
             staticField('TIEOSANUMERO', firstSelectedLinkProperty.roadPartNumber) +
             startAddress +
@@ -397,12 +400,17 @@
         }
     };
 
-    var showMunicipality = function(selectedLinkProperty, linkProperties) {
-      // TODO add the case for same municipality in all the lnks
-      if (selectedLinkProperty.count() === 1) {
+    var showMunicipality = function() {
+      var municipalityValue = _.reduce(selectedLinkProperty.get(), function (acc, link) {
+        return {
+          municipalityName: acc.municipalityName,
+          valid: acc.municipalityName === link.municipalityName
+        };
+      });
+      if ((selectedLinkProperty.count() === 1 || municipalityValue.valid) && municipalityValue.municipalityName) {
         return '' +
           '<div class="form-group">' +
-            '<p class="form-control-static asset-log-info">Kunta: ' + linkProperties.municipalityName + '</p>' +
+            '<p class="form-control-static asset-log-info">Kunta: ' + municipalityValue.municipalityName + '</p>' +
           '</div>';
       } else {
         return '';


### PR DESCRIPTION
What was changed:
1. **MTKID**: MtkId is displayed only when selecting a single link.

2. **Kunta**: When several links selected, the municipality name will **only** be displayed if it's the same for all of them.
 
3. **Tien nimi**: When road name is not defined the label will not be displayed.