### PR TITLE
VIITE-2061 Dif. Road types mixes the change table on new 2-track roads

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/ProjectDeltaCalculator.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/ProjectDeltaCalculator.scala
@@ -226,9 +226,9 @@ object ProjectDeltaCalculator {
       val matches = matchingTracks(paired, key)
       val target = targetToMap.map(t => t.copy(projectLinks = projectLinks.filter(link => link.roadNumber == t.roadNumber && link.roadPartNumber == t.roadPartNumberEnd && link.track == t.track && link.roadType == t.roadType && link.ely == t.ely &&
         link.startAddrMValue >= t.startMAddr && link.endAddrMValue <= t.endMAddr)))
-      if (matches.nonEmpty && matches.get.lengthCompare(target.length) == 0 && matchesFitOnTarget(target, matches.get))
-        adjustTrack((target, matches.get))
-      else
+      if (matches.nonEmpty && matches.get.lengthCompare(target.length) == 0 && matchesFitOnTarget(target, matches.get)){
+        adjustTrack((target.sortBy(_.startMAddr), matches.get.sortBy(_.startMAddr)))
+      } else
         target
     }.toSeq
     result

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/ProjectDeltaCalculator.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/ProjectDeltaCalculator.scala
@@ -226,7 +226,7 @@ object ProjectDeltaCalculator {
       val matches = matchingTracks(paired, key)
       val target = targetToMap.map(t => t.copy(projectLinks = projectLinks.filter(link => link.roadNumber == t.roadNumber && link.roadPartNumber == t.roadPartNumberEnd && link.track == t.track && link.roadType == t.roadType && link.ely == t.ely &&
         link.startAddrMValue >= t.startMAddr && link.endAddrMValue <= t.endMAddr)))
-      if (matches.nonEmpty && matches.get.lengthCompare(target.length) == 0 && matchesFitOnTarget(target, matches.get)){
+      if (matches.nonEmpty && matches.get.lengthCompare(target.length) == 0 && matchesFitOnTarget(target, matches.get)) {
         adjustTrack((target.sortBy(_.startMAddr), matches.get.sortBy(_.startMAddr)))
       } else
         target


### PR DESCRIPTION
Adjust between both tracks should be made according to their "rowchanges" ascending order.