### PR TITLE
VIITE-2069 Termination has differences between AET and LET values for track 1 and 2

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/ProjectSectionCalculator.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/ProjectSectionCalculator.scala
@@ -114,7 +114,7 @@ object ProjectSectionCalculator {
 
         val (adjustedRestRight, adjustedRestLeft) = adjustTracksToMatch(trackCalcResult.restLeft ++ restLeft, trackCalcResult.restRight ++ restRight, Some(trackCalcResult.endAddrMValue))
 
-        (trackCalcResult.leftProjectLinks++adjustedRestRight, trackCalcResult.rightProjectLinks++adjustedRestLeft)
+        (trackCalcResult.leftProjectLinks ++ adjustedRestRight, trackCalcResult.rightProjectLinks ++ adjustedRestLeft)
       }
     }
 


### PR DESCRIPTION
VIITE-2069 even though name of the branch is VIITE-2062.

We were joining unchanged(or other) track 2 with terminated track 1 in left list
And joining unchanged(or other) track 1 with terminated 2 in right list.
