### PR TITLE
VIITE-1995 added message to warn user that connection to VKM failed

### DIFF
--- a/viite-UI/src/view/navigationpanel/SearchBox.js
+++ b/viite-UI/src/view/navigationpanel/SearchBox.js
@@ -1,5 +1,7 @@
 (function(root) {
   root.SearchBox = function(instructionsPopup, locationSearch) {
+    var INTERNAL_SERVER_ERROR_500 = 500;
+
     var tooltip = "Hae katuosoitteella, tieosoitteella tai koordinaateilla";
     var groupDiv = $('<div id="searchBox" class="panel-group search-box"/>');
     var coordinatesDiv = $('<div class="panel"/>');
@@ -49,7 +51,10 @@
             var result = results[0];
             eventbus.trigger('coordinates:selected', { lon: result.lon, lat: result.lat });
           }
-        }).fail(showDialog);
+        }).fail(function (message) {
+          if (!_.isUndefined(message) && message.status === INTERNAL_SERVER_ERROR_500) { message = "Yhteys Viitekehysmuuntimeen epäonnistui"; }
+          showDialog(message);
+        });
       };
 
       coordinatesText.keypress(function(event) {


### PR DESCRIPTION
If VKM connection fails, the user will no longer see an "[object Object]" text on the screen, instead, the message "_Yhteys Viitekehysmuuntimeen epäonnistui_" will be displayed.