### PR TITLE
VIITE-2196 Getting reverse flag from the initial import data for the …

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/util/RoadAddressImporter.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/util/RoadAddressImporter.scala
@@ -285,9 +285,8 @@ class RoadAddressImporter(conversionDatabase: DatabaseDef, vvhClient: VVHClient,
         val maxAddress = addresses.last._1
         val linkIds = addresses.map(_._1.linkId)
         val currentAddresses = currentConversionAddresses.filter(add => add.roadwayNumber == minAddress.roadwayNumber && linkIds.contains(add.linkId)).sortBy(_.startAddressM)
-        val isReversed = if (currentAddresses.head.linkId == minAddress.linkId && currentAddresses.head.startM == minAddress.startM) 1 else 0
 
-        val roadAddress = IncomingRoadway(minAddress.roadwayNumber, minAddress.roadNumber, minAddress.roadPartNumber, minAddress.trackCode, minAddress.startAddressM, maxAddress.endAddressM, isReversed, minAddress.startDate,
+        val roadAddress = IncomingRoadway(minAddress.roadwayNumber, minAddress.roadNumber, minAddress.roadPartNumber, minAddress.trackCode, minAddress.startAddressM, maxAddress.endAddressM, minAddress.directionFlag, minAddress.startDate,
           minAddress.endDate, "import", minAddress.roadType, minAddress.ely, minAddress.validFrom, None, maxAddress.discontinuity, terminated = NoTermination.value)
 
         insertRoadway(roadwayPs, roadAddress)


### PR DESCRIPTION
…historical roadways.

In initial import data the reversed flag is same for all the rows in one roadway in one history layer, so this implementation should be correct.