### PR TITLE
VIITE-2304 check existence of empty valid junction points in junction

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/NodesAndJunctionsService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/NodesAndJunctionsService.scala
@@ -773,6 +773,7 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
               Seq.empty[JunctionPoint]
             else
               junctionPointsToCheck
+          case _ => Seq.empty[JunctionPoint]
         }
         affectedJunctionsPoints
       }


### PR DESCRIPTION
Existing valid junction points "can be empty" for yet not expired Junctions.
This can happen if they were already expired in previous iterations for other road parts.