### PR TITLE
ViiteProperties.vvhRoadlinkFrozen is boolean, not string.

### DIFF
--- a/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Context.scala
+++ b/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Context.scala
@@ -8,11 +8,11 @@ import fi.liikennevirasto.digiroad2.municipality.MunicipalityProvider
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.user.UserProvider
 import fi.liikennevirasto.digiroad2.util.ViiteProperties
-import fi.liikennevirasto.viite.{NodesAndJunctionsService, ProjectService, RoadAddressService, RoadCheckOptions, RoadNameService, RoadNetworkService}
-import fi.liikennevirasto.viite.util.JsonSerializer
 import fi.liikennevirasto.viite.dao._
 import fi.liikennevirasto.viite.process.RoadAddressFiller.ChangeSet
 import fi.liikennevirasto.viite.process.RoadwayAddressMapper
+import fi.liikennevirasto.viite.util.JsonSerializer
+import fi.liikennevirasto.viite.{NodesAndJunctionsService, ProjectService, RoadAddressService, RoadCheckOptions, RoadNameService, RoadNetworkService}
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.concurrent.duration.FiniteDuration
@@ -96,9 +96,8 @@ object Digiroad2Context {
   val roadNetworkChecker: ActorRef = system.actorOf(Props(classOf[RoadNetworkChecker], roadNetworkService), name = "roadNetworkChecker")
   eventbus.subscribe(roadNetworkChecker, "roadAddress:RoadNetworkChecker")
 
-  lazy val roadAddressService: RoadAddressService = {
-    new RoadAddressService(roadLinkService, roadwayDAO, linearLocationDAO, roadNetworkDAO, roadwayPointDAO, nodePointDAO, junctionPointDAO, roadwayAddressMapper, eventbus, ViiteProperties.vvhRoadlinkFrozen)
-  }
+  lazy val roadAddressService: RoadAddressService = new RoadAddressService(roadLinkService, roadwayDAO, linearLocationDAO,
+    roadNetworkDAO, roadwayPointDAO, nodePointDAO, junctionPointDAO, roadwayAddressMapper, eventbus, ViiteProperties.vvhRoadlinkFrozen)
 
   lazy val projectService: ProjectService = {
     new ProjectService(roadAddressService, roadLinkService, nodesAndJunctionsService, roadwayDAO,

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/client/VVHClientSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/client/VVHClientSpec.scala
@@ -1,62 +1,59 @@
 package fi.liikennevirasto.digiroad2.client
 
+import com.vividsolutions.jts.geom.GeometryFactory
 import fi.liikennevirasto.digiroad2.Point
 import fi.liikennevirasto.digiroad2.asset.BoundingRectangle
 import fi.liikennevirasto.digiroad2.client.vvh.VVHClient
 import fi.liikennevirasto.digiroad2.util.ViiteProperties
 import org.geotools.geometry.jts.GeometryBuilder
-import com.vividsolutions.jts.geom.GeometryFactory
 import org.scalatest.{FunSuite, Matchers}
 
-import scala.concurrent.Await
-import scala.concurrent.duration.Duration
+class VVHClientSpec extends FunSuite with Matchers {
 
-class VVHClientSpec extends FunSuite with Matchers{
-
-  val geomFact= new GeometryFactory()
+  val geomFact = new GeometryFactory()
   val geomBuilder = new GeometryBuilder(geomFact)
 
   /**
     * Checks that VVH history bounding box search works uses API example bounding box so it should receive results
     */
   test("Test fetchByMunicipalitiesAndBounds When connecting to VVH roadLink history and retrieve result Then it should indeed result some") {
-    val vvhClient= new VVHClient(ViiteProperties.vvhRestApiEndPoint)
-    val result= vvhClient.historyData.fetchByMunicipalitiesAndBounds(BoundingRectangle(Point(564000, 6930000),Point(566000, 6931000)), Set(420))
-    result.size should be >1
+    val vvhClient = new VVHClient(ViiteProperties.vvhRestApiEndPoint)
+    val result = vvhClient.historyData.fetchByMunicipalitiesAndBounds(BoundingRectangle(Point(564000, 6930000), Point(566000, 6931000)), Set(420))
+    result.size should be > 1
   }
 
   /**
     * Checks that VVH history link id search works and returns something
     */
   test("Test fetchVVHRoadLinkByLinkIds When connecting to VVH roadLink history and giving some linkIds Then should be returned some data") {
-    val vvhClient= new VVHClient(ViiteProperties.vvhRestApiEndPoint)
-    val result = vvhClient.historyData.fetchVVHRoadLinkByLinkIds(Set(440484,440606,440405,440489))
-    result.nonEmpty should be (true)
+    val vvhClient = new VVHClient(ViiteProperties.vvhRestApiEndPoint)
+    val result = vvhClient.historyData.fetchVVHRoadLinkByLinkIds(Set(440484, 440606, 440405, 440489))
+    result.nonEmpty should be(true)
   }
 
   test("Test fetchByBoundsAndMunicipalities When connecting to VVH ChangeInfo and giving some bounding box Then should return some data") {
-    val vvhClient= new VVHClient(ViiteProperties.vvhRestApiEndPoint)
-    val result= vvhClient.roadLinkChangeInfo.fetchByBoundsAndMunicipalities(BoundingRectangle(Point(532578.3338013917,6993401.605560873,0.0),Point(532978.3338013917,6994261.605560873,0.0)), Set.empty[Int])
-    result.size should be >1
+    val vvhClient = new VVHClient(ViiteProperties.vvhRestApiEndPoint)
+    val result = vvhClient.roadLinkChangeInfo.fetchByBoundsAndMunicipalities(BoundingRectangle(Point(532578.3338013917, 6993401.605560873, 0.0), Point(532978.3338013917, 6994261.605560873, 0.0)), Set.empty[Int])
+    result.size should be > 1
   }
 
   /**
-    * Test for frozen december 15.12.2016 VVH API: No test cases writen to documentation so test might fail for not having any links
-  */
+    * Test for frozen december 15.12.2016 VVH API: No test cases written to documentation so test might fail for not having any links
+    */
 
   test("Test fetchByBounds When giving some bounding box Then should return some data") {
     val frozenApiEnabled = ViiteProperties.vvhRoadlinkFrozen
-    if (frozenApiEnabled=="true") { //Api only exists in QA and Production
-      val vvhClient= new VVHClient(ViiteProperties.vvhRestApiEndPoint)
-      val result= vvhClient.frozenTimeRoadLinkData.fetchByBounds(BoundingRectangle(Point(445000, 7000000),Point(446000, 7005244)))
-      result.size should be >1
+    if (frozenApiEnabled == true) {
+      val vvhClient = new VVHClient(ViiteProperties.vvhRestApiEndPoint)
+      val result = vvhClient.frozenTimeRoadLinkData.fetchByBounds(BoundingRectangle(Point(445000, 7000000), Point(446000, 7005244)))
+      result.size should be > 1
     }
   }
 
   test("Test fetchByLinkIds When connecting to VVH ChangeInfo and giving one linkId Then should return some data") {
-    val vvhClient= new VVHClient(ViiteProperties.vvhRestApiEndPoint)
+    val vvhClient = new VVHClient(ViiteProperties.vvhRestApiEndPoint)
     val result = vvhClient.roadLinkChangeInfo.fetchByLinkIds(Set(5176799))
-    result.nonEmpty should be (true)
+    result.nonEmpty should be(true)
   }
 }
 

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectValidator.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectValidator.scala
@@ -31,7 +31,10 @@ class ProjectValidator {
   val roadwayPointDAO = new RoadwayPointDAO
   val nodePointDAO = new NodePointDAO
   val junctionPointDAO = new JunctionPointDAO
-  val roadAddressService = new RoadAddressService(linkService, roadwayDAO, linearLocationDAO, roadNetworkDAO, roadwayPointDAO, nodePointDAO, junctionPointDAO, new RoadwayAddressMapper(roadwayDAO, linearLocationDAO), eventBus, ViiteProperties.vvhRoadlinkFrozen) {
+  val roadAddressService = new RoadAddressService(linkService, roadwayDAO, linearLocationDAO, roadNetworkDAO,
+    roadwayPointDAO, nodePointDAO, junctionPointDAO, new RoadwayAddressMapper(roadwayDAO, linearLocationDAO), eventBus,
+    ViiteProperties.vvhRoadlinkFrozen) {
+
     override def withDynSession[T](f: => T): T = f
 
     override def withDynTransaction[T](f: => T): T = f

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilder.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilder.scala
@@ -17,7 +17,10 @@ class RoadAddressLinkBuilder(roadwayDAO: RoadwayDAO, linearLocationDAO: LinearLo
   val vvhClient = new VVHClient(ViiteProperties.vvhRestApiEndPoint)
   val eventBus = new DummyEventBus
   val linkService = new RoadLinkService(vvhClient, eventBus, new DummySerializer, ViiteProperties.vvhRoadlinkFrozen)
-  val roadAddressService = new RoadAddressService(linkService, roadwayDAO, linearLocationDAO, new RoadNetworkDAO, new RoadwayPointDAO, new NodePointDAO, new JunctionPointDAO, new RoadwayAddressMapper(roadwayDAO, linearLocationDAO), eventBus, ViiteProperties.vvhRoadlinkFrozen) {
+  val roadAddressService = new RoadAddressService(linkService, roadwayDAO, linearLocationDAO, new RoadNetworkDAO,
+    new RoadwayPointDAO, new NodePointDAO, new JunctionPointDAO, new RoadwayAddressMapper(roadwayDAO, linearLocationDAO),
+    eventBus, ViiteProperties.vvhRoadlinkFrozen) {
+
     override def withDynSession[T](f: => T): T = f
     override def withDynTransaction[T](f: => T): T = f
   }

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
@@ -25,7 +25,10 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 import scala.util.control.NonFatal
 
-class RoadAddressService(roadLinkService: RoadLinkService, roadwayDAO: RoadwayDAO, linearLocationDAO: LinearLocationDAO, roadNetworkDAO: RoadNetworkDAO, roadwayPointDAO: RoadwayPointDAO, nodePointDAO: NodePointDAO, junctionPointDAO: JunctionPointDAO, roadwayAddressMapper: RoadwayAddressMapper, eventbus: DigiroadEventBus, frozenTimeVVHAPIServiceEnabled: Boolean = false) {
+class RoadAddressService(roadLinkService: RoadLinkService, roadwayDAO: RoadwayDAO, linearLocationDAO: LinearLocationDAO,
+                         roadNetworkDAO: RoadNetworkDAO, roadwayPointDAO: RoadwayPointDAO, nodePointDAO: NodePointDAO,
+                         junctionPointDAO: JunctionPointDAO, roadwayAddressMapper: RoadwayAddressMapper,
+                         eventbus: DigiroadEventBus, frozenVVH: Boolean) {
 
   def withDynTransaction[T](f: => T): T = OracleDatabase.withDynTransaction(f)
 
@@ -97,8 +100,8 @@ class RoadAddressService(roadLinkService: RoadLinkService, roadwayDAO: RoadwayDA
     val allRoadLinks = roadLinks ++ complementaryRoadLinks
 
     //removed apply changes before adjusting topology since in future NLS will give perfect geometry and supposedly, we will not need any changes
-    val (adjustedLinearLocations, changeSet) = if (frozenTimeVVHAPIServiceEnabled) (linearLocations, Seq()) else RoadAddressFiller.adjustToTopology(allRoadLinks, linearLocations)
-    if (!frozenTimeVVHAPIServiceEnabled)
+    val (adjustedLinearLocations, changeSet) = if (frozenVVH) (linearLocations, Seq()) else RoadAddressFiller.adjustToTopology(allRoadLinks, linearLocations)
+    if (!frozenVVH)
       eventbus.publish("roadAddress:persistChangeSet", changeSet)
 
     val roadAddresses = withDynSession {
@@ -196,8 +199,8 @@ class RoadAddressService(roadLinkService: RoadLinkService, roadwayDAO: RoadwayDA
         linearLocationDAO.fetchRoadwayByLinkId(roadLinks.map(_.linkId).toSet)
       }
     }
-    val (adjustedLinearLocations, changeSet) = if (frozenTimeVVHAPIServiceEnabled) (linearLocations, Seq()) else RoadAddressFiller.adjustToTopology(roadLinks, linearLocations)
-    if (!frozenTimeVVHAPIServiceEnabled) {
+    val (adjustedLinearLocations, changeSet) = if (frozenVVH) (linearLocations, Seq()) else RoadAddressFiller.adjustToTopology(roadLinks, linearLocations)
+    if (!frozenVVH) {
       //TODO we should think to update both servers with cache at the same time, and before the apply change batch that way we will not need to do any kind of changes here
       eventbus.publish("roadAddress:persistChangeSet", changeSet)
     }

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/NodesAndJunctionsServiceSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/NodesAndJunctionsServiceSpec.scala
@@ -50,7 +50,10 @@ class NodesAndJunctionsServiceSpec extends FunSuite with Matchers with BeforeAnd
   val projectLinkDAO = new ProjectLinkDAO
   val projectReservedPartDAO = new ProjectReservedPartDAO
   val roadwayAddressMapper = new RoadwayAddressMapper(roadwayDAO, linearLocationDAO)
-  val roadAddressService: RoadAddressService = new RoadAddressService(mockRoadLinkService, new RoadwayDAO, new LinearLocationDAO, new RoadNetworkDAO, roadwayPointDAO, nodePointDAO, junctionPointDAO, mockRoadwayAddressMapper, mockEventBus) {
+  val roadAddressService: RoadAddressService = new RoadAddressService(mockRoadLinkService, new RoadwayDAO,
+    new LinearLocationDAO, new RoadNetworkDAO, roadwayPointDAO, nodePointDAO, junctionPointDAO,
+    mockRoadwayAddressMapper, mockEventBus, frozenVVH = false) {
+
     override def withDynSession[T](f: => T): T = f
 
     override def withDynTransaction[T](f: => T): T = f

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectLinkNameDAOSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectLinkNameDAOSpec.scala
@@ -45,7 +45,10 @@ class ProjectLinkNameDAOSpec extends FunSuite with Matchers with BeforeAndAfter 
   val mockLinearLocationDAO = MockitoSugar.mock[LinearLocationDAO]
   val mockRoadwayChangesDAO = MockitoSugar.mock[RoadwayChangesDAO]
 
-  val roadAddressServiceRealRoadwayAddressMapper = new RoadAddressService(mockRoadLinkService, roadwayDAO, linearLocationDAO, roadNetworkDAO, roadwayPointDAO, nodePointDAO, junctionPointDAO, roadwayAddressMapper, mockEventBus) {
+  val roadAddressServiceRealRoadwayAddressMapper = new RoadAddressService(mockRoadLinkService, roadwayDAO,
+    linearLocationDAO, roadNetworkDAO, roadwayPointDAO, nodePointDAO, junctionPointDAO, roadwayAddressMapper,
+    mockEventBus, frozenVVH = false) {
+
     override def withDynSession[T](f: => T): T = f
 
     override def withDynTransaction[T](f: => T): T = f

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceLinkSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceLinkSpec.scala
@@ -50,7 +50,9 @@ class ProjectServiceLinkSpec extends FunSuite with Matchers with BeforeAndAfter 
   val projectReservedPartDAO = new ProjectReservedPartDAO
   val roadwayAddressMapper = new RoadwayAddressMapper(roadwayDAO, linearLocationDAO)
 
-  val roadAddressService: RoadAddressService = new RoadAddressService(mockRoadLinkService, roadwayDAO, linearLocationDAO, roadNetworkDAO, roadwayPointDAO, nodePointDAO, junctionPointDAO, roadwayAddressMapper, mockEventBus) {
+  val roadAddressService: RoadAddressService = new RoadAddressService(mockRoadLinkService, roadwayDAO, linearLocationDAO,
+    roadNetworkDAO, roadwayPointDAO, nodePointDAO, junctionPointDAO, roadwayAddressMapper, mockEventBus, frozenVVH = false) {
+
     override def withDynSession[T](f: => T): T = f
 
     override def withDynTransaction[T](f: => T): T = f

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
@@ -70,12 +70,17 @@ class ProjectServiceSpec extends FunSuite with Matchers with BeforeAndAfter {
 
   val mockRoadwayAddressMapper: RoadwayAddressMapper = MockitoSugar.mock[RoadwayAddressMapper]
 
-  val roadAddressService: RoadAddressService = new RoadAddressService(mockRoadLinkService, roadwayDAO, linearLocationDAO, roadNetworkDAO, roadwayPointDAO, nodePointDAO, junctionPointDAO, mockRoadwayAddressMapper, mockEventBus) {
+  val roadAddressService: RoadAddressService = new RoadAddressService(mockRoadLinkService, roadwayDAO, linearLocationDAO,
+    roadNetworkDAO, roadwayPointDAO, nodePointDAO, junctionPointDAO, mockRoadwayAddressMapper, mockEventBus, frozenVVH = false) {
+
     override def withDynSession[T](f: => T): T = f
 
     override def withDynTransaction[T](f: => T): T = f
   }
-  val roadAddressServiceRealRoadwayAddressMapper: RoadAddressService = new RoadAddressService(mockRoadLinkService, roadwayDAO, linearLocationDAO, roadNetworkDAO, roadwayPointDAO, nodePointDAO, junctionPointDAO, roadwayAddressMapper, mockEventBus) {
+  val roadAddressServiceRealRoadwayAddressMapper: RoadAddressService = new RoadAddressService(mockRoadLinkService,
+    roadwayDAO, linearLocationDAO, roadNetworkDAO, roadwayPointDAO, nodePointDAO, junctionPointDAO, roadwayAddressMapper,
+    mockEventBus, frozenVVH = false) {
+
     override def withDynSession[T](f: => T): T = f
 
     override def withDynTransaction[T](f: => T): T = f

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceTRSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceTRSpec.scala
@@ -40,7 +40,9 @@ class ProjectServiceTRSpec extends FunSuite with Matchers with BeforeAndAfter {
   val projectReservedPartDAO = new ProjectReservedPartDAO
   val roadNetworkDAO = new RoadNetworkDAO
   val roadwayAddressMapper = new RoadwayAddressMapper(roadwayDAO, linearLocationDAO)
-  val roadAddressService: RoadAddressService = new RoadAddressService(mockRoadLinkService, roadwayDAO, linearLocationDAO, roadNetworkDAO, roadwayPointDAO, nodePointDAO, junctionPointDAO, mockRoadwayAddressMapper, mockEventBus) {
+  val roadAddressService: RoadAddressService = new RoadAddressService(mockRoadLinkService, roadwayDAO, linearLocationDAO,
+    roadNetworkDAO, roadwayPointDAO, nodePointDAO, junctionPointDAO, mockRoadwayAddressMapper, mockEventBus, frozenVVH = false) {
+
     override def withDynSession[T](f: => T): T = f
 
     override def withDynTransaction[T](f: => T): T = f

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilderSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilderSpec.scala
@@ -59,7 +59,9 @@ class RoadAddressLinkBuilderSpec extends FunSuite with Matchers {
   val junctionPointDAO = new JunctionPointDAO
   val roadwayChangesDAO = new RoadwayChangesDAO
   val roadwayAddressMapper = new RoadwayAddressMapper(roadwayDAO, linearLocationDAO)
-  val roadAddressService = new RoadAddressService(mockRoadLinkService, mockRoadwayDAO, mockLinearLocationDAO, mockRoadNetworkDAO, mockRoadwayPointDAO, mockNodePointDAO, mockJunctionPointDAO, mockRoadwayAddressMapper, mockEventBus) {
+  val roadAddressService = new RoadAddressService(mockRoadLinkService, mockRoadwayDAO, mockLinearLocationDAO,
+    mockRoadNetworkDAO, mockRoadwayPointDAO, mockNodePointDAO, mockJunctionPointDAO, mockRoadwayAddressMapper, mockEventBus, frozenVVH = false) {
+
     override def withDynSession[T](f: => T): T = f
 
     override def withDynTransaction[T](f: => T): T = f

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/RoadAddressServiceSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/RoadAddressServiceSpec.scala
@@ -53,7 +53,9 @@ class RoadAddressServiceSpec extends FunSuite with Matchers{
   val linearLocationDAO = new LinearLocationDAO
   val roadwayAddressMapper = new RoadwayAddressMapper(roadwayDAO, linearLocationDAO)
   val mockViiteVkmClient: ViiteVkmClient = MockitoSugar.mock[ViiteVkmClient]
-  val roadAddressService: RoadAddressService = new RoadAddressService(mockRoadLinkService, mockRoadwayDAO, mockLinearLocationDAO, mockRoadNetworkDAO, roadwayPointDAO, nodePointDAO, junctionPointDAO, roadwayAddressMappper, mockEventBus) {
+  val roadAddressService: RoadAddressService = new RoadAddressService(mockRoadLinkService, mockRoadwayDAO, mockLinearLocationDAO,
+    mockRoadNetworkDAO, roadwayPointDAO, nodePointDAO, junctionPointDAO, roadwayAddressMappper, mockEventBus, frozenVVH = false) {
+
     override def withDynSession[T](f: => T): T = f
     override def withDynTransaction[T](f: => T): T = f
     override val viiteVkmClient = mockViiteVkmClient

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/ProjectSectionCalculatorSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/ProjectSectionCalculatorSpec.scala
@@ -39,8 +39,9 @@ class ProjectSectionCalculatorSpec extends FunSuite with Matchers {
   val linearLocationDAO = new LinearLocationDAO
   val roadNetworkDAO = new RoadNetworkDAO
   val roadwayAddressMapper = new RoadwayAddressMapper(roadwayDAO, linearLocationDAO)
-  val roadAddressService: RoadAddressService {
-  } = new RoadAddressService(mockRoadLinkService, roadwayDAO, linearLocationDAO, roadNetworkDAO, roadwayPointDAO, nodePointDAO, junctionPointDAO, mockRoadwayAddressMapper, mockEventBus) {
+  val roadAddressService: RoadAddressService = new RoadAddressService(mockRoadLinkService, roadwayDAO, linearLocationDAO,
+    roadNetworkDAO, roadwayPointDAO, nodePointDAO, junctionPointDAO, mockRoadwayAddressMapper, mockEventBus, frozenVVH = false) {
+
     override def withDynSession[T](f: => T): T = f
 
     override def withDynTransaction[T](f: => T): T = f

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/RoadwayFillerSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/RoadwayFillerSpec.scala
@@ -49,7 +49,9 @@ class RoadwayFillerSpec extends FunSuite with Matchers with BeforeAndAfter {
   val roadwayChangesDAO = new RoadwayChangesDAO
   val roadwayAddressMapper = new RoadwayAddressMapper(roadwayDAO, linearLocationDAO)
   val mockRoadwayAddressMapper: RoadwayAddressMapper = MockitoSugar.mock[RoadwayAddressMapper]
-  val roadAddressService: RoadAddressService = new RoadAddressService(mockRoadLinkService, roadwayDAO, linearLocationDAO, roadNetworkDAO, roadwayPointDAO, nodePointDAO, junctionPointDAO, mockRoadwayAddressMapper, mockEventBus) {
+  val roadAddressService: RoadAddressService = new RoadAddressService(mockRoadLinkService, roadwayDAO, linearLocationDAO,
+    roadNetworkDAO, roadwayPointDAO, nodePointDAO, junctionPointDAO, mockRoadwayAddressMapper, mockEventBus, frozenVVH = false) {
+
     override def withDynSession[T](f: => T): T = f
 
     override def withDynTransaction[T](f: => T): T = f

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/util/DataFixture.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/util/DataFixture.scala
@@ -36,7 +36,9 @@ object DataFixture {
   val roadwayPointDAO = new RoadwayPointDAO
   val nodePointDAO = new NodePointDAO
   val junctionPointDAO = new JunctionPointDAO
-  val roadAddressService = new RoadAddressService(linkService, roadAddressDAO, linearLocationDAO, roadNetworkDAO, roadwayPointDAO, nodePointDAO, junctionPointDAO, new RoadwayAddressMapper(roadAddressDAO, linearLocationDAO), eventBus, ViiteProperties.vvhRoadlinkFrozen)
+  val roadAddressService = new RoadAddressService(linkService, roadAddressDAO, linearLocationDAO, roadNetworkDAO,
+    roadwayPointDAO, nodePointDAO, junctionPointDAO, new RoadwayAddressMapper(roadAddressDAO, linearLocationDAO),
+    eventBus, ViiteProperties.vvhRoadlinkFrozen)
 
   lazy val continuityChecker = new ContinuityChecker(new RoadLinkService(vvhClient, new DummyEventBus, new DummySerializer, geometryFrozen))
 

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/util/ProjectLinkSplitterSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/util/ProjectLinkSplitterSpec.scala
@@ -46,7 +46,9 @@ class ProjectLinkSplitterSpec extends FunSuite with Matchers with BeforeAndAfter
   val junctionPointDAO = new JunctionPointDAO
   val roadwayChangesDAO = new RoadwayChangesDAO
   val roadwayAddressMapper = new RoadwayAddressMapper(roadwayDAO, linearLocationDAO)
-  val roadAddressService = new RoadAddressService(mockRoadLinkService, roadwayDAO, linearLocationDAO, roadNetworkDAO, roadwayPointDAO, nodePointDAO, junctionPointDAO, mockRoadwayAddressMapper, mockEventBus) {
+  val roadAddressService = new RoadAddressService(mockRoadLinkService, roadwayDAO, linearLocationDAO, roadNetworkDAO,
+    roadwayPointDAO, nodePointDAO, junctionPointDAO, mockRoadwayAddressMapper, mockEventBus, frozenVVH = false) {
+
     override def withDynSession[T](f: => T): T = f
 
     override def withDynTransaction[T](f: => T): T = f


### PR DESCRIPTION
RoadAddressService does not give default value for vvhFrozen parameter any more.