### PR TITLE
Viite 2358 fix to production

### DIFF
--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/GeometryUtils.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/GeometryUtils.scala
@@ -1,7 +1,9 @@
 package fi.liikennevirasto
 
-import fi.liikennevirasto.digiroad2.{Point, Vector3d}
+import fi.liikennevirasto.digiroad2.asset.SideCode
+import fi.liikennevirasto.digiroad2.asset.SideCode.AgainstDigitizing
 import fi.liikennevirasto.digiroad2.linearasset.PolyLine
+import fi.liikennevirasto.digiroad2.{Point, Vector3d}
 
 object GeometryUtils {
 
@@ -25,6 +27,11 @@ object GeometryUtils {
 
   def truncateGeometry2D(geometry: Seq[Point], startMeasure: Double, endMeasure: Double): Seq[Point] = {
     truncateGeometry3D(geometry.map(p => to2DGeometry(p)), startMeasure, endMeasure)
+  }
+
+  def truncateGeometry3D(sideCode: SideCode, geometry: Seq[Point], startMeasure: Double, endMeasure: Double): Seq[Point] = {
+    if(sideCode == AgainstDigitizing) GeometryUtils.truncateGeometry3D(geometry.reverse, startMeasure, endMeasure).reverse
+    else truncateGeometry3D(geometry, startMeasure, endMeasure)
   }
 
   def truncateGeometry3D(geometry: Seq[Point], startMeasure: Double, endMeasure: Double): Seq[Point] = {

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/GeometryUtils.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/GeometryUtils.scala
@@ -1,7 +1,5 @@
 package fi.liikennevirasto
 
-import fi.liikennevirasto.digiroad2.asset.SideCode
-import fi.liikennevirasto.digiroad2.asset.SideCode.AgainstDigitizing
 import fi.liikennevirasto.digiroad2.linearasset.PolyLine
 import fi.liikennevirasto.digiroad2.{Point, Vector3d}
 
@@ -27,11 +25,6 @@ object GeometryUtils {
 
   def truncateGeometry2D(geometry: Seq[Point], startMeasure: Double, endMeasure: Double): Seq[Point] = {
     truncateGeometry3D(geometry.map(p => to2DGeometry(p)), startMeasure, endMeasure)
-  }
-
-  def truncateGeometry3D(sideCode: SideCode, geometry: Seq[Point], startMeasure: Double, endMeasure: Double): Seq[Point] = {
-    if(sideCode == AgainstDigitizing) GeometryUtils.truncateGeometry3D(geometry.reverse, startMeasure, endMeasure).reverse
-    else truncateGeometry3D(geometry, startMeasure, endMeasure)
   }
 
   def truncateGeometry3D(geometry: Seq[Point], startMeasure: Double, endMeasure: Double): Seq[Point] = {

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -1452,6 +1452,7 @@ class ProjectService(roadAddressService: RoadAddressService, roadLinkService: Ro
       val assignedTerminatedRoadwayNumbers = assignTerminatedRoadwayNumbers(others ++ recalculatedTerminated)
       val originalAddresses = roadAddressService.getRoadAddressesByRoadwayIds((recalculated ++ recalculatedTerminated).map(_.roadwayId))
       projectLinkDAO.updateProjectLinks(recalculated ++ assignedTerminatedRoadwayNumbers, userName, originalAddresses)
+      projectLinkDAO.create(recalculated.filterNot(r => others.exists(_.id == r.id)).map(_.copy(createdBy = Some(userName))))
     }
   }
 

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilder.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilder.scala
@@ -6,7 +6,7 @@ import fi.liikennevirasto.GeometryUtils
 import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.{Unknown => _, apply => _}
 import fi.liikennevirasto.digiroad2.asset.{LinkGeomSource, _}
-import fi.liikennevirasto.digiroad2.client.vvh.{VVHClient, VVHHistoryRoadLink, VVHRoadlink}
+import fi.liikennevirasto.digiroad2.client.vvh.VVHClient
 import fi.liikennevirasto.digiroad2.linearasset.{RoadLink, RoadLinkLike}
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.util.Track
@@ -32,7 +32,7 @@ class RoadAddressLinkBuilder(roadwayDAO: RoadwayDAO, linearLocationDAO: LinearLo
   val roadwayAddressMapper = new RoadwayAddressMapper(roadwayDAO, linearLocationDAO)
 
   def build(roadLink: RoadLinkLike, roadAddress: RoadAddress): RoadAddressLink = {
-    val geom = GeometryUtils.truncateGeometry3D(roadLink.geometry, roadAddress.startMValue, roadAddress.endMValue)
+    val geom = GeometryUtils.truncateGeometry3D(roadAddress.sideCode, roadLink.geometry, roadAddress.startMValue, roadAddress.endMValue)
     val length = GeometryUtils.geometryLength(geom)
     val VVHRoadName = getVVHRoadName(roadLink.attributes)
     val roadName = roadAddress.roadName

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilder.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilder.scala
@@ -32,7 +32,7 @@ class RoadAddressLinkBuilder(roadwayDAO: RoadwayDAO, linearLocationDAO: LinearLo
   val roadwayAddressMapper = new RoadwayAddressMapper(roadwayDAO, linearLocationDAO)
 
   def build(roadLink: RoadLinkLike, roadAddress: RoadAddress): RoadAddressLink = {
-    val geom = GeometryUtils.truncateGeometry3D(roadAddress.sideCode, roadLink.geometry, roadAddress.startMValue, roadAddress.endMValue)
+    val geom = GeometryUtils.truncateGeometry3D(roadLink.geometry, roadAddress.startMValue, roadAddress.endMValue)
     val length = GeometryUtils.geometryLength(geom)
     val VVHRoadName = getVVHRoadName(roadLink.attributes)
     val roadName = roadAddress.roadName

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectLinkDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectLinkDAO.scala
@@ -76,8 +76,8 @@ case class ProjectLink(id: Long, roadNumber: Long, roadPartNumber: Long, track: 
                        roadAddressStartAddrM: Option[Long] = None, roadAddressEndAddrM: Option[Long] = None, roadAddressTrack: Option[Track] = None, roadAddressRoadNumber: Option[Long] = None, roadAddressRoadPart: Option[Long] = None)
   extends BaseRoadAddress with PolyLine {
 
-  override lazy val startCalibrationPoint: Option[ProjectLinkCalibrationPoint] = calibrationPoints._1
-  override lazy val endCalibrationPoint: Option[ProjectLinkCalibrationPoint] = calibrationPoints._2
+//  override lazy val startCalibrationPoint: Option[ProjectLinkCalibrationPoint] = calibrationPoints._1
+//  override lazy val endCalibrationPoint: Option[ProjectLinkCalibrationPoint] = calibrationPoints._2
 
   val isSplit: Boolean = connectedLinkId.nonEmpty || connectedLinkId.contains(0L)
 

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectLinkDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectLinkDAO.scala
@@ -11,9 +11,9 @@ import fi.liikennevirasto.digiroad2.util.LogUtils.time
 import fi.liikennevirasto.digiroad2.util.Track
 import fi.liikennevirasto.digiroad2.{Point, Vector3d}
 import fi.liikennevirasto.viite._
-import fi.liikennevirasto.viite.dao.ProjectCalibrationPointDAO.BaseCalibrationPoint
 import fi.liikennevirasto.viite.dao.CalibrationPointSource.UnknownSource
 import fi.liikennevirasto.viite.dao.LinkStatus.{NotHandled, UnChanged}
+import fi.liikennevirasto.viite.dao.ProjectCalibrationPointDAO.BaseCalibrationPoint
 import fi.liikennevirasto.viite.process.InvalidAddressDataException
 import fi.liikennevirasto.viite.util.CalibrationPointsUtils
 import org.joda.time.DateTime
@@ -352,6 +352,7 @@ class ProjectLinkDAO {
   }
 
   def create(links: Seq[ProjectLink]): Seq[Long] = {
+    if(links.nonEmpty)
     time(logger, "Create project links") {
       val addressPS = dynamicSession.prepareStatement("insert into PROJECT_LINK (id, project_id, " +
         "road_number, road_part_number, " +
@@ -407,8 +408,8 @@ class ProjectLinkDAO {
       addressPS.executeBatch()
       addressPS.close()
       projectLinks.map(_.id)
-    }
-
+    } else
+      Seq.empty[Long]
   }
 
   def updateProjectLinks(projectLinks: Seq[ProjectLink], modifier: String, addresses: Seq[RoadAddress]): Unit = {

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectLinkDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectLinkDAO.scala
@@ -361,10 +361,10 @@ class ProjectLinkDAO {
     time(logger, "Create project links") {
       val addressPS = dynamicSession.prepareStatement("insert into PROJECT_LINK (id, project_id, " +
         "road_number, road_part_number, " +
-        "TRACK, discontinuity_type, START_ADDR_M, END_ADDR_M, ORIGINAL_START_ADDR_M, ORIGINAL_END_ADDR_M, created_by, " +
+        "TRACK, discontinuity_type, START_ADDR_M, END_ADDR_M, ORIGINAL_START_ADDR_M, ORIGINAL_END_ADDR_M, created_by, modified_by, " +
         "calibration_points, status, road_type, roadway_id, linear_location_id, connected_link_id, ely, roadway_number, reversed, geometry, " +
-        "link_id, SIDE, start_measure, end_measure, adjusted_timestamp, link_source, calibration_points_source) values " +
-        "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+        "link_id, SIDE, start_measure, end_measure, adjusted_timestamp, link_source, calibration_points_source, modified_date) values " +
+        "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
       val (ready, idLess) = links.partition(_.id != NewIdValue)
       val plIds = Sequences.fetchViitePrimaryKeySeqValues(idLess.size)
       val projectLinks = ready ++ idLess.zip(plIds).map(x =>
@@ -382,32 +382,34 @@ class ProjectLinkDAO {
         addressPS.setLong(9, pl.originalStartAddrMValue)
         addressPS.setLong(10, pl.originalEndAddrMValue)
         addressPS.setString(11, pl.createdBy.orNull)
-        addressPS.setDouble(12, CalibrationCode.getFromAddress(pl).value)
-        addressPS.setLong(13, pl.status.value)
-        addressPS.setLong(14, pl.roadType.value)
+        addressPS.setString(12, pl.createdBy.orNull)
+        addressPS.setDouble(13, CalibrationCode.getFromAddress(pl).value)
+        addressPS.setLong(14, pl.status.value)
+        addressPS.setLong(15, pl.roadType.value)
         if (pl.roadwayId == 0)
-          addressPS.setString(15, null)
-        else
-          addressPS.setLong(15, pl.roadwayId)
-        if (pl.linearLocationId == 0)
           addressPS.setString(16, null)
         else
-          addressPS.setLong(16, pl.linearLocationId)
-        if (pl.connectedLinkId.isDefined)
-          addressPS.setLong(17, pl.connectedLinkId.get)
-        else
+          addressPS.setLong(16, pl.roadwayId)
+        if (pl.linearLocationId == 0)
           addressPS.setString(17, null)
-        addressPS.setLong(18, pl.ely)
-        addressPS.setLong(19, pl.roadwayNumber)
-        addressPS.setBoolean(20, pl.reversed)
-        addressPS.setObject(21, OracleDatabase.createJGeometry(pl.geometry, dynamicSession.conn))
-        addressPS.setLong(22, pl.linkId)
-        addressPS.setLong(23, pl.sideCode.value)
-        addressPS.setDouble(24, pl.startMValue)
-        addressPS.setDouble(25, pl.endMValue)
-        addressPS.setDouble(26, pl.linkGeometryTimeStamp)
-        addressPS.setInt(27, pl.linkGeomSource.value)
-        addressPS.setInt(28, pl.calibrationPointsSourcesToDB.value)
+        else
+          addressPS.setLong(17, pl.linearLocationId)
+        if (pl.connectedLinkId.isDefined)
+          addressPS.setLong(18, pl.connectedLinkId.get)
+        else
+          addressPS.setString(18, null)
+        addressPS.setLong(19, pl.ely)
+        addressPS.setLong(20, pl.roadwayNumber)
+        addressPS.setBoolean(21, pl.reversed)
+        addressPS.setObject(22, OracleDatabase.createJGeometry(pl.geometry, dynamicSession.conn))
+        addressPS.setLong(23, pl.linkId)
+        addressPS.setLong(24, pl.sideCode.value)
+        addressPS.setDouble(25, pl.startMValue)
+        addressPS.setDouble(26, pl.endMValue)
+        addressPS.setDouble(27, pl.linkGeometryTimeStamp)
+        addressPS.setInt(28, pl.linkGeomSource.value)
+        addressPS.setInt(29, pl.calibrationPointsSourcesToDB.value)
+        addressPS.setDate(30, new java.sql.Date(new Date().getTime))
         addressPS.addBatch()
       }
       addressPS.executeBatch()

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadwayDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadwayDAO.scala
@@ -308,6 +308,9 @@ trait BaseRoadAddress {
       (startingPoint, endPoint)
     }
   }
+
+//  lazy val startCalibrationPoint: Option[BaseCalibrationPoint] = calibrationPoints._1
+//  lazy val endCalibrationPoint: Option[BaseCalibrationPoint] = calibrationPoints._2
 }
 
 //TODO the start date and the created by should not be optional on the road address case class
@@ -320,6 +323,9 @@ case class RoadAddress(id: Long, linearLocationId: Long, roadNumber: Long, roadP
                        geometry: Seq[Point], linkGeomSource: LinkGeomSource, ely: Long,
                        terminated: TerminationCode = NoTermination, roadwayNumber: Long, validFrom: Option[DateTime] = None, validTo: Option[DateTime] = None,
                        roadName: Option[String] = None) extends BaseRoadAddress {
+
+//  override lazy val startCalibrationPoint: Option[CalibrationPoint] = calibrationPoints._1
+//  override lazy val endCalibrationPoint: Option[CalibrationPoint] = calibrationPoints._2
 
   val endCalibrationPoint = calibrationPoints._2
   val startCalibrationPoint = calibrationPoints._1

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/package.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/package.scala
@@ -32,6 +32,8 @@ package object viite {
 
   val MinDistanceForGeometryUpdate = 0.5
 
+  val MaxThreshHoldDistance = 2
+
   val MaxAdjustmentRange = 10L
 
   val noRoadwayId: Long = 0L

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/ProjectDeltaCalculator.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/ProjectDeltaCalculator.scala
@@ -150,8 +150,8 @@ object ProjectDeltaCalculator {
           else
             Seq(r1.copy(discontinuity = r2.discontinuity, endAddrMValue = r2.endAddrMValue, calibrationPoints = r2.calibrationPoints))
         case LinkStatus.New =>
-          if (!hasCalibrationPoint && r1.discontinuity.value != Discontinuity.ParallelLink.value) {
-            Seq(r1.copy(endAddrMValue = r2.endAddrMValue, discontinuity = r2.discontinuity, calibrationPoints = r2.calibrationPoints))
+          if (!hasCalibrationPoint && r1.discontinuity.value != Discontinuity.ParallelLink.value && !r1.isSplit) {
+            Seq(r1.copy(endAddrMValue = r2.endAddrMValue, discontinuity = r2.discontinuity, calibrationPoints = r2.calibrationPoints, connectedLinkId = r2.connectedLinkId))
           } else if (!hasCalibrationPoint && r1.discontinuity.value == Discontinuity.ParallelLink.value) {
             Seq(r2, r1)
           } else {

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/ProjectSectionMValueCalculator.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/ProjectSectionMValueCalculator.scala
@@ -48,12 +48,16 @@ object ProjectSectionMValueCalculator {
   def assignLinkValues(seq: Seq[ProjectLink], cps: Map[Long, UserDefinedCalibrationPoint], addrSt: Option[Double], addrEn: Option[Double], coEff: Double = 1.0): Seq[ProjectLink] = {
     val newAddressValues = seq.scanLeft(addrSt.getOrElse(0.0)) { case (m, pl) =>
       val someCalibrationPoint: Option[UserDefinedCalibrationPoint] = cps.get(pl.id)
-      val addressValue = if (someCalibrationPoint.nonEmpty) someCalibrationPoint.get.addressMValue else m + pl.geometryLength * coEff
-      pl.status match {
-        case LinkStatus.New => addressValue
-        case LinkStatus.Transfer | LinkStatus.NotHandled | LinkStatus.Numbering | LinkStatus.UnChanged => m + pl.addrMLength
-        case LinkStatus.Terminated => pl.endAddrMValue
-        case _ => throw new InvalidAddressDataException(s"Invalid status found at value assignment ${pl.status}, linkId: ${pl.linkId}")
+      if(!pl.isSplit){
+        val addressValue = if (someCalibrationPoint.nonEmpty) someCalibrationPoint.get.addressMValue else m + pl.geometryLength * coEff
+        pl.status match {
+          case LinkStatus.New => addressValue
+          case LinkStatus.Transfer | LinkStatus.NotHandled | LinkStatus.Numbering | LinkStatus.UnChanged => m + pl.addrMLength
+          case LinkStatus.Terminated => pl.endAddrMValue
+          case _ => throw new InvalidAddressDataException(s"Invalid status found at value assignment ${pl.status}, linkId: ${pl.linkId}")
+        }
+      } else {
+        pl.endAddrMValue
       }
     }
     seq.zip(newAddressValues.zip(newAddressValues.tail)).map { case (pl, (st, en)) =>

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/DefaultSectionCalculatorStrategy.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/DefaultSectionCalculatorStrategy.scala
@@ -141,7 +141,7 @@ class DefaultSectionCalculatorStrategy extends RoadAddressSectionCalculatorStrat
         val transferLength: Double = groupedTransfer.values.flatten.map(l => l.endMValue - l.startMValue).sum
         val newLinksMValues = newLinks.map(l => l.endMValue - l.startMValue).sum
         val resetNewLinksIfNeed = if(newLinks.exists(_.connectedLinkId.nonEmpty)) newLinks else newLinks.map(_.copy(roadwayNumber = NewIdValue))
-        val assignedNewLinks = if(groupedTransfer.size == resetNewLinksIfNeed.map(_.roadwayNumber).distinct.size) newLinks else splitLinksIfNeed(groupedTransfer, Seq(), resetNewLinksIfNeed, Seq(), transferLength, newLinksMValues, groupedTransfer.size - resetNewLinksIfNeed.map(_.roadwayNumber).distinct.size)
+        val assignedNewLinks = if(groupedTransfer.size == resetNewLinksIfNeed.map(_.roadwayNumber).distinct.size) newLinks else splitLinksIfNeed(groupedTransfer, Seq(), resetNewLinksIfNeed, Seq(), transferLength, newLinksMValues, groupedTransfer.size)
 
         val (right, left) = if (assignedNewLinks.exists(_.track == Track.RightSide)) (assignedNewLinks, transferLinks) else (transferLinks, assignedNewLinks)
         ((right, restRight), (left, restLeft))

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/DefaultSectionCalculatorStrategy.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/DefaultSectionCalculatorStrategy.scala
@@ -211,17 +211,21 @@ class DefaultSectionCalculatorStrategy extends RoadAddressSectionCalculatorStrat
             val firstSplitedEndAddr = remainingTransfer.head._2.last.endAddrMValue
             val firstSplitedLinkGeom = if(linkToBeSplited.sideCode == TowardsDigitizing) GeometryUtils.truncateGeometry2D(linkToBeSplited.geometry, 0.0, splitMValue)
             else GeometryUtils.truncateGeometry2D(linkToBeSplited.geometry, linkToBeSplited.endMValue - splitMValue, linkToBeSplited.endMValue)
+            val (firstSplitedStartMeasure, firstSplitedEndMeasure) = if(linkToBeSplited.sideCode == TowardsDigitizing) (linkToBeSplited.startMValue, linkToBeSplited.startMValue + splitMValue) else
+              (linkToBeSplited.endMValue - splitMValue, linkToBeSplited.endMValue)
+            val (secondSplitedStartMeasure, secondSplitedEndMeasure) = if(linkToBeSplited.sideCode == TowardsDigitizing) (linkToBeSplited.startMValue + splitMValue, linkToBeSplited.endMValue) else
+              (linkToBeSplited.startMValue, linkToBeSplited.endMValue - splitMValue)
             val secondSplitedLinkGeom = if(linkToBeSplited.sideCode == TowardsDigitizing) GeometryUtils.truncateGeometry2D(linkToBeSplited.geometry, splitMValue, linkToBeSplited.endMValue)
             else GeometryUtils.truncateGeometry2D(linkToBeSplited.geometry, 0.0, linkToBeSplited.endMValue - splitMValue)
 
             //processedLinks without and with roadwayNumber
             val (unassignedRwnLinks, assignedRwnLinks) = processedNew.partition(_.roadwayNumber == NewIdValue)
             val nextRoadwayNumber = Sequences.nextRoadwayNumber
-            val processedNewWithSplitedLink = assignedRwnLinks ++ unassignedRwnLinks.map(_.copy(roadwayNumber = nextRoadwayNumber)) :+linkToBeSplited.copy(endMValue = linkToBeSplited.startMValue + splitMValue,
+            val processedNewWithSplitedLink = assignedRwnLinks ++ unassignedRwnLinks.map(_.copy(roadwayNumber = nextRoadwayNumber)) :+linkToBeSplited.copy(startMValue = firstSplitedStartMeasure, endMValue = firstSplitedEndMeasure,
               geometry = firstSplitedLinkGeom, geometryLength = GeometryUtils.geometryLength(firstSplitedLinkGeom), endAddrMValue = firstSplitedEndAddr,
               roadwayNumber = nextRoadwayNumber, connectedLinkId = Some(linkToBeSplited.linkId))
 
-            splitLinksIfNeed(remainingTransfer.tail, processedTransfer++remainingTransfer.head._2, linkToBeSplited.copy(id = NewIdValue, startMValue = linkToBeSplited.startMValue + splitMValue,
+            splitLinksIfNeed(remainingTransfer.tail, processedTransfer++remainingTransfer.head._2, linkToBeSplited.copy(id = NewIdValue, startMValue = secondSplitedStartMeasure, endMValue = secondSplitedEndMeasure,
               geometry = secondSplitedLinkGeom, geometryLength = GeometryUtils.geometryLength(secondSplitedLinkGeom), startAddrMValue = firstSplitedEndAddr) +: remainingNew.tail,
               processedNewWithSplitedLink, totalTransferMLength, totalNewMLength, missingRoadwayNumbers-1)
           }

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/DefaultSectionCalculatorStrategy.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/DefaultSectionCalculatorStrategy.scala
@@ -141,7 +141,7 @@ class DefaultSectionCalculatorStrategy extends RoadAddressSectionCalculatorStrat
         val transferLength: Double = groupedTransfer.values.flatten.map(l => l.endMValue - l.startMValue).sum
         val newLinksMValues = newLinks.map(l => l.endMValue - l.startMValue).sum
         val resetNewLinksIfNeed = if(newLinks.exists(_.connectedLinkId.nonEmpty)) newLinks else newLinks.map(_.copy(roadwayNumber = NewIdValue))
-        val assignedNewLinks = if(groupedTransfer.size == resetNewLinksIfNeed.map(_.roadwayNumber).distinct.size) newLinks else splitLinksIfNeed(groupedTransfer, Seq(), resetNewLinksIfNeed, Seq(), transferLength, newLinksMValues, groupedTransfer.size)
+        val assignedNewLinks = if(groupedTransfer.size == resetNewLinksIfNeed.filterNot(_.roadwayNumber == NewIdValue).map(_.roadwayNumber).distinct.size) newLinks else splitLinksIfNeed(groupedTransfer, Seq(), resetNewLinksIfNeed, Seq(), transferLength, newLinksMValues, groupedTransfer.size)
 
         val (right, left) = if (assignedNewLinks.exists(_.track == Track.RightSide)) (assignedNewLinks, transferLinks) else (transferLinks, assignedNewLinks)
         ((right, restRight), (left, restLeft))

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/DefaultSectionCalculatorStrategy.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/DefaultSectionCalculatorStrategy.scala
@@ -217,11 +217,11 @@ class DefaultSectionCalculatorStrategy extends RoadAddressSectionCalculatorStrat
             //processedLinks without and with roadwayNumber
             val (unassignedRwnLinks, assignedRwnLinks) = processedNew.partition(_.roadwayNumber == NewIdValue)
             val nextRoadwayNumber = Sequences.nextRoadwayNumber
-            val processedNewWithSplitedLink = assignedRwnLinks ++ unassignedRwnLinks.map(_.copy(roadwayNumber = nextRoadwayNumber)) :+linkToBeSplited.copy(endMValue = splitMValue,
+            val processedNewWithSplitedLink = assignedRwnLinks ++ unassignedRwnLinks.map(_.copy(roadwayNumber = nextRoadwayNumber)) :+linkToBeSplited.copy(endMValue = linkToBeSplited.startMValue + splitMValue,
               geometry = firstSplitedLinkGeom, geometryLength = GeometryUtils.geometryLength(firstSplitedLinkGeom), endAddrMValue = firstSplitedEndAddr,
               roadwayNumber = nextRoadwayNumber, connectedLinkId = Some(linkToBeSplited.linkId))
 
-            splitLinksIfNeed(remainingTransfer.tail, processedTransfer++remainingTransfer.head._2, linkToBeSplited.copy(id = NewIdValue, startMValue = splitMValue,
+            splitLinksIfNeed(remainingTransfer.tail, processedTransfer++remainingTransfer.head._2, linkToBeSplited.copy(id = NewIdValue, startMValue = linkToBeSplited.startMValue + splitMValue,
               geometry = secondSplitedLinkGeom, geometryLength = GeometryUtils.geometryLength(secondSplitedLinkGeom), startAddrMValue = firstSplitedEndAddr) +: remainingNew.tail,
               processedNewWithSplitedLink, totalTransferMLength, totalNewMLength, missingRoadwayNumbers-1)
           }

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/DefaultSectionCalculatorStrategy.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/DefaultSectionCalculatorStrategy.scala
@@ -176,7 +176,7 @@ class DefaultSectionCalculatorStrategy extends RoadAddressSectionCalculatorStrat
       def splitLinks(remainingTransfer: ListMap[Long, Seq[ProjectLink]], processedTransfer: Seq[ProjectLink], remainingNew: Seq[ProjectLink], processedNew: Seq[ProjectLink], totalTransferMLength: Double, totalNewMLength: Double, missingRoadwayNumbers: Int) : Seq[ProjectLink]= {
         if(missingRoadwayNumbers == 0){//if links size the same as the diff roadwayNumbers in Transfer side, then
           processedNew ++ remainingNew.map(_.copy(roadwayNumber = Sequences.nextRoadwayNumber))
-         }else if(remainingNew.isEmpty && remainingTransfer.isEmpty) {
+        } else if(remainingNew.isEmpty && remainingTransfer.isEmpty) {
           processedNew
         } else if (remainingNew.isEmpty && remainingTransfer.nonEmpty){
           splitLinks(remainingTransfer, processedTransfer, remainingNew:+processedNew.last, processedNew.init,
@@ -213,7 +213,7 @@ class DefaultSectionCalculatorStrategy extends RoadAddressSectionCalculatorStrat
               remainingNew.head.copy(endMValue = firstSplitedEndMValue,
                 geometry = firstSplitedLinkGeom, geometryLength = GeometryUtils.geometryLength(firstSplitedLinkGeom), endAddrMValue = firstSplitedEndAddr,
                 roadwayNumber = Sequences.nextRoadwayNumber),
-              remainingNew.head.copy(startMValue = firstSplitedEndMValue,
+              remainingNew.head.copy(id = NewIdValue, startMValue = firstSplitedEndMValue,
                 geometry = secondSplitedLinkGeom, geometryLength = GeometryUtils.geometryLength(secondSplitedLinkGeom), startAddrMValue = firstSplitedEndAddr,
                 endAddrMValue = secondSplitedEndAddr, roadwayNumber = Sequences.nextRoadwayNumber)),
               totalTransferMLength, totalNewMLength, missingRoadwayNumbers-1)

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/DefaultSectionCalculatorStrategy.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/DefaultSectionCalculatorStrategy.scala
@@ -2,6 +2,7 @@ package fi.liikennevirasto.viite.process.strategy
 
 import fi.liikennevirasto.GeometryUtils
 import fi.liikennevirasto.digiroad2.asset.SideCode
+import fi.liikennevirasto.digiroad2.asset.SideCode.TowardsDigitizing
 import fi.liikennevirasto.digiroad2.dao.Sequences
 import fi.liikennevirasto.digiroad2.util.Track.LeftSide
 import fi.liikennevirasto.digiroad2.util.{RoadAddressException, Track}
@@ -137,115 +138,12 @@ class DefaultSectionCalculatorStrategy extends RoadAddressSectionCalculatorStrat
       : ((Seq[ProjectLink], Seq[ProjectLink]), (Seq[ProjectLink], Seq[ProjectLink])) = {
         val (transferLinks, newLinks) = if (firstRight.exists(_.status == LinkStatus.Transfer)) (firstRight, firstLeft) else (firstLeft, firstRight)
         val groupedTransfer: ListMap[Long, Seq[ProjectLink]] = ListMap(transferLinks.groupBy(_.roadwayNumber).toSeq.sortBy(r => r._2.minBy(_.startAddrMValue).startAddrMValue): _*)
+        val transferLength: Double = groupedTransfer.values.flatten.map(l => l.endMValue - l.startMValue).sum
+        val newLinksMValues = newLinks.map(l => l.endMValue - l.startMValue).sum
+        val assignedNewLinks = splitLinksIfNeed(groupedTransfer, Seq(), newLinks, Seq(), transferLength, newLinksMValues, groupedTransfer.size)
 
-          if(newLinks.size >= groupedTransfer.size && newLinks.size >= groupedTransfer.values.flatten.size){
-
-            val (equatedNewLinks, restNewLinks) = groupedTransfer.foldLeft(Seq.empty[ProjectLink], newLinks) {
-              case ((adjustedLinks, linksToProcess), group) =>
-                val newRoadwayNumber = Sequences.nextRoadwayNumber
-                val links = linksToProcess.take(group._2.size).map(l => l.copy(roadwayNumber = newRoadwayNumber))
-                val rest = linksToProcess.drop(group._2.size)
-                (adjustedLinks ++ links.init :+ links.last.copy(connectedLinkId = Some(links.last.linkId), endAddrMValue = group._2.last.endAddrMValue), if(rest.nonEmpty)
-                  rest.head.copy(startAddrMValue = group._2.last.endAddrMValue) +: rest.tail else rest)
-            }
-            val adjustedNewLinks = equatedNewLinks ++ restNewLinks.map(l => l.copy(roadwayNumber = equatedNewLinks.last.roadwayNumber))
-
-            val (right, left) = if (adjustedNewLinks.exists(_.track == Track.RightSide)) (adjustedNewLinks, transferLinks) else (transferLinks, adjustedNewLinks)
-            ((right, restRight), (left, restLeft))
-
-          } else if (newLinks.size >= groupedTransfer.size && newLinks.size < groupedTransfer.values.flatten.size){
-
-            val transferLength: Double = groupedTransfer.values.flatten.map(l => l.endMValue - l.startMValue).sum
-            val newLinksMValues = newLinks.map(l => l.endMValue - l.startMValue).sum
-            val assignedNewLinks = specialCaseSplitLinks(groupedTransfer, Seq(), newLinks, Seq(), transferLength, newLinksMValues, groupedTransfer.size)
-
-            val (right, left) = if (assignedNewLinks.exists(_.track == Track.RightSide)) (assignedNewLinks, transferLinks) else (transferLinks, assignedNewLinks)
-            ((right, restRight), (left, restLeft))
-
-          } else {
-
-            val transferLength: Double = groupedTransfer.values.flatten.map(l => l.endMValue - l.startMValue).sum
-            val newLinksMValues = newLinks.map(l => l.endMValue - l.startMValue).sum
-            val splitedLinks = splitLinks(groupedTransfer, Seq(), newLinks, Seq(),
-              transferLength, newLinksMValues, groupedTransfer.size-newLinks.size)
-
-            val (right, left) = if (splitedLinks.exists(_.track == Track.RightSide)) (splitedLinks, transferLinks) else (transferLinks, splitedLinks)
-            ((right, restRight), (left, restLeft))
-
-          }
-      }
-
-      def specialCaseSplitLinks(remainingTransfer: ListMap[Long, Seq[ProjectLink]], processedTransfer: Seq[ProjectLink], remainingNew: Seq[ProjectLink], processedNew: Seq[ProjectLink], totalTransferMLength: Double, totalNewMLength: Double, missingRoadwayNumbers: Int) : Seq[ProjectLink] = {
-        if(missingRoadwayNumbers == 0 || (remainingNew.nonEmpty && remainingTransfer.isEmpty)){
-          val nextRoadwayNumber = Sequences.nextRoadwayNumber
-          processedNew ++ remainingNew.map(_.copy(roadwayNumber = nextRoadwayNumber))
-        } else if(remainingNew.isEmpty && remainingTransfer.isEmpty) {
-          processedNew
-        } else if (remainingNew.isEmpty && remainingTransfer.nonEmpty){
-          //TODO cenas
-          Seq()
-        } else {
-          val threshHoldMaxDistance = 2
-
-          //transfer m length coeff
-          val groupTransferMLength = remainingTransfer.head._2.map(l => l.endMValue - l.startMValue).sum
-
-          val lowerAllowedTransferGroupCoeff = (groupTransferMLength-threshHoldMaxDistance)/totalTransferMLength
-          val biggerAllowedTransferGroupCoeff = (groupTransferMLength+threshHoldMaxDistance)/totalTransferMLength
-
-          //new m length coeff
-          val processedNewToBeAssigned = processedNew.filter(_.roadwayNumber == NewIdValue)
-          val processingLength: Double = if(processedNewToBeAssigned.isEmpty){ remainingNew.head.endMValue - remainingNew.head.startMValue
-              } else {
-                (remainingNew.head.endMValue - remainingNew.head.startMValue) +
-                  processedNewToBeAssigned.map(l => l.endMValue - l.startMValue).sum
-              }
-          val currentNewLinksGroupCoeff: Double = processingLength/totalNewMLength
-          if(lowerAllowedTransferGroupCoeff <= currentNewLinksGroupCoeff && currentNewLinksGroupCoeff <= biggerAllowedTransferGroupCoeff){
-            specialCaseSplitLinks(remainingTransfer.tail, processedTransfer ++ remainingTransfer.head._2, remainingNew.tail, processedNew:+remainingNew.head,
-              totalTransferMLength, totalNewMLength, missingRoadwayNumbers - 1)
-          } else if(lowerAllowedTransferGroupCoeff > currentNewLinksGroupCoeff){
-            specialCaseSplitLinks(remainingTransfer, processedTransfer, remainingNew.tail, processedNew:+remainingNew.head,
-              totalTransferMLength, totalNewMLength, missingRoadwayNumbers)
-          } else {
-            /*
-            calculate missing geometry left to fulfill the exactly groupTransfer coefficient
-             */
-            //by that we want to pick previous processedLinks
-            val processedNewToBeAssigned = processedNew.filter(_.roadwayNumber == NewIdValue)
-            val previousProcessed = if(processedNewToBeAssigned.isEmpty) Seq() else processedNewToBeAssigned
-            val linkToBeSplited = remainingNew.head
-            //get their length
-            val previousProcessedLength: Double = if(previousProcessed.isEmpty){ remainingNew.head.endMValue - remainingNew.head.startMValue
-            } else {
-              previousProcessed.map(l => l.endMValue - l.startMValue).sum
-            }
-
-            //coeficient to be matched for current transfer group
-            val perfectTransferGroupCoeff = groupTransferMLength/totalTransferMLength
-            /*
-              (previousProcessedLength+m)/totalNewMLength = perfectTransferGroupCoeff <=>
-              <=> previousProcessedLength+m = perfectTransferGroupCoeff*totalNewMLength <=>
-              <=> m = (perfectTransferGroupCoeff*totalNewMLength) - previousProcessedLength
-             */
-            val splitMValue = (perfectTransferGroupCoeff*totalNewMLength) - previousProcessedLength
-
-            val firstSplitedEndAddr = remainingTransfer.head._2.last.endAddrMValue
-            val firstSplitedLinkGeom = GeometryUtils.truncateGeometry2D(linkToBeSplited.geometry, 0.0, splitMValue)
-            val secondSplitedLinkGeom = GeometryUtils.truncateGeometry2D(linkToBeSplited.geometry, splitMValue, linkToBeSplited.endMValue)
-
-            //processedLinks without and with roadwayNumber
-            val (unassignedRoadwayNumber, assignedRoadwayNumber) = processedNew.partition(_.roadwayNumber == NewIdValue)
-            val nextRoadwayNumber = Sequences.nextRoadwayNumber
-            val processedNewWithSplitedLink = assignedRoadwayNumber ++ unassignedRoadwayNumber.map(_.copy(roadwayNumber = nextRoadwayNumber)) :+linkToBeSplited.copy(endMValue = splitMValue,
-              geometry = firstSplitedLinkGeom, geometryLength = GeometryUtils.geometryLength(firstSplitedLinkGeom), endAddrMValue = firstSplitedEndAddr,
-              roadwayNumber = nextRoadwayNumber, connectedLinkId = Some(linkToBeSplited.linkId))
-
-            specialCaseSplitLinks(remainingTransfer.tail, processedTransfer++remainingTransfer.head._2, linkToBeSplited.copy(id = NewIdValue, startMValue = splitMValue,
-              geometry = secondSplitedLinkGeom, geometryLength = GeometryUtils.geometryLength(secondSplitedLinkGeom), startAddrMValue = firstSplitedEndAddr) +: remainingNew.tail , processedNewWithSplitedLink
-              , totalTransferMLength, totalNewMLength, missingRoadwayNumbers-1)
-          }
-        }
+        val (right, left) = if (assignedNewLinks.exists(_.track == Track.RightSide)) (assignedNewLinks, transferLinks) else (transferLinks, assignedNewLinks)
+        ((right, restRight), (left, restLeft))
       }
 
       /**
@@ -254,47 +152,77 @@ class DefaultSectionCalculatorStrategy extends RoadAddressSectionCalculatorStrat
         * @param processedTransfer
         * @param remainingNew
         * @param processedNew
-        * @return New links with proper same different roadwayNumbers as the opposite Transfer track
+        * @param totalTransferMLength
+        * @param totalNewMLength
+        * @param missingRoadwayNumbers
+        * @return matched new links by roadwaynumbers according to their same size proportion
         */
-      def splitLinks(remainingTransfer: ListMap[Long, Seq[ProjectLink]], processedTransfer: Seq[ProjectLink], remainingNew: Seq[ProjectLink], processedNew: Seq[ProjectLink], totalTransferMLength: Double, totalNewMLength: Double, missingRoadwayNumbers: Int) : Seq[ProjectLink] = {
-        if(missingRoadwayNumbers == 0){
-          val nextRoadwayNumber = Sequences.nextRoadwayNumber
-          processedNew ++ remainingNew.map(_.copy(roadwayNumber = nextRoadwayNumber))
+      @scala.annotation.tailrec
+      def splitLinksIfNeed(remainingTransfer: ListMap[Long, Seq[ProjectLink]], processedTransfer: Seq[ProjectLink], remainingNew: Seq[ProjectLink], processedNew: Seq[ProjectLink], totalTransferMLength: Double, totalNewMLength: Double, missingRoadwayNumbers: Int) : Seq[ProjectLink] = {
+        if(missingRoadwayNumbers == 0 || (remainingNew.nonEmpty && remainingTransfer.isEmpty)){
+          val remainingRoadwayNumber = Sequences.nextRoadwayNumber
+          val unassignedRoadwayNumber = Sequences.nextRoadwayNumber
+          val (unassignedRwnLinks, assignedRwnLinks) = processedNew.partition(_.roadwayNumber == NewIdValue)
+          assignedRwnLinks ++ unassignedRwnLinks.map(_.copy(roadwayNumber = unassignedRoadwayNumber)) ++ remainingNew.map(_.copy(roadwayNumber = remainingRoadwayNumber))
         } else if(remainingNew.isEmpty && remainingTransfer.isEmpty) {
           processedNew
-        } else if (remainingNew.isEmpty && remainingTransfer.nonEmpty){
-          splitLinks(remainingTransfer, processedTransfer, remainingNew:+processedNew.last, processedNew.init,
-            totalTransferMLength, totalNewMLength, missingRoadwayNumbers)
         } else {
           val threshHoldMaxDistance = 2
 
-          //transfer m length coeff
+          //Transfer M length coeff
           val groupTransferMLength = remainingTransfer.head._2.map(l => l.endMValue - l.startMValue).sum
+          val minAllowedTransferGroupCoeff = (groupTransferMLength-threshHoldMaxDistance)/totalTransferMLength
+          val maxAllowedTransferGroupCoeff = (groupTransferMLength+threshHoldMaxDistance)/totalTransferMLength
 
-          val transferGroupCoeff = (groupTransferMLength-threshHoldMaxDistance)/totalTransferMLength
-
-          //new m length coeff
-          val currentLinkLength: Double = remainingNew.head.endMValue - remainingNew.head.startMValue
-          val currentLinkCoeff: Double = currentLinkLength/totalNewMLength
-
-          if(transferGroupCoeff>currentLinkCoeff){
-            splitLinks(remainingTransfer, processedTransfer, remainingNew.tail, processedNew:+remainingNew.head,
+          //New M length coeff
+          val processedNewToBeAssigned = processedNew.filter(_.roadwayNumber == NewIdValue)
+          val processingLength: Double = if(processedNewToBeAssigned.isEmpty){ remainingNew.head.endMValue - remainingNew.head.startMValue
+              } else {
+                (remainingNew.head.endMValue - remainingNew.head.startMValue) +
+                  processedNewToBeAssigned.map(l => l.endMValue - l.startMValue).sum
+              }
+          val currentNewLinksGroupCoeff: Double = processingLength/totalNewMLength
+          if(minAllowedTransferGroupCoeff <= currentNewLinksGroupCoeff && currentNewLinksGroupCoeff <= maxAllowedTransferGroupCoeff){
+            splitLinksIfNeed(remainingTransfer.tail, processedTransfer ++ remainingTransfer.head._2, remainingNew.tail, processedNew:+remainingNew.head,
+              totalTransferMLength, totalNewMLength, missingRoadwayNumbers - 1)
+          } else if(minAllowedTransferGroupCoeff > currentNewLinksGroupCoeff){
+            splitLinksIfNeed(remainingTransfer, processedTransfer, remainingNew.tail, processedNew:+remainingNew.head,
               totalTransferMLength, totalNewMLength, missingRoadwayNumbers)
           } else {
-            val firstSplitedEndAddr = remainingTransfer.head._2.last.endAddrMValue
-//            val secondSplitedEndAddr = remainingTransfer.tail.head._2.last.endAddrMValue
-            val firstSplitedEndMValue = transferGroupCoeff*currentLinkLength
-            val firstSplitedLinkGeom = GeometryUtils.truncateGeometry2D(remainingNew.head.geometry, 0.0, firstSplitedEndMValue)
-            val secondSplitedLinkGeom = GeometryUtils.truncateGeometry2D(remainingNew.head.geometry, firstSplitedEndMValue, remainingNew.head.endMValue)
+            /*
+              calculate missing geometry left to fulfill the exactly groupTransfer coefficient
+              Note: and by that we want to pick previous processedLinks
+             */
 
-            splitLinks(remainingTransfer.tail, processedTransfer++remainingTransfer.head._2, remainingNew.tail, processedNew++Seq(
-              remainingNew.head.copy(endMValue = firstSplitedEndMValue,
-                geometry = firstSplitedLinkGeom, geometryLength = GeometryUtils.geometryLength(firstSplitedLinkGeom), endAddrMValue = firstSplitedEndAddr,
-                roadwayNumber = Sequences.nextRoadwayNumber, connectedLinkId = Some(remainingNew.head.linkId)),
-              remainingNew.head.copy(id = NewIdValue, startMValue = firstSplitedEndMValue,
-                geometry = secondSplitedLinkGeom, geometryLength = GeometryUtils.geometryLength(secondSplitedLinkGeom), startAddrMValue = firstSplitedEndAddr,
-                /*endAddrMValue = secondSplitedEndAddr,*/ roadwayNumber = Sequences.nextRoadwayNumber, connectedLinkId = Some(remainingNew.head.linkId))),
-              totalTransferMLength, totalNewMLength, missingRoadwayNumbers-1)
+            val processedNewToBeAssigned = processedNew.filter(_.roadwayNumber == NewIdValue)
+            val previousProcessed = if(processedNewToBeAssigned.isEmpty) Seq() else processedNewToBeAssigned
+            val linkToBeSplited = remainingNew.head
+            val previousProcessedLength: Double = previousProcessed.map(l => l.endMValue - l.startMValue).sum
+
+            val perfectTransferGroupCoeff = groupTransferMLength/totalTransferMLength
+            //finally high school math serves for something
+            /*
+              (previousProcessedLength+m)/totalNewMLength = perfectTransferGroupCoeff <=>
+              <=> previousProcessedLength+m = perfectTransferGroupCoeff*totalNewMLength <=>
+              <=> m = (perfectTransferGroupCoeff*totalNewMLength) - previousProcessedLength
+             */
+            val splitMValue = (perfectTransferGroupCoeff*totalNewMLength) - previousProcessedLength
+            val firstSplitedEndAddr = remainingTransfer.head._2.last.endAddrMValue
+            val firstSplitedLinkGeom = if(linkToBeSplited.sideCode == TowardsDigitizing) GeometryUtils.truncateGeometry2D(linkToBeSplited.geometry, 0.0, splitMValue)
+            else GeometryUtils.truncateGeometry2D(linkToBeSplited.geometry, linkToBeSplited.endMValue - splitMValue, linkToBeSplited.endMValue)
+            val secondSplitedLinkGeom = if(linkToBeSplited.sideCode == TowardsDigitizing) GeometryUtils.truncateGeometry2D(linkToBeSplited.geometry, splitMValue, linkToBeSplited.endMValue)
+            else GeometryUtils.truncateGeometry2D(linkToBeSplited.geometry, 0.0, linkToBeSplited.endMValue - splitMValue)
+
+            //processedLinks without and with roadwayNumber
+            val (unassignedRwnLinks, assignedRwnLinks) = processedNew.partition(_.roadwayNumber == NewIdValue)
+            val nextRoadwayNumber = Sequences.nextRoadwayNumber
+            val processedNewWithSplitedLink = assignedRwnLinks ++ unassignedRwnLinks.map(_.copy(roadwayNumber = nextRoadwayNumber)) :+linkToBeSplited.copy(endMValue = splitMValue,
+              geometry = firstSplitedLinkGeom, geometryLength = GeometryUtils.geometryLength(firstSplitedLinkGeom), endAddrMValue = firstSplitedEndAddr,
+              roadwayNumber = nextRoadwayNumber, connectedLinkId = Some(linkToBeSplited.linkId))
+
+            splitLinksIfNeed(remainingTransfer.tail, processedTransfer++remainingTransfer.head._2, linkToBeSplited.copy(id = NewIdValue, startMValue = splitMValue,
+              geometry = secondSplitedLinkGeom, geometryLength = GeometryUtils.geometryLength(secondSplitedLinkGeom), startAddrMValue = firstSplitedEndAddr) +: remainingNew.tail,
+              processedNewWithSplitedLink, totalTransferMLength, totalNewMLength, missingRoadwayNumbers-1)
           }
         }
       }

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/DefaultSectionCalculatorStrategy.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/DefaultSectionCalculatorStrategy.scala
@@ -212,10 +212,10 @@ class DefaultSectionCalculatorStrategy extends RoadAddressSectionCalculatorStrat
             splitLinks(remainingTransfer.tail, processedTransfer++remainingTransfer.head._2, remainingNew.tail, processedNew++Seq(
               remainingNew.head.copy(endMValue = firstSplitedEndMValue,
                 geometry = firstSplitedLinkGeom, geometryLength = GeometryUtils.geometryLength(firstSplitedLinkGeom), endAddrMValue = firstSplitedEndAddr,
-                roadwayNumber = Sequences.nextRoadwayNumber),
+                roadwayNumber = Sequences.nextRoadwayNumber, connectedLinkId = Some(remainingNew.head.linkId)),
               remainingNew.head.copy(id = NewIdValue, startMValue = firstSplitedEndMValue,
                 geometry = secondSplitedLinkGeom, geometryLength = GeometryUtils.geometryLength(secondSplitedLinkGeom), startAddrMValue = firstSplitedEndAddr,
-                endAddrMValue = secondSplitedEndAddr, roadwayNumber = Sequences.nextRoadwayNumber)),
+                endAddrMValue = secondSplitedEndAddr, roadwayNumber = Sequences.nextRoadwayNumber, connectedLinkId = Some(remainingNew.head.linkId))),
               totalTransferMLength, totalNewMLength, missingRoadwayNumbers-1)
           }
         }

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/DefaultSectionCalculatorStrategy.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/DefaultSectionCalculatorStrategy.scala
@@ -140,9 +140,6 @@ class DefaultSectionCalculatorStrategy extends RoadAddressSectionCalculatorStrat
 
           if(newLinks.size >= groupedTransfer.size){
 
-//            val zippedAll = newLinks.zipAll(transferLinks, "", "").map({ case (n, t) =>
-//            })
-            //TODO assignRoadwayNumbers proporcionally
           val (equatedNewLinks, restNewLinks) = groupedTransfer.foldLeft(Seq.empty[ProjectLink], newLinks) {
             case ((adjustedLinks, linksToProcess), group) =>
               val newRoadwayNumber = Sequences.nextRoadwayNumber
@@ -155,9 +152,73 @@ class DefaultSectionCalculatorStrategy extends RoadAddressSectionCalculatorStrat
           val (right, left) = if (adjustedNewLinks.exists(_.track == Track.RightSide)) (adjustedNewLinks, transferLinks) else (transferLinks, adjustedNewLinks)
           ((right, restRight), (left, restLeft))
           } else {
-            //TODO split links case here
-          ((Seq.empty[ProjectLink], Seq.empty[ProjectLink]), (Seq.empty[ProjectLink], Seq.empty[ProjectLink]))
+
+            val transferLength: Double = groupedTransfer.values.flatten.zip(groupedTransfer.values.flatten.tail).map{
+              case (a, b) => (a.endMValue-a.startMValue) + (b.endMValue-b.startMValue)}.sum
+            val newLinksMValues = if(newLinks.size == 1)
+              newLinks.head.endMValue - newLinks.head.startMValue
+            else newLinks.zip(newLinks.tail).map{case (a, b) => (a.endMValue-a.startMValue) + (b.endMValue-b.startMValue)}.sum
+            val splitedLinks = splitLinks(groupedTransfer, Seq(), newLinks, Seq(),
+              transferLength, newLinksMValues , groupedTransfer.size-newLinks.size)
+            val (right, left) = if (splitedLinks.exists(_.track == Track.RightSide)) (splitedLinks, transferLinks) else (transferLinks, splitedLinks)
+            ((right, restRight), (left, restLeft))
           }
+      }
+
+      /**
+        *
+        * @param remainingTransfer
+        * @param processedTransfer
+        * @param remainingNew
+        * @param processedNew
+        * @return New links with proper same different roadwayNumbers as the opposite Transfer track
+        */
+      def splitLinks(remainingTransfer: ListMap[Long, Seq[ProjectLink]], processedTransfer: Seq[ProjectLink], remainingNew: Seq[ProjectLink], processedNew: Seq[ProjectLink], totalTransferMLength: Double, totalNewMLength: Double, missingRoadwayNumbers: Int) : Seq[ProjectLink]= {
+        if(missingRoadwayNumbers == 0){//if links size the same as the diff roadwayNumbers in Transfer side, then
+          processedNew ++ remainingNew.map(_.copy(roadwayNumber = Sequences.nextRoadwayNumber))
+         }else if(remainingNew.isEmpty && remainingTransfer.isEmpty) {
+          processedNew
+        } else if (remainingNew.isEmpty && remainingTransfer.nonEmpty){
+          splitLinks(remainingTransfer, processedTransfer, remainingNew:+processedNew.last, processedNew.init,
+            totalTransferMLength, totalNewMLength, missingRoadwayNumbers)
+        } else {
+          val threshHoldMaxDistance = 2
+          //transfer addr coeff
+          val groupTransferAddr = remainingTransfer.head._2.last.endAddrMValue - remainingTransfer.head._2.head.startAddrMValue
+          val transferAddrCoeff = groupTransferAddr/remainingTransfer.last._2.last.endAddrMValue
+
+          //transfer m length coeff
+          val groupTransferMLength = if(remainingTransfer.head._2.size == 1)
+            remainingTransfer.head._2.head.endMValue - remainingTransfer.head._2.head.startMValue
+          else
+            remainingTransfer.head._2.zip(remainingTransfer.head._2.tail).map{case (a, b) => (a.endMValue-a.startMValue) + (b.endMValue-b.startMValue)}.sum
+          val transferGroupCoeff = (groupTransferMLength-threshHoldMaxDistance)/totalTransferMLength
+
+          //new m length coeff
+          val currentLinkLength: Double = remainingNew.head.endMValue - remainingNew.head.startMValue
+          val currentLinkCoeff: Double = currentLinkLength/totalNewMLength
+
+          if(transferGroupCoeff>currentLinkCoeff){
+            splitLinks(remainingTransfer, processedTransfer, remainingNew.tail, processedNew:+remainingNew.head,
+              totalTransferMLength, totalNewMLength, missingRoadwayNumbers)
+          } else {
+            //TODO entao fazer o split da current new link
+            val firstSplitedEndAddr = remainingTransfer.head._2.last.endAddrMValue
+            val secondSplitedEndAddr = remainingTransfer.tail.head._2.last.endAddrMValue
+            val firstSplitedEndMValue = transferGroupCoeff*currentLinkLength
+            val firstSplitedLinkGeom = GeometryUtils.truncateGeometry2D(remainingNew.head.geometry, 0.0, firstSplitedEndMValue)
+            val secondSplitedLinkGeom = GeometryUtils.truncateGeometry2D(remainingNew.head.geometry, firstSplitedEndMValue, remainingNew.head.endMValue)
+
+            splitLinks(remainingTransfer.tail, processedTransfer++remainingTransfer.head._2, remainingNew.tail, processedNew++Seq(
+              remainingNew.head.copy(endMValue = firstSplitedEndMValue,
+                geometry = firstSplitedLinkGeom, geometryLength = GeometryUtils.geometryLength(firstSplitedLinkGeom), endAddrMValue = firstSplitedEndAddr,
+                roadwayNumber = Sequences.nextRoadwayNumber),
+              remainingNew.head.copy(startMValue = firstSplitedEndMValue,
+                geometry = secondSplitedLinkGeom, geometryLength = GeometryUtils.geometryLength(secondSplitedLinkGeom), startAddrMValue = firstSplitedEndAddr,
+                endAddrMValue = secondSplitedEndAddr, roadwayNumber = Sequences.nextRoadwayNumber)),
+              totalTransferMLength, totalNewMLength, missingRoadwayNumbers-1)
+          }
+        }
       }
 
       def adjustableToRoadwayNumberAttribution(firstRight: Seq[ProjectLink], restRight: Seq[ProjectLink], firstLeft: Seq[ProjectLink], restLeft: Seq[ProjectLink]): Boolean = {

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/DefaultSectionCalculatorStrategy.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/DefaultSectionCalculatorStrategy.scala
@@ -140,7 +140,8 @@ class DefaultSectionCalculatorStrategy extends RoadAddressSectionCalculatorStrat
         val groupedTransfer: ListMap[Long, Seq[ProjectLink]] = ListMap(transferLinks.groupBy(_.roadwayNumber).toSeq.sortBy(r => r._2.minBy(_.startAddrMValue).startAddrMValue): _*)
         val transferLength: Double = groupedTransfer.values.flatten.map(l => l.endMValue - l.startMValue).sum
         val newLinksMValues = newLinks.map(l => l.endMValue - l.startMValue).sum
-        val assignedNewLinks = splitLinksIfNeed(groupedTransfer, Seq(), newLinks, Seq(), transferLength, newLinksMValues, groupedTransfer.size)
+        val resetNewLinksIfNeed = if(newLinks.exists(_.connectedLinkId.nonEmpty)) newLinks else newLinks.map(_.copy(roadwayNumber = NewIdValue))
+        val assignedNewLinks = if(groupedTransfer.size == resetNewLinksIfNeed.map(_.roadwayNumber).distinct.size) newLinks else splitLinksIfNeed(groupedTransfer, Seq(), resetNewLinksIfNeed, Seq(), transferLength, newLinksMValues, groupedTransfer.size - resetNewLinksIfNeed.map(_.roadwayNumber).distinct.size)
 
         val (right, left) = if (assignedNewLinks.exists(_.track == Track.RightSide)) (assignedNewLinks, transferLinks) else (transferLinks, assignedNewLinks)
         ((right, restRight), (left, restLeft))

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/DefaultSectionCalculatorStrategy.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/DefaultSectionCalculatorStrategy.scala
@@ -132,26 +132,37 @@ class DefaultSectionCalculatorStrategy extends RoadAddressSectionCalculatorStrat
                                             userDefinedCalibrationPoint: Map[Long, UserDefinedCalibrationPoint]): Seq[CombinedSection] = {
 
     def adjustTracksToMatch(leftLinks: Seq[ProjectLink], rightLinks: Seq[ProjectLink], previousStart: Option[Long]): (Seq[ProjectLink], Seq[ProjectLink]) = {
+
       def adjustTwoTrackRoadwayNumbers(firstRight: Seq[ProjectLink], restRight: Seq[ProjectLink], firstLeft: Seq[ProjectLink], restLeft: Seq[ProjectLink])
       : ((Seq[ProjectLink], Seq[ProjectLink]), (Seq[ProjectLink], Seq[ProjectLink])) = {
         val (transferLinks, newLinks) = if (firstRight.exists(_.status == LinkStatus.Transfer)) (firstRight, firstLeft) else (firstLeft, firstRight)
         val groupedTransfer: ListMap[Long, Seq[ProjectLink]] = ListMap(transferLinks.groupBy(_.roadwayNumber).toSeq.sortBy(r => r._2.minBy(_.startAddrMValue).startAddrMValue): _*)
 
-        val adjustedNewLinks = groupedTransfer.foldLeft(Seq.empty[ProjectLink], newLinks) {
-          case ((adjustedLinks, linksToProcess), group) =>
-            val newRoadwayNumber = Sequences.nextRoadwayNumber
-            val links = linksToProcess.take(group._2.size).map(_.copy(roadwayNumber = newRoadwayNumber))
-            val linksLeft = linksToProcess.drop(group._2.size)
-            (adjustedLinks ++ links, linksLeft)
-        }._1
+          if(newLinks.size >= groupedTransfer.size){
 
-        val (right, left) = if (adjustedNewLinks.exists(_.track == Track.RightSide)) (adjustedNewLinks, transferLinks) else (transferLinks, adjustedNewLinks)
-        ((right, restRight), (left, restLeft))
+//            val zippedAll = newLinks.zipAll(transferLinks, "", "").map({ case (n, t) =>
+//            })
+            //TODO assignRoadwayNumbers proporcionally
+          val (equatedNewLinks, restNewLinks) = groupedTransfer.foldLeft(Seq.empty[ProjectLink], newLinks) {
+            case ((adjustedLinks, linksToProcess), group) =>
+              val newRoadwayNumber = Sequences.nextRoadwayNumber
+              val links = linksToProcess.take(group._2.size).map(_.copy(roadwayNumber = newRoadwayNumber))
+              val rest = linksToProcess.drop(group._2.size)
+              (adjustedLinks ++ links, rest)
+          }
+          val adjustedNewLinks = equatedNewLinks ++ restNewLinks.map(_.copy(roadwayNumber = equatedNewLinks.last.roadwayNumber))
+
+          val (right, left) = if (adjustedNewLinks.exists(_.track == Track.RightSide)) (adjustedNewLinks, transferLinks) else (transferLinks, adjustedNewLinks)
+          ((right, restRight), (left, restLeft))
+          } else {
+            //TODO split links case here
+          ((Seq.empty[ProjectLink], Seq.empty[ProjectLink]), (Seq.empty[ProjectLink], Seq.empty[ProjectLink]))
+          }
       }
 
       def adjustableToRoadwayNumberAttribution(firstRight: Seq[ProjectLink], restRight: Seq[ProjectLink], firstLeft: Seq[ProjectLink], restLeft: Seq[ProjectLink]): Boolean = {
         ((firstRight.forall(_.status == LinkStatus.New) && firstLeft.forall(_.status == LinkStatus.Transfer))
-          || (firstRight.forall(_.status == LinkStatus.Transfer) && firstLeft.forall(_.status == LinkStatus.New))) && firstRight.size == firstLeft.size
+          || (firstRight.forall(_.status == LinkStatus.Transfer) && firstLeft.forall(_.status == LinkStatus.New)))
       }
 
       if (rightLinks.isEmpty && leftLinks.isEmpty) {
@@ -163,7 +174,7 @@ class DefaultSectionCalculatorStrategy extends RoadAddressSectionCalculatorStrat
 
         val ((firstRight, restRight), (firstLeft, restLeft)): ((Seq[ProjectLink], Seq[ProjectLink]), (Seq[ProjectLink], Seq[ProjectLink])) =
           if (adjustableToRoadwayNumberAttribution(right._1, right._2, left._1, left._2)) {
-            adjustTwoTrackRoadwayNumbers(right._1, right._2, left._1, left._2)
+              adjustTwoTrackRoadwayNumbers(right._1, right._2, left._1, left._2)
           } else {
             val newRoadwayNumber1 = Sequences.nextRoadwayNumber
             val newRoadwayNumber2 = if (rightLinks.head.track == Track.Combined || leftLinks.head.track == Track.Combined) newRoadwayNumber1 else Sequences.nextRoadwayNumber

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/DefaultSectionCalculatorStrategy.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/strategy/DefaultSectionCalculatorStrategy.scala
@@ -138,32 +138,114 @@ class DefaultSectionCalculatorStrategy extends RoadAddressSectionCalculatorStrat
         val (transferLinks, newLinks) = if (firstRight.exists(_.status == LinkStatus.Transfer)) (firstRight, firstLeft) else (firstLeft, firstRight)
         val groupedTransfer: ListMap[Long, Seq[ProjectLink]] = ListMap(transferLinks.groupBy(_.roadwayNumber).toSeq.sortBy(r => r._2.minBy(_.startAddrMValue).startAddrMValue): _*)
 
-          if(newLinks.size >= groupedTransfer.size){
+          if(newLinks.size >= groupedTransfer.size && newLinks.size >= groupedTransfer.values.flatten.size){
 
-          val (equatedNewLinks, restNewLinks) = groupedTransfer.foldLeft(Seq.empty[ProjectLink], newLinks) {
-            case ((adjustedLinks, linksToProcess), group) =>
-              val newRoadwayNumber = Sequences.nextRoadwayNumber
-              val links = linksToProcess.take(group._2.size).map(l => l.copy(roadwayNumber = newRoadwayNumber))
-              val rest = linksToProcess.drop(group._2.size)
-              (adjustedLinks ++ links.init :+ links.last.copy(connectedLinkId = Some(links.last.linkId), endAddrMValue = group._2.last.endAddrMValue), if(rest.nonEmpty)
-                rest.head.copy(startAddrMValue = group._2.last.endAddrMValue) +: rest.tail else rest)
-          }
-          val adjustedNewLinks = equatedNewLinks ++ restNewLinks.map(l => l.copy(roadwayNumber = equatedNewLinks.last.roadwayNumber))
+            val (equatedNewLinks, restNewLinks) = groupedTransfer.foldLeft(Seq.empty[ProjectLink], newLinks) {
+              case ((adjustedLinks, linksToProcess), group) =>
+                val newRoadwayNumber = Sequences.nextRoadwayNumber
+                val links = linksToProcess.take(group._2.size).map(l => l.copy(roadwayNumber = newRoadwayNumber))
+                val rest = linksToProcess.drop(group._2.size)
+                (adjustedLinks ++ links.init :+ links.last.copy(connectedLinkId = Some(links.last.linkId), endAddrMValue = group._2.last.endAddrMValue), if(rest.nonEmpty)
+                  rest.head.copy(startAddrMValue = group._2.last.endAddrMValue) +: rest.tail else rest)
+            }
+            val adjustedNewLinks = equatedNewLinks ++ restNewLinks.map(l => l.copy(roadwayNumber = equatedNewLinks.last.roadwayNumber))
 
-          val (right, left) = if (adjustedNewLinks.exists(_.track == Track.RightSide)) (adjustedNewLinks, transferLinks) else (transferLinks, adjustedNewLinks)
-          ((right, restRight), (left, restLeft))
+            val (right, left) = if (adjustedNewLinks.exists(_.track == Track.RightSide)) (adjustedNewLinks, transferLinks) else (transferLinks, adjustedNewLinks)
+            ((right, restRight), (left, restLeft))
+
+          } else if (newLinks.size >= groupedTransfer.size && newLinks.size < groupedTransfer.values.flatten.size){
+
+            val transferLength: Double = groupedTransfer.values.flatten.map(l => l.endMValue - l.startMValue).sum
+            val newLinksMValues = newLinks.map(l => l.endMValue - l.startMValue).sum
+            val assignedNewLinks = specialCaseSplitLinks(groupedTransfer, Seq(), newLinks, Seq(), transferLength, newLinksMValues, groupedTransfer.size)
+
+            val (right, left) = if (assignedNewLinks.exists(_.track == Track.RightSide)) (assignedNewLinks, transferLinks) else (transferLinks, assignedNewLinks)
+            ((right, restRight), (left, restLeft))
+
           } else {
 
-            val transferLength: Double = groupedTransfer.values.flatten.zip(groupedTransfer.values.flatten.tail).map{
-              case (a, b) => (a.endMValue-a.startMValue) + (b.endMValue-b.startMValue)}.sum
-            val newLinksMValues = if(newLinks.size == 1)
-              newLinks.head.endMValue - newLinks.head.startMValue
-            else newLinks.zip(newLinks.tail).map{case (a, b) => (a.endMValue-a.startMValue) + (b.endMValue-b.startMValue)}.sum
+            val transferLength: Double = groupedTransfer.values.flatten.map(l => l.endMValue - l.startMValue).sum
+            val newLinksMValues = newLinks.map(l => l.endMValue - l.startMValue).sum
             val splitedLinks = splitLinks(groupedTransfer, Seq(), newLinks, Seq(),
-              transferLength, newLinksMValues , groupedTransfer.size-newLinks.size)
+              transferLength, newLinksMValues, groupedTransfer.size-newLinks.size)
+
             val (right, left) = if (splitedLinks.exists(_.track == Track.RightSide)) (splitedLinks, transferLinks) else (transferLinks, splitedLinks)
             ((right, restRight), (left, restLeft))
+
           }
+      }
+
+      def specialCaseSplitLinks(remainingTransfer: ListMap[Long, Seq[ProjectLink]], processedTransfer: Seq[ProjectLink], remainingNew: Seq[ProjectLink], processedNew: Seq[ProjectLink], totalTransferMLength: Double, totalNewMLength: Double, missingRoadwayNumbers: Int) : Seq[ProjectLink] = {
+        if(missingRoadwayNumbers == 0 || (remainingNew.nonEmpty && remainingTransfer.isEmpty)){
+          val nextRoadwayNumber = Sequences.nextRoadwayNumber
+          processedNew ++ remainingNew.map(_.copy(roadwayNumber = nextRoadwayNumber))
+        } else if(remainingNew.isEmpty && remainingTransfer.isEmpty) {
+          processedNew
+        } else if (remainingNew.isEmpty && remainingTransfer.nonEmpty){
+          //TODO cenas
+          Seq()
+        } else {
+          val threshHoldMaxDistance = 2
+
+          //transfer m length coeff
+          val groupTransferMLength = remainingTransfer.head._2.map(l => l.endMValue - l.startMValue).sum
+
+          val lowerAllowedTransferGroupCoeff = (groupTransferMLength-threshHoldMaxDistance)/totalTransferMLength
+          val biggerAllowedTransferGroupCoeff = (groupTransferMLength+threshHoldMaxDistance)/totalTransferMLength
+
+          //new m length coeff
+          val processedNewToBeAssigned = processedNew.filter(_.roadwayNumber == NewIdValue)
+          val processingLength: Double = if(processedNewToBeAssigned.isEmpty){ remainingNew.head.endMValue - remainingNew.head.startMValue
+              } else {
+                (remainingNew.head.endMValue - remainingNew.head.startMValue) +
+                  processedNewToBeAssigned.map(l => l.endMValue - l.startMValue).sum
+              }
+          val currentNewLinksGroupCoeff: Double = processingLength/totalNewMLength
+          if(lowerAllowedTransferGroupCoeff <= currentNewLinksGroupCoeff && currentNewLinksGroupCoeff <= biggerAllowedTransferGroupCoeff){
+            specialCaseSplitLinks(remainingTransfer.tail, processedTransfer ++ remainingTransfer.head._2, remainingNew.tail, processedNew:+remainingNew.head,
+              totalTransferMLength, totalNewMLength, missingRoadwayNumbers - 1)
+          } else if(lowerAllowedTransferGroupCoeff > currentNewLinksGroupCoeff){
+            specialCaseSplitLinks(remainingTransfer, processedTransfer, remainingNew.tail, processedNew:+remainingNew.head,
+              totalTransferMLength, totalNewMLength, missingRoadwayNumbers)
+          } else {
+            /*
+            calculate missing geometry left to fulfill the exactly groupTransfer coefficient
+             */
+            //by that we want to pick previous processedLinks
+            val processedNewToBeAssigned = processedNew.filter(_.roadwayNumber == NewIdValue)
+            val previousProcessed = if(processedNewToBeAssigned.isEmpty) Seq() else processedNewToBeAssigned
+            val linkToBeSplited = remainingNew.head
+            //get their length
+            val previousProcessedLength: Double = if(previousProcessed.isEmpty){ remainingNew.head.endMValue - remainingNew.head.startMValue
+            } else {
+              previousProcessed.map(l => l.endMValue - l.startMValue).sum
+            }
+
+            //coeficient to be matched for current transfer group
+            val perfectTransferGroupCoeff = groupTransferMLength/totalTransferMLength
+            /*
+              (previousProcessedLength+m)/totalNewMLength = perfectTransferGroupCoeff <=>
+              <=> previousProcessedLength+m = perfectTransferGroupCoeff*totalNewMLength <=>
+              <=> m = (perfectTransferGroupCoeff*totalNewMLength) - previousProcessedLength
+             */
+            val splitMValue = (perfectTransferGroupCoeff*totalNewMLength) - previousProcessedLength
+
+            val firstSplitedEndAddr = remainingTransfer.head._2.last.endAddrMValue
+            val firstSplitedLinkGeom = GeometryUtils.truncateGeometry2D(linkToBeSplited.geometry, 0.0, splitMValue)
+            val secondSplitedLinkGeom = GeometryUtils.truncateGeometry2D(linkToBeSplited.geometry, splitMValue, linkToBeSplited.endMValue)
+
+            //processedLinks without and with roadwayNumber
+            val (unassignedRoadwayNumber, assignedRoadwayNumber) = processedNew.partition(_.roadwayNumber == NewIdValue)
+            val nextRoadwayNumber = Sequences.nextRoadwayNumber
+            val processedNewWithSplitedLink = assignedRoadwayNumber ++ unassignedRoadwayNumber.map(_.copy(roadwayNumber = nextRoadwayNumber)) :+linkToBeSplited.copy(endMValue = splitMValue,
+              geometry = firstSplitedLinkGeom, geometryLength = GeometryUtils.geometryLength(firstSplitedLinkGeom), endAddrMValue = firstSplitedEndAddr,
+              roadwayNumber = nextRoadwayNumber, connectedLinkId = Some(linkToBeSplited.linkId))
+
+            specialCaseSplitLinks(remainingTransfer.tail, processedTransfer++remainingTransfer.head._2, linkToBeSplited.copy(id = NewIdValue, startMValue = splitMValue,
+              geometry = secondSplitedLinkGeom, geometryLength = GeometryUtils.geometryLength(secondSplitedLinkGeom), startAddrMValue = firstSplitedEndAddr) +: remainingNew.tail , processedNewWithSplitedLink
+              , totalTransferMLength, totalNewMLength, missingRoadwayNumbers-1)
+          }
+        }
       }
 
       /**
@@ -174,9 +256,10 @@ class DefaultSectionCalculatorStrategy extends RoadAddressSectionCalculatorStrat
         * @param processedNew
         * @return New links with proper same different roadwayNumbers as the opposite Transfer track
         */
-      def splitLinks(remainingTransfer: ListMap[Long, Seq[ProjectLink]], processedTransfer: Seq[ProjectLink], remainingNew: Seq[ProjectLink], processedNew: Seq[ProjectLink], totalTransferMLength: Double, totalNewMLength: Double, missingRoadwayNumbers: Int) : Seq[ProjectLink]= {
-        if(missingRoadwayNumbers == 0){//if links size the same as the diff roadwayNumbers in Transfer side, then
-          processedNew ++ remainingNew.map(_.copy(roadwayNumber = Sequences.nextRoadwayNumber))
+      def splitLinks(remainingTransfer: ListMap[Long, Seq[ProjectLink]], processedTransfer: Seq[ProjectLink], remainingNew: Seq[ProjectLink], processedNew: Seq[ProjectLink], totalTransferMLength: Double, totalNewMLength: Double, missingRoadwayNumbers: Int) : Seq[ProjectLink] = {
+        if(missingRoadwayNumbers == 0){
+          val nextRoadwayNumber = Sequences.nextRoadwayNumber
+          processedNew ++ remainingNew.map(_.copy(roadwayNumber = nextRoadwayNumber))
         } else if(remainingNew.isEmpty && remainingTransfer.isEmpty) {
           processedNew
         } else if (remainingNew.isEmpty && remainingTransfer.nonEmpty){
@@ -184,15 +267,10 @@ class DefaultSectionCalculatorStrategy extends RoadAddressSectionCalculatorStrat
             totalTransferMLength, totalNewMLength, missingRoadwayNumbers)
         } else {
           val threshHoldMaxDistance = 2
-          //transfer addr coeff
-          val groupTransferAddr = remainingTransfer.head._2.last.endAddrMValue - remainingTransfer.head._2.head.startAddrMValue
-          val transferAddrCoeff = groupTransferAddr/remainingTransfer.last._2.last.endAddrMValue
 
           //transfer m length coeff
-          val groupTransferMLength = if(remainingTransfer.head._2.size == 1)
-            remainingTransfer.head._2.head.endMValue - remainingTransfer.head._2.head.startMValue
-          else
-            remainingTransfer.head._2.zip(remainingTransfer.head._2.tail).map{case (a, b) => (a.endMValue-a.startMValue) + (b.endMValue-b.startMValue)}.sum
+          val groupTransferMLength = remainingTransfer.head._2.map(l => l.endMValue - l.startMValue).sum
+
           val transferGroupCoeff = (groupTransferMLength-threshHoldMaxDistance)/totalTransferMLength
 
           //new m length coeff
@@ -204,7 +282,7 @@ class DefaultSectionCalculatorStrategy extends RoadAddressSectionCalculatorStrat
               totalTransferMLength, totalNewMLength, missingRoadwayNumbers)
           } else {
             val firstSplitedEndAddr = remainingTransfer.head._2.last.endAddrMValue
-            val secondSplitedEndAddr = remainingTransfer.tail.head._2.last.endAddrMValue
+//            val secondSplitedEndAddr = remainingTransfer.tail.head._2.last.endAddrMValue
             val firstSplitedEndMValue = transferGroupCoeff*currentLinkLength
             val firstSplitedLinkGeom = GeometryUtils.truncateGeometry2D(remainingNew.head.geometry, 0.0, firstSplitedEndMValue)
             val secondSplitedLinkGeom = GeometryUtils.truncateGeometry2D(remainingNew.head.geometry, firstSplitedEndMValue, remainingNew.head.endMValue)
@@ -215,7 +293,7 @@ class DefaultSectionCalculatorStrategy extends RoadAddressSectionCalculatorStrat
                 roadwayNumber = Sequences.nextRoadwayNumber, connectedLinkId = Some(remainingNew.head.linkId)),
               remainingNew.head.copy(id = NewIdValue, startMValue = firstSplitedEndMValue,
                 geometry = secondSplitedLinkGeom, geometryLength = GeometryUtils.geometryLength(secondSplitedLinkGeom), startAddrMValue = firstSplitedEndAddr,
-                endAddrMValue = secondSplitedEndAddr, roadwayNumber = Sequences.nextRoadwayNumber, connectedLinkId = Some(remainingNew.head.linkId))),
+                /*endAddrMValue = secondSplitedEndAddr,*/ roadwayNumber = Sequences.nextRoadwayNumber, connectedLinkId = Some(remainingNew.head.linkId))),
               totalTransferMLength, totalNewMLength, missingRoadwayNumbers-1)
           }
         }

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/DefaultSectionCalculatorStrategySpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/DefaultSectionCalculatorStrategySpec.scala
@@ -310,7 +310,7 @@ class DefaultSectionCalculatorStrategySpec extends FunSuite with Matchers {
         "", Seq(), Seq(), None, None)
 
       val projectLinkLeft1 = ProjectLink(projectLinkId, 9999L, 1L, Track.apply(2), Discontinuity.Discontinuous, 0L, 0L, 0L, 0L, None, None,
-        Some("user"), 12345L, 0.0, 0.0, SideCode.Unknown, (None, None),
+        Some("user"), 12345L, 0.0, 60.0, SideCode.Unknown, (None, None),
         geomLeft1, 0L, LinkStatus.New, RoadType.PublicRoad, LinkGeomSource.NormalLinkInterface, GeometryUtils.geometryLength(geomLeft1), 0L, 0, 0, reversed = false,
         None, 86400L, roadwayNumber = 12345L)
 

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/DefaultSectionCalculatorStrategySpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/DefaultSectionCalculatorStrategySpec.scala
@@ -1086,6 +1086,153 @@ Left     |  ^   Right
 
       val (left, right) = assignedValues.filterNot(_.track == Track.Combined).partition(_.track == Track.LeftSide)
       assignedValues.size should be (6)
+//      left.count(_.roadwayNumber).distinct should be (right.count(_.roadwayNumber).distinct)
+      left.head.startAddrMValue should be (right.head.startAddrMValue)
+      left.head.endAddrMValue should be (right.head.endAddrMValue)
+      left.last.startAddrMValue should be (right.last.startAddrMValue)
+      left.last.endAddrMValue should be (right.last.endAddrMValue)
+    }
+  }
+
+  test("Test defaultSectionCalculatorStrategy.assignMValues() and the attribution of roadway_numbers for new Left Right sections with diff number of links Then " +
+    "if there are some consecutive links with diff roadway_number (and all Transfer status), the opposite track, should split their link(s) if the amount of links is lower than the Transfer track side with same end addresses as the other side and different roadway numbers") {
+    runWithRollback {
+
+      /*geoms
+
+                 ^ Combined2
+                 |
+Left3 ----------^^  Right4
+      |          |
+      |          ^   Right3
+Left2 ^          |
+      |          ^  Right2
+      |         |
+Left1 ---<----  ^ Right1
+             |  |
+              ^
+              | Combined1
+      */
+
+      //Combined
+      val geomTransferCombined1 = Seq(Point(10.0, 0.0), Point(10.0, 5.0))
+      val geomTransferCombined2 = Seq(Point(12.0, 20.0), Point(12.0, 25.0))
+
+      //Left
+      val geomNewLeft1 = Seq(Point(10.0, 5.0), Point(8.0, 10.0), Point(5.0, 10.0))
+      val geomNewLeft2 = Seq(Point(5.0, 10.0), Point(0.0, 10.0), Point(0.0, 15.0))
+      val geomNewLeft3 = Seq(Point(0.0, 15.0), Point(0.0, 20.0), Point(12.0, 20.0))
+
+      //Right
+      val geomTransferRight1 = Seq(Point(10.0, 5.0), Point(12.0, 10.0))
+      val geomTransferRight2 = Seq(Point(12.0, 10.0), Point(12.0, 13.0))
+      val geomTransferRight3 = Seq(Point(12.0, 13.0), Point(12.0, 16.0))
+      val geomTransferRight4 = Seq(Point(12.0, 16.0), Point(12.0, 20.0))
+
+
+      val projectId = Sequences.nextViiteProjectId
+      val roadwayId1 = Sequences.nextRoadwayId
+      val roadwayId2 = Sequences.nextRoadwayId
+      val roadwayNumber1 = Sequences.nextRoadwayNumber
+      val roadwayNumber2 = Sequences.nextRoadwayNumber
+      val linearLocationId1 = Sequences.nextLinearLocationId
+      val linearLocationId2 = Sequences.nextLinearLocationId
+      val linearLocationId3 = Sequences.nextLinearLocationId
+      val linearLocationId4 = Sequences.nextLinearLocationId
+      val linearLocationId5 = Sequences.nextLinearLocationId
+      val linearLocationId6 = Sequences.nextLinearLocationId
+      val project = Project(projectId, ProjectState.Incomplete, "f", "s", DateTime.now(), "", DateTime.now(), DateTime.now(),
+        "", Seq(), Seq(), None, None)
+
+      //projectlinks
+
+      //Combined Transfer
+      val projectLinkCombined1 = ProjectLink(-1000L, 9999L, 1L, Track.apply(0), Discontinuity.Continuous, 0L, 5L, 0L, 5L, None, None,
+        None, 12345L, 0.0, 5.0, SideCode.TowardsDigitizing, (None, None),
+        geomTransferCombined1, projectId, LinkStatus.Transfer, RoadType.PublicRoad, LinkGeomSource.NormalLinkInterface, GeometryUtils.geometryLength(geomTransferCombined1), roadwayId1, linearLocationId1, 8L, reversed = false,
+        None, 86400L, roadwayNumber = roadwayNumber1)
+
+      val projectLinkCombined2 = ProjectLink(-1000L, 9999L, 1L, Track.apply(0), Discontinuity.EndOfRoad, 20L, 25L, 20L, 25L, None, None,
+        None, 12349L, 0.0, 5.0, SideCode.TowardsDigitizing, (None, None),
+        geomTransferCombined2, projectId, LinkStatus.Transfer, RoadType.PublicRoad, LinkGeomSource.NormalLinkInterface, GeometryUtils.geometryLength(geomTransferCombined2), roadwayId2, linearLocationId6, 8L, reversed = false,
+        None, 86400L, roadwayNumber = roadwayNumber2)
+
+      //Left New
+      val projectLinkLeft1 = ProjectLink(-1000L, 9999L, 1L, Track.apply(2), Discontinuity.Continuous, 0L, 0L, 0L, 0L, None, None,
+        None, 12350L, 0.0, 20.0, SideCode.TowardsDigitizing, (None, None),
+        geomNewLeft1, projectId, LinkStatus.New, RoadType.PublicRoad, LinkGeomSource.NormalLinkInterface, GeometryUtils.geometryLength(geomNewLeft1), -1000, -1000, 8L, reversed = false,
+        None, 86400L)
+      val projectLinkLeft2 = ProjectLink(-1000L, 9999L, 1L, Track.apply(2), Discontinuity.Continuous, 0L, 0L, 0L, 0L, None, None,
+        None, 12351L, 0.0, 20.0, SideCode.TowardsDigitizing, (None, None),
+        geomNewLeft2, projectId, LinkStatus.New, RoadType.PublicRoad, LinkGeomSource.NormalLinkInterface, GeometryUtils.geometryLength(geomNewLeft2), -1000, -1000, 8L, reversed = false,
+        None, 86400L)
+      val projectLinkLeft3 = ProjectLink(-1000L, 9999L, 1L, Track.apply(2), Discontinuity.Continuous, 0L, 0L, 0L, 0L, None, None,
+        None, 12352L, 0.0, 20.0, SideCode.TowardsDigitizing, (None, None),
+        geomNewLeft3, projectId, LinkStatus.New, RoadType.PublicRoad, LinkGeomSource.NormalLinkInterface, GeometryUtils.geometryLength(geomNewLeft3), -1000, -1000, 8L, reversed = false,
+        None, 86400L)
+
+      //Right Transfer
+      val projectLinkRight1 = ProjectLink(-1000L, 9999L, 1L, Track.apply(1), Discontinuity.Continuous, 5L, 10L, 5L, 10L, None, None,
+        None, 12346L, 0.0, 5.0, SideCode.TowardsDigitizing, (None, None),
+        geomTransferRight1, projectId, LinkStatus.Transfer, RoadType.PublicRoad, LinkGeomSource.NormalLinkInterface, GeometryUtils.geometryLength(geomTransferRight1), roadwayId1, linearLocationId2, 8L, reversed = false,
+        None, 86400L, roadwayNumber = roadwayNumber1)
+      val projectLinkRight2 = ProjectLink(-1000L, 9999L, 1L, Track.apply(1), Discontinuity.Continuous, 10L, 13, 10L, 13L, None, None,
+        None, 12347L, 3.0, 6.0, SideCode.TowardsDigitizing, (None, None),
+        geomTransferRight2, projectId, LinkStatus.Transfer, RoadType.PublicRoad, LinkGeomSource.NormalLinkInterface, GeometryUtils.geometryLength(geomTransferRight2), roadwayId1, linearLocationId3, 8L, reversed = false,
+        None, 86400L, roadwayNumber = roadwayNumber1)
+      val projectLinkRight3 = ProjectLink(-1000L, 9999L, 1L, Track.apply(1), Discontinuity.Continuous, 13L, 16L, 13L, 16L, None, None,
+        None, 12347L, 0.0, 3.0, SideCode.TowardsDigitizing, (None, None),
+        geomTransferRight3, projectId, LinkStatus.Transfer, RoadType.PublicRoad, LinkGeomSource.NormalLinkInterface, GeometryUtils.geometryLength(geomTransferRight3), roadwayId2, linearLocationId4, 8L, reversed = false,
+        None, 86400L, roadwayNumber = roadwayNumber2)
+      val projectLinkRight4 = ProjectLink(-1000L, 9999L, 1L, Track.apply(1), Discontinuity.Continuous, 16L, 20L, 16L, 20L, None, None,
+        None, 12348L, 0.0, 4.0, SideCode.TowardsDigitizing, (None, None),
+        geomTransferRight4, projectId, LinkStatus.Transfer, RoadType.PublicRoad, LinkGeomSource.NormalLinkInterface, GeometryUtils.geometryLength(geomTransferRight4), roadwayId2, linearLocationId5, 8L, reversed = false,
+        None, 86400L, roadwayNumber = roadwayNumber2)
+
+      //create before transfer data
+      val roadwayCombined1 =  Roadway(roadwayId1, roadwayNumber1, 9999L,1, RoadType.PublicRoad, Track.apply(0), Discontinuity.Continuous, 0, 13, reversed = false, DateTime.now(), None,
+        "tester", Some("rd 9999"), 8L, TerminationCode.NoTermination, DateTime.now(), None)
+      val linearCombined1 = LinearLocation(linearLocationId1, 1, 12345L, 0.0, 5.0, SideCode.TowardsDigitizing, 86400L,
+        (CalibrationPointsUtils.toCalibrationPointReference(Some(ProjectLinkCalibrationPoint(12345L, 0.0, 0))),
+          CalibrationPointsUtils.toCalibrationPointReference(None)),
+        geomTransferCombined1, LinkGeomSource.NormalLinkInterface,
+        roadwayNumber1, Some(DateTime.now().minusDays(1)), None)
+      val linearCombined2 = LinearLocation(linearLocationId1, 2, 12346L, 0.0, 5.0, SideCode.TowardsDigitizing, 86400L,
+        (CalibrationPointsUtils.toCalibrationPointReference(None),
+          CalibrationPointsUtils.toCalibrationPointReference(None)),
+        geomTransferRight1, LinkGeomSource.NormalLinkInterface,
+        roadwayNumber1, Some(DateTime.now().minusDays(1)), None)
+      val linearCombined3 = LinearLocation(linearLocationId1, 3, 12347L, 3.0, 6.0, SideCode.TowardsDigitizing, 86400L,
+        (CalibrationPointsUtils.toCalibrationPointReference(None),
+          CalibrationPointsUtils.toCalibrationPointReference(None)),
+        geomTransferRight2, LinkGeomSource.NormalLinkInterface,
+        roadwayNumber1, Some(DateTime.now().minusDays(1)), None)
+
+      val roadwayCombined2 = Roadway(roadwayId2, roadwayNumber2, 9999L,1, RoadType.PublicRoad, Track.apply(0), Discontinuity.EndOfRoad, 13, 25, reversed = false, DateTime.now(), None,
+        "tester", Some("rd 9999"), 8L, TerminationCode.NoTermination, DateTime.now(), None)
+      val linearCombined4 = LinearLocation(linearLocationId2, 1, 12347L, 0.0, 3.0, SideCode.TowardsDigitizing, 86400L,
+        (CalibrationPointsUtils.toCalibrationPointReference(None),
+          CalibrationPointsUtils.toCalibrationPointReference(None)),
+        geomTransferRight3, LinkGeomSource.NormalLinkInterface,
+        roadwayNumber2, Some(DateTime.now().minusDays(1)), None)
+      val linearCombined5 = LinearLocation(linearLocationId3, 2, 12348L, 0.0, 4.0, SideCode.TowardsDigitizing, 86400L,
+        (CalibrationPointsUtils.toCalibrationPointReference(None),
+          CalibrationPointsUtils.toCalibrationPointReference(None)),
+        geomTransferRight4, LinkGeomSource.NormalLinkInterface,
+        roadwayNumber2, Some(DateTime.now().minusDays(1)), None)
+      val linearCombined6 = LinearLocation(linearLocationId3, 3, 12349L, 0.0, 5.0, SideCode.TowardsDigitizing, 86400L,
+        (CalibrationPointsUtils.toCalibrationPointReference(None),
+          CalibrationPointsUtils.toCalibrationPointReference(Some(ProjectLinkCalibrationPoint(12349L, 5.0, 20)))),
+        geomTransferCombined2, LinkGeomSource.NormalLinkInterface,
+        roadwayNumber2, Some(DateTime.now().minusDays(1)), None)
+
+
+      buildTestDataForProject(Some(project), Some(Seq(roadwayCombined1, roadwayCombined2)), Some(Seq(linearCombined1, linearCombined2, linearCombined3, linearCombined4, linearCombined5, linearCombined6)), None)
+      val assignedValues = defaultSectionCalculatorStrategy.assignMValues(Seq(projectLinkLeft1, projectLinkLeft2, projectLinkLeft3), Seq(projectLinkCombined1, projectLinkRight1, projectLinkRight2, projectLinkRight3, projectLinkRight4, projectLinkCombined2), Seq.empty[UserDefinedCalibrationPoint])
+
+      val (left, right) = assignedValues.filterNot(_.track == Track.Combined).partition(_.track == Track.LeftSide)
+      assignedValues.size should be (8)
+//      left.count(_.roadwayNumber).distinct should be (right.count(_.roadwayNumber).distinct)
       left.head.startAddrMValue should be (right.head.startAddrMValue)
       left.head.endAddrMValue should be (right.head.endAddrMValue)
       left.last.startAddrMValue should be (right.last.startAddrMValue)

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/DefaultSectionCalculatorStrategySpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/DefaultSectionCalculatorStrategySpec.scala
@@ -1417,11 +1417,11 @@ Left     |      |
 
 
       //Left New
-      val projectLinkLeft1 = ProjectLink(-1000L, 9999L, 1L, Track.apply(2), Discontinuity.Discontinuous, 0L, 0L, 0L, 0L, None, None,
+      val projectLinkLeft1 = ProjectLink(-1000L, 9999L, 1L, Track.apply(2), Discontinuity.Continuous, 0L, 0L, 0L, 0L, None, None,
         None, 12350L, 0.0, 1.0, SideCode.TowardsDigitizing, (None, None),
         geomNewLeft1, projectId, LinkStatus.New, RoadType.PublicRoad, LinkGeomSource.NormalLinkInterface, GeometryUtils.geometryLength(geomNewLeft1), -1000, -1000, 8L, reversed = false,
         None, 86400L)
-      val projectLinkLeft2 = ProjectLink(-1000L, 9999L, 1L, Track.apply(2), Discontinuity.Discontinuous, 0L, 0L, 0L, 0L, None, None,
+      val projectLinkLeft2 = ProjectLink(-1000L, 9999L, 1L, Track.apply(2), Discontinuity.Continuous, 0L, 0L, 0L, 0L, None, None,
         None, 12348L, 0.0, 10.18, SideCode.TowardsDigitizing, (None, None),
         geomNewLeft2, projectId, LinkStatus.New, RoadType.PublicRoad, LinkGeomSource.NormalLinkInterface, GeometryUtils.geometryLength(geomNewLeft2), -1000, -1000, 8L, reversed = false,
         None, 86400L)

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/DefaultSectionCalculatorStrategySpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/DefaultSectionCalculatorStrategySpec.scala
@@ -1339,10 +1339,12 @@ Left     |  ^   Right
     runWithRollback {
 
       /*geoms
-         ^  ^
-         |  |
-Left     |  ^   Right
-         |  |
+         ^  ^----
+         |      |
+Left     |      |
+         |      ^  Right
+         |      |
+         ^  ---->
          |  |
           ^
           | Combined
@@ -1448,7 +1450,7 @@ Left     |  ^   Right
         roadwayNumber3, Some(DateTime.now().minusDays(1)), None)
 
       buildTestDataForProject(Some(project), Some(Seq(roadwayCombined1, roadwayCombined2, roadwayCombined3)), Some(Seq(linearCombined1, linearCombined2, linearCombined3, linearCombined4)), None)
-      val assignedValues = defaultSectionCalculatorStrategy.assignMValues(Seq(projectLinkLeft1), Seq(projectLinkCombined1, projectLinkCombined2, projectLinkRight1, projectLinkRight2), Seq.empty[UserDefinedCalibrationPoint])
+      val assignedValues = defaultSectionCalculatorStrategy.assignMValues(Seq(projectLinkLeft1, projectLinkLeft2), Seq(projectLinkCombined1, projectLinkCombined2, projectLinkRight1, projectLinkRight2, projectLinkRight3), Seq.empty[UserDefinedCalibrationPoint])
 
       val (left, right) = assignedValues.filterNot(_.track == Track.Combined).partition(_.track == Track.LeftSide)
       assignedValues.size should be (8)
@@ -1456,9 +1458,6 @@ Left     |  ^   Right
       left.map(_.roadwayNumber).distinct.size should be (2)
     }
   }
-
-//  test("Test defaultSectionCalculatorStrategy.assignMValues() and the attribution of roadway_numbers for new Left Right sections with diff number of links Then " +
-//    "if there are for e.g. 3 (three) consecutive links with diff roadway number (and all Transfer status), the opposite track (New), should split their link(s) if the amount of links is lower than three, to have the same amount of roadway numbers, and not split the first one if the first transfer link found is too long when comparing to the opposite first New link") {
 
   test("Test defaultSectionCalculatorStrategy.assignMValues() and the attribution of roadway_numbers for new Left Right sections with diff number of links Then " +
     "if there are some consecutive links with diff roadway_number (and all Transfer status), the opposite track, should split their link(s) if the amount of links is lower than the Transfer track side with same end addresses as the other side and different roadway numbers") {

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/DefaultSectionCalculatorStrategySpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/DefaultSectionCalculatorStrategySpec.scala
@@ -1373,6 +1373,7 @@ Left     |      |
       val roadwayNumber1 = Sequences.nextRoadwayNumber
       val roadwayNumber2 = Sequences.nextRoadwayNumber
       val roadwayNumber3 = Sequences.nextRoadwayNumber
+      val roadwayNumber4 = Sequences.nextRoadwayNumber
       val linearLocationId1 = Sequences.nextLinearLocationId
       val linearLocationId2 = Sequences.nextLinearLocationId
       val linearLocationId3 = Sequences.nextLinearLocationId
@@ -1417,7 +1418,7 @@ Left     |      |
       val projectLinkRight3 = ProjectLink(-1000L, 9999L, 1L, Track.apply(1), Discontinuity.Discontinuous, 24L, 30, 23L, 30L, None, None,
         None, 12347L, 0.0, 5.0, SideCode.TowardsDigitizing, (None, None),
         geomTransferRight3, projectId, LinkStatus.Transfer, RoadType.PublicRoad, LinkGeomSource.NormalLinkInterface, GeometryUtils.geometryLength(geomTransferRight3), roadwayId3, linearLocationId5, 8L, reversed = false,
-        None, 86400L, roadwayNumber = roadwayNumber3)
+        None, 86400L, roadwayNumber = roadwayNumber4)
 
       //create before transfer data
       val roadwayCombined1 =  Roadway(roadwayId1, roadwayNumber1, 9999L,1, RoadType.PublicRoad, Track.apply(0), Discontinuity.Continuous, 0, 5, reversed = false, DateTime.now(), None,
@@ -1455,7 +1456,7 @@ Left     |      |
       val (left, right) = assignedValues.filterNot(_.track == Track.Combined).partition(_.track == Track.LeftSide)
       assignedValues.size should be (8)
       left.map(_.roadwayNumber).distinct.size should be (right.map(_.roadwayNumber).size)
-      left.map(_.roadwayNumber).distinct.size should be (2)
+      left.map(_.roadwayNumber).distinct.size should be (3)
     }
   }
 

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/DefaultSectionCalculatorStrategySpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/DefaultSectionCalculatorStrategySpec.scala
@@ -981,6 +981,124 @@ class DefaultSectionCalculatorStrategySpec extends FunSuite with Matchers {
     }
   }
 
+  test("Test defaultSectionCalculatorStrategy.assignMValues() and the attribution of roadway_numbers for new Left Right sections with same number of links Then " +
+    "if there are for e.g. 2 (two) consecutive links with diff roadway number (and all Transfer status), the opposite track (New), should also have 2 diff roadway numbers link(s) even if the amount of the new links is the same than the Transfer side") {
+    runWithRollback {
+
+      /*geoms
+         ^  ^
+         |  |
+Left     |  ^   Right
+         ^  |
+         |  |
+         |  |
+          ^
+          | Combined
+          ^
+          |
+      */
+
+      //Combined
+      val geomTransferCombined1 = Seq(Point(10.0, 0.0), Point(10.0, 5.0))
+      val geomTransferCombined2 = Seq(Point(10.0, 5.0), Point(10.0, 10.0))
+
+      //Left
+      val geomNewLeft1 = Seq(Point(10.0, 10.0), Point(8.0, 13.0))
+      val geomNewLeft2 = Seq(Point(8.0, 13.0), Point(5.0, 20.0))
+
+      //Right
+      val geomTransferRight1 = Seq(Point(10.0, 10.0), Point(15.0, 23.0))
+      val geomTransferRight2 = Seq(Point(15.0, 23.0), Point(15.0, 30.0))
+
+
+      val projectId = Sequences.nextViiteProjectId
+      val roadwayId1 = Sequences.nextRoadwayId
+      val roadwayId2 = Sequences.nextRoadwayId
+      val roadwayId3 = Sequences.nextRoadwayId
+      val roadwayNumber1 = Sequences.nextRoadwayNumber
+      val roadwayNumber2 = Sequences.nextRoadwayNumber
+      val roadwayNumber3 = Sequences.nextRoadwayNumber
+      val linearLocationId1 = Sequences.nextLinearLocationId
+      val linearLocationId2 = Sequences.nextLinearLocationId
+      val linearLocationId3 = Sequences.nextLinearLocationId
+      val linearLocationId4 = Sequences.nextLinearLocationId
+      val project = Project(projectId, ProjectState.Incomplete, "f", "s", DateTime.now(), "", DateTime.now(), DateTime.now(),
+        "", Seq(), Seq(), None, None)
+
+      //projectlinks
+
+      //Combined Transfer
+      val projectLinkCombined1 = ProjectLink(-1000L, 9999L, 1L, Track.apply(0), Discontinuity.Continuous, 0L, 5L, 0L, 5L, None, None,
+        None, 12345L, 0.0, 5.0, SideCode.TowardsDigitizing, (None, None),
+        geomTransferCombined1, projectId, LinkStatus.Transfer, RoadType.PublicRoad, LinkGeomSource.NormalLinkInterface, GeometryUtils.geometryLength(geomTransferCombined1), roadwayId1, linearLocationId1, 8L, reversed = false,
+        None, 86400L, roadwayNumber = roadwayNumber1)
+
+      val projectLinkCombined2 = ProjectLink(-1000L, 9999L, 1L, Track.apply(0), Discontinuity.Continuous, 5L, 10L, 5L, 10L, None, None,
+        None, 12346L, 0.0, 5.0, SideCode.TowardsDigitizing, (None, None),
+        geomTransferCombined2, projectId, LinkStatus.Transfer, RoadType.PublicRoad, LinkGeomSource.NormalLinkInterface, GeometryUtils.geometryLength(geomTransferCombined2), roadwayId2, linearLocationId2, 8L, reversed = false,
+        None, 86400L, roadwayNumber = roadwayNumber2)
+
+
+      //Left New
+      val projectLinkLeft1 = ProjectLink(-1000L, 9999L, 1L, Track.apply(2), Discontinuity.Discontinuous, 0L, 0L, 0L, 0L, None, None,
+        None, 12348L, 0.0, 3.0, SideCode.TowardsDigitizing, (None, None),
+        geomNewLeft1, projectId, LinkStatus.New, RoadType.PublicRoad, LinkGeomSource.NormalLinkInterface, GeometryUtils.geometryLength(geomNewLeft1), -1000, -1000, 8L, reversed = false,
+        None, 86400L)
+      val projectLinkLeft2 = ProjectLink(-1000L, 9999L, 1L, Track.apply(2), Discontinuity.Discontinuous, 0L, 0L, 0L, 0L, None, None,
+        None, 12349L, 0.0, 6.0, SideCode.TowardsDigitizing, (None, None),
+        geomNewLeft2, projectId, LinkStatus.New, RoadType.PublicRoad, LinkGeomSource.NormalLinkInterface, GeometryUtils.geometryLength(geomNewLeft2), -1000, -1000, 8L, reversed = false,
+        None, 86400L)
+
+      //Right Transfer
+      val projectLinkRight1 = ProjectLink(-1000L, 9999L, 1L, Track.apply(1), Discontinuity.Continuous, 10L, 23L, 10L, 23L, None, None,
+        None, 12346L, 5.0, 18.0, SideCode.TowardsDigitizing, (None, None),
+        geomTransferRight1, projectId, LinkStatus.Transfer, RoadType.PublicRoad, LinkGeomSource.NormalLinkInterface, GeometryUtils.geometryLength(geomTransferRight1), roadwayId2, linearLocationId3, 8L, reversed = false,
+        None, 86400L, roadwayNumber = roadwayNumber2)
+      val projectLinkRight2 = ProjectLink(-1000L, 9999L, 1L, Track.apply(1), Discontinuity.Discontinuous, 23L, 30, 23L, 30L, None, None,
+        None, 12347L, 0.0, 7.0, SideCode.TowardsDigitizing, (None, None),
+        geomTransferRight2, projectId, LinkStatus.Transfer, RoadType.PublicRoad, LinkGeomSource.NormalLinkInterface, GeometryUtils.geometryLength(geomTransferRight2), roadwayId3, linearLocationId4, 8L, reversed = false,
+        None, 86400L, roadwayNumber = roadwayNumber3)
+
+      //create before transfer data
+      val roadwayCombined1 =  Roadway(roadwayId1, roadwayNumber1, 9999L,1, RoadType.PublicRoad, Track.apply(0), Discontinuity.Continuous, 0, 5, reversed = false, DateTime.now(), None,
+        "tester", Some("rd 9999"), 8L, TerminationCode.NoTermination, DateTime.now(), None)
+      val linearCombined1 = LinearLocation(linearLocationId1, 1, 12345L, 0.0, 5.0, SideCode.TowardsDigitizing, 86400L,
+        (CalibrationPointsUtils.toCalibrationPointReference(Some(ProjectLinkCalibrationPoint(12345L, 0.0, 0))),
+          CalibrationPointsUtils.toCalibrationPointReference(None)),
+        geomTransferCombined1, LinkGeomSource.NormalLinkInterface,
+        roadwayNumber1, Some(DateTime.now().minusDays(1)), None)
+
+      val roadwayCombined2 = Roadway(roadwayId2, roadwayNumber2, 9999L,1, RoadType.PublicRoad, Track.apply(0), Discontinuity.Continuous, 5, 18, reversed = false, DateTime.now(), None,
+        "tester", Some("rd 9999"), 8L, TerminationCode.NoTermination, DateTime.now(), None)
+      val linearCombined2 = LinearLocation(linearLocationId2, 1, 12346L, 0.0, 5.0, SideCode.TowardsDigitizing, 86400L,
+        (CalibrationPointsUtils.toCalibrationPointReference(None),
+          CalibrationPointsUtils.toCalibrationPointReference(None)),
+        geomTransferCombined2, LinkGeomSource.NormalLinkInterface,
+        roadwayNumber2, Some(DateTime.now().minusDays(1)), None)
+      val linearCombined3 = LinearLocation(linearLocationId3, 2, 12346L, 5.0, 18.0, SideCode.TowardsDigitizing, 86400L,
+        (CalibrationPointsUtils.toCalibrationPointReference(None),
+          CalibrationPointsUtils.toCalibrationPointReference(None)),
+        geomTransferRight1, LinkGeomSource.NormalLinkInterface,
+        roadwayNumber2, Some(DateTime.now().minusDays(1)), None)
+
+      val roadwayCombined3 = Roadway(roadwayId3, roadwayNumber3, 9999L,1, RoadType.PublicRoad, Track.apply(0), Discontinuity.Discontinuous, 0, 7, reversed = false, DateTime.now(), None,
+        "tester", Some("rd 9999"), 8L, TerminationCode.NoTermination, DateTime.now(), None)
+      val linearCombined4 = LinearLocation(linearLocationId4, 1, 12347L, 0.0, 7.0, SideCode.TowardsDigitizing, 86400L,
+        (CalibrationPointsUtils.toCalibrationPointReference(None),
+          CalibrationPointsUtils.toCalibrationPointReference(Some(ProjectLinkCalibrationPoint(12347L, 7.0, 30)))),
+        geomTransferRight2, LinkGeomSource.NormalLinkInterface,
+        roadwayNumber3, Some(DateTime.now().minusDays(1)), None)
+
+      buildTestDataForProject(Some(project), Some(Seq(roadwayCombined1, roadwayCombined2, roadwayCombined3)), Some(Seq(linearCombined1, linearCombined2, linearCombined3, linearCombined4)), None)
+      val assignedValues = defaultSectionCalculatorStrategy.assignMValues(Seq(projectLinkLeft1, projectLinkLeft2), Seq(projectLinkCombined1, projectLinkCombined2, projectLinkRight1, projectLinkRight2), Seq.empty[UserDefinedCalibrationPoint])
+
+      val (left, right) = assignedValues.filterNot(_.track == Track.Combined).partition(_.track == Track.LeftSide)
+      assignedValues.size should be (6)
+      left.map(_.roadwayNumber).distinct.size should be (right.map(_.roadwayNumber).distinct.size)
+      left.map(_.roadwayNumber).distinct.size should be (2)
+    }
+  }
+
   test("Test defaultSectionCalculatorStrategy.assignMValues() and the attribution of roadway_numbers for new Left Right sections with diff number of links Then " +
     "if there are for e.g. 2 (two) consecutive links with diff roadway number (and all Transfer status), the opposite track (New), should also have 2 diff roadway numbers link(s) even if the amount of the new links is bigger than the Transfer side") {
     runWithRollback {
@@ -994,6 +1112,8 @@ Left     ^  ^   Right
          |  |
           ^
           | Combined
+          ^
+          |
       */
 
       //Combined
@@ -1097,12 +1217,8 @@ Left     ^  ^   Right
 
       val (left, right) = assignedValues.filterNot(_.track == Track.Combined).partition(_.track == Track.LeftSide)
       assignedValues.size should be (7)
-      left.map(_.roadwayNumber).distinct.size should be (right.map(_.roadwayNumber).size)
+      left.map(_.roadwayNumber).distinct.size should be (right.map(_.roadwayNumber).distinct.size)
       left.map(_.roadwayNumber).distinct.size should be (2)
-      left.head.startAddrMValue should be (right.head.startAddrMValue)
-      left.head.endAddrMValue should be (right.head.endAddrMValue)
-      left.last.startAddrMValue should be (right.last.startAddrMValue)
-      left.last.endAddrMValue should be (right.last.endAddrMValue)
     }
   }
 
@@ -1215,10 +1331,6 @@ Left     |  ^   Right
       assignedValues.size should be (6)
       left.map(_.roadwayNumber).distinct.size should be (right.map(_.roadwayNumber).size)
       left.map(_.roadwayNumber).distinct.size should be (2)
-      left.head.startAddrMValue should be (right.head.startAddrMValue)
-      left.head.endAddrMValue should be (right.head.endAddrMValue)
-      left.last.startAddrMValue should be (right.last.startAddrMValue)
-      left.last.endAddrMValue should be (right.last.endAddrMValue)
     }
   }
 
@@ -1360,12 +1472,8 @@ Left1 ---<----  ^ Right1
 
       val (left, right) = assignedValues.filterNot(_.track == Track.Combined).partition(_.track == Track.LeftSide)
       assignedValues.size should be (9)
-      left.map(_.roadwayNumber).distinct.size should be (right.map(_.roadwayNumber).size)
+      left.map(_.roadwayNumber).distinct.size should be (right.map(_.roadwayNumber).distinct.size)
       left.map(_.roadwayNumber).distinct.size should be (2)
-      left.head.startAddrMValue should be (right.head.startAddrMValue)
-      left.head.endAddrMValue should be (right.head.endAddrMValue)
-      left.last.startAddrMValue should be (right.last.startAddrMValue)
-      left.last.endAddrMValue should be (right.last.endAddrMValue)
     }
   }
 

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/DefaultSectionCalculatorStrategySpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/DefaultSectionCalculatorStrategySpec.scala
@@ -1280,7 +1280,7 @@ Left     |  ^   Right
 
       //Left New
       val projectLinkLeft1 = ProjectLink(-1000L, 9999L, 1L, Track.apply(2), Discontinuity.Discontinuous, 0L, 0L, 0L, 0L, None, None,
-        None, 12348L, 0.0, 20.0, SideCode.TowardsDigitizing, (None, None),
+        None, 12348L, 0.0, 11.18, SideCode.TowardsDigitizing, (None, None),
         geomNewLeft1, projectId, LinkStatus.New, RoadType.PublicRoad, LinkGeomSource.NormalLinkInterface, GeometryUtils.geometryLength(geomNewLeft1), -1000, -1000, 8L, reversed = false,
         None, 86400L)
 

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/DefaultSectionCalculatorStrategySpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/DefaultSectionCalculatorStrategySpec.scala
@@ -1077,29 +1077,33 @@ Left     |  ^   Right
       val roadwayCombined1 =  Roadway(roadwayId1, roadwayNumber1, 9999L,1, RoadType.PublicRoad, Track.apply(0), Discontinuity.Continuous, 0, 5, reversed = false, DateTime.now(), None,
         "tester", Some("rd 9999"), 8L, TerminationCode.NoTermination, DateTime.now(), None)
       val linearCombined1 = LinearLocation(linearLocationId1, 1, 12345L, 0.0, 5.0, SideCode.TowardsDigitizing, 86400L,
-        (CalibrationPointsUtils.toCalibrationPointReference(Some(ProjectLinkCalibrationPoint(12345L, 0.0, 0))),
-          CalibrationPointsUtils.toCalibrationPointReference(None)),
+//        (CalibrationPointsUtils.toCalibrationPointReference(Some(ProjectLinkCalibrationPoint(12345L, 0.0, 0))),
+//          CalibrationPointsUtils.toCalibrationPointReference(None)),
+        (Some(0), None),
         geomTransferCombined1, LinkGeomSource.NormalLinkInterface,
         roadwayNumber1, Some(DateTime.now().minusDays(1)), None)
 
       val roadwayCombined2 = Roadway(roadwayId2, roadwayNumber2, 9999L,1, RoadType.PublicRoad, Track.apply(0), Discontinuity.Continuous, 5, 18, reversed = false, DateTime.now(), None,
         "tester", Some("rd 9999"), 8L, TerminationCode.NoTermination, DateTime.now(), None)
       val linearCombined2 = LinearLocation(linearLocationId2, 1, 12346L, 0.0, 5.0, SideCode.TowardsDigitizing, 86400L,
-        (CalibrationPointsUtils.toCalibrationPointReference(None),
-          CalibrationPointsUtils.toCalibrationPointReference(None)),
+//        (CalibrationPointsUtils.toCalibrationPointReference(None),
+//          CalibrationPointsUtils.toCalibrationPointReference(None)),
+        (None, None),
         geomTransferCombined2, LinkGeomSource.NormalLinkInterface,
         roadwayNumber2, Some(DateTime.now().minusDays(1)), None)
       val linearCombined3 = LinearLocation(linearLocationId3, 2, 12346L, 5.0, 18.0, SideCode.TowardsDigitizing, 86400L,
-        (CalibrationPointsUtils.toCalibrationPointReference(None),
-          CalibrationPointsUtils.toCalibrationPointReference(None)),
+//        (CalibrationPointsUtils.toCalibrationPointReference(None),
+//          CalibrationPointsUtils.toCalibrationPointReference(None)),
+        (None, None),
         geomTransferRight1, LinkGeomSource.NormalLinkInterface,
         roadwayNumber2, Some(DateTime.now().minusDays(1)), None)
 
       val roadwayCombined3 = Roadway(roadwayId3, roadwayNumber3, 9999L,1, RoadType.PublicRoad, Track.apply(0), Discontinuity.Discontinuous, 0, 7, reversed = false, DateTime.now(), None,
         "tester", Some("rd 9999"), 8L, TerminationCode.NoTermination, DateTime.now(), None)
       val linearCombined4 = LinearLocation(linearLocationId4, 1, 12347L, 0.0, 7.0, SideCode.TowardsDigitizing, 86400L,
-        (CalibrationPointsUtils.toCalibrationPointReference(None),
-          CalibrationPointsUtils.toCalibrationPointReference(Some(ProjectLinkCalibrationPoint(12347L, 7.0, 30)))),
+//        (CalibrationPointsUtils.toCalibrationPointReference(None),
+//          CalibrationPointsUtils.toCalibrationPointReference(Some(ProjectLinkCalibrationPoint(12347L, 7.0, 30)))),
+        (None, Some(30)),
         geomTransferRight2, LinkGeomSource.NormalLinkInterface,
         roadwayNumber3, Some(DateTime.now().minusDays(1)), None)
 
@@ -1202,29 +1206,33 @@ Left     ^  ^   Right
       val roadwayCombined1 =  Roadway(roadwayId1, roadwayNumber1, 9999L,1, RoadType.PublicRoad, Track.apply(0), Discontinuity.Continuous, 0, 5, reversed = false, DateTime.now(), None,
         "tester", Some("rd 9999"), 8L, TerminationCode.NoTermination, DateTime.now(), None)
       val linearCombined1 = LinearLocation(linearLocationId1, 1, 12345L, 0.0, 5.0, SideCode.TowardsDigitizing, 86400L,
-        (CalibrationPointsUtils.toCalibrationPointReference(Some(ProjectLinkCalibrationPoint(12345L, 0.0, 0))),
-          CalibrationPointsUtils.toCalibrationPointReference(None)),
+//        (CalibrationPointsUtils.toCalibrationPointReference(Some(ProjectLinkCalibrationPoint(12345L, 0.0, 0))),
+//          CalibrationPointsUtils.toCalibrationPointReference(None)),
+        (Some(0), None),
         geomTransferCombined1, LinkGeomSource.NormalLinkInterface,
         roadwayNumber1, Some(DateTime.now().minusDays(1)), None)
 
       val roadwayCombined2 = Roadway(roadwayId2, roadwayNumber2, 9999L,1, RoadType.PublicRoad, Track.apply(0), Discontinuity.Continuous, 5, 18, reversed = false, DateTime.now(), None,
         "tester", Some("rd 9999"), 8L, TerminationCode.NoTermination, DateTime.now(), None)
       val linearCombined2 = LinearLocation(linearLocationId2, 1, 12346L, 0.0, 5.0, SideCode.TowardsDigitizing, 86400L,
-        (CalibrationPointsUtils.toCalibrationPointReference(None),
-          CalibrationPointsUtils.toCalibrationPointReference(None)),
+//        (CalibrationPointsUtils.toCalibrationPointReference(None),
+//          CalibrationPointsUtils.toCalibrationPointReference(None)),
+        (None, None),
         geomTransferCombined2, LinkGeomSource.NormalLinkInterface,
         roadwayNumber2, Some(DateTime.now().minusDays(1)), None)
       val linearCombined3 = LinearLocation(linearLocationId3, 2, 12346L, 5.0, 18.0, SideCode.TowardsDigitizing, 86400L,
-        (CalibrationPointsUtils.toCalibrationPointReference(None),
-          CalibrationPointsUtils.toCalibrationPointReference(None)),
+//        (CalibrationPointsUtils.toCalibrationPointReference(None),
+//          CalibrationPointsUtils.toCalibrationPointReference(None)),
+        (None, None),
         geomTransferRight1, LinkGeomSource.NormalLinkInterface,
         roadwayNumber2, Some(DateTime.now().minusDays(1)), None)
 
       val roadwayCombined3 = Roadway(roadwayId3, roadwayNumber3, 9999L,1, RoadType.PublicRoad, Track.apply(0), Discontinuity.Discontinuous, 0, 7, reversed = false, DateTime.now(), None,
         "tester", Some("rd 9999"), 8L, TerminationCode.NoTermination, DateTime.now(), None)
       val linearCombined4 = LinearLocation(linearLocationId4, 1, 12347L, 0.0, 7.0, SideCode.TowardsDigitizing, 86400L,
-        (CalibrationPointsUtils.toCalibrationPointReference(None),
-          CalibrationPointsUtils.toCalibrationPointReference(Some(ProjectLinkCalibrationPoint(12347L, 7.0, 30)))),
+//        (CalibrationPointsUtils.toCalibrationPointReference(None),
+//          CalibrationPointsUtils.toCalibrationPointReference(Some(ProjectLinkCalibrationPoint(12347L, 7.0, 30)))),
+        (None, Some(30)),
         geomTransferRight2, LinkGeomSource.NormalLinkInterface,
         roadwayNumber3, Some(DateTime.now().minusDays(1)), None)
 
@@ -1316,29 +1324,33 @@ Left     |  ^   Right
       val roadwayCombined1 =  Roadway(roadwayId1, roadwayNumber1, 9999L,1, RoadType.PublicRoad, Track.apply(0), Discontinuity.Continuous, 0, 5, reversed = false, DateTime.now(), None,
         "tester", Some("rd 9999"), 8L, TerminationCode.NoTermination, DateTime.now(), None)
       val linearCombined1 = LinearLocation(linearLocationId1, 1, 12345L, 0.0, 5.0, SideCode.TowardsDigitizing, 86400L,
-        (CalibrationPointsUtils.toCalibrationPointReference(Some(ProjectLinkCalibrationPoint(12345L, 0.0, 0))),
-          CalibrationPointsUtils.toCalibrationPointReference(None)),
+//        (CalibrationPointsUtils.toCalibrationPointReference(Some(ProjectLinkCalibrationPoint(12345L, 0.0, 0))),
+//          CalibrationPointsUtils.toCalibrationPointReference(None)),
+        (Some(0), None),
         geomTransferCombined1, LinkGeomSource.NormalLinkInterface,
         roadwayNumber1, Some(DateTime.now().minusDays(1)), None)
 
       val roadwayCombined2 = Roadway(roadwayId2, roadwayNumber2, 9999L,1, RoadType.PublicRoad, Track.apply(0), Discontinuity.Continuous, 5, 18, reversed = false, DateTime.now(), None,
         "tester", Some("rd 9999"), 8L, TerminationCode.NoTermination, DateTime.now(), None)
       val linearCombined2 = LinearLocation(linearLocationId2, 1, 12346L, 0.0, 5.0, SideCode.TowardsDigitizing, 86400L,
-        (CalibrationPointsUtils.toCalibrationPointReference(None),
-          CalibrationPointsUtils.toCalibrationPointReference(None)),
+//        (CalibrationPointsUtils.toCalibrationPointReference(None),
+//          CalibrationPointsUtils.toCalibrationPointReference(None)),
+        (None, None),
         geomTransferCombined2, LinkGeomSource.NormalLinkInterface,
         roadwayNumber2, Some(DateTime.now().minusDays(1)), None)
       val linearCombined3 = LinearLocation(linearLocationId3, 2, 12346L, 5.0, 18.0, SideCode.TowardsDigitizing, 86400L,
-        (CalibrationPointsUtils.toCalibrationPointReference(None),
-          CalibrationPointsUtils.toCalibrationPointReference(None)),
+//        (CalibrationPointsUtils.toCalibrationPointReference(None),
+//          CalibrationPointsUtils.toCalibrationPointReference(None)),
+        (None, None),
         geomTransferRight1, LinkGeomSource.NormalLinkInterface,
         roadwayNumber2, Some(DateTime.now().minusDays(1)), None)
 
       val roadwayCombined3 = Roadway(roadwayId3, roadwayNumber3, 9999L,1, RoadType.PublicRoad, Track.apply(0), Discontinuity.Discontinuous, 0, 7, reversed = false, DateTime.now(), None,
         "tester", Some("rd 9999"), 8L, TerminationCode.NoTermination, DateTime.now(), None)
       val linearCombined4 = LinearLocation(linearLocationId4, 1, 12347L, 0.0, 7.0, SideCode.TowardsDigitizing, 86400L,
-        (CalibrationPointsUtils.toCalibrationPointReference(None),
-          CalibrationPointsUtils.toCalibrationPointReference(Some(ProjectLinkCalibrationPoint(12347L, 7.0, 30)))),
+//        (CalibrationPointsUtils.toCalibrationPointReference(None),
+//          CalibrationPointsUtils.toCalibrationPointReference(Some(ProjectLinkCalibrationPoint(12347L, 7.0, 30)))),
+        (None, Some(30)),
         geomTransferRight2, LinkGeomSource.NormalLinkInterface,
         roadwayNumber3, Some(DateTime.now().minusDays(1)), None)
 
@@ -1444,29 +1456,33 @@ Left     |      |
       val roadwayCombined1 =  Roadway(roadwayId1, roadwayNumber1, 9999L,1, RoadType.PublicRoad, Track.apply(0), Discontinuity.Continuous, 0, 5, reversed = false, DateTime.now(), None,
         "tester", Some("rd 9999"), 8L, TerminationCode.NoTermination, DateTime.now(), None)
       val linearCombined1 = LinearLocation(linearLocationId1, 1, 12345L, 0.0, 5.0, SideCode.TowardsDigitizing, 86400L,
-        (CalibrationPointsUtils.toCalibrationPointReference(Some(ProjectLinkCalibrationPoint(12345L, 0.0, 0))),
-          CalibrationPointsUtils.toCalibrationPointReference(None)),
+//        (CalibrationPointsUtils.toCalibrationPointReference(Some(ProjectLinkCalibrationPoint(12345L, 0.0, 0))),
+//          CalibrationPointsUtils.toCalibrationPointReference(None)),
+        (Some(0), None),
         geomTransferCombined1, LinkGeomSource.NormalLinkInterface,
         roadwayNumber1, Some(DateTime.now().minusDays(1)), None)
 
       val roadwayCombined2 = Roadway(roadwayId2, roadwayNumber2, 9999L,1, RoadType.PublicRoad, Track.apply(0), Discontinuity.Continuous, 5, 18, reversed = false, DateTime.now(), None,
         "tester", Some("rd 9999"), 8L, TerminationCode.NoTermination, DateTime.now(), None)
       val linearCombined2 = LinearLocation(linearLocationId2, 1, 12346L, 0.0, 5.0, SideCode.TowardsDigitizing, 86400L,
-        (CalibrationPointsUtils.toCalibrationPointReference(None),
-          CalibrationPointsUtils.toCalibrationPointReference(None)),
+//        (CalibrationPointsUtils.toCalibrationPointReference(None),
+//          CalibrationPointsUtils.toCalibrationPointReference(None)),
+        (None, None),
         geomTransferCombined2, LinkGeomSource.NormalLinkInterface,
         roadwayNumber2, Some(DateTime.now().minusDays(1)), None)
       val linearCombined3 = LinearLocation(linearLocationId3, 2, 12346L, 5.0, 18.0, SideCode.TowardsDigitizing, 86400L,
-        (CalibrationPointsUtils.toCalibrationPointReference(None),
-          CalibrationPointsUtils.toCalibrationPointReference(None)),
+//        (CalibrationPointsUtils.toCalibrationPointReference(None),
+//          CalibrationPointsUtils.toCalibrationPointReference(None)),
+        (None, None),
         geomTransferRight1, LinkGeomSource.NormalLinkInterface,
         roadwayNumber2, Some(DateTime.now().minusDays(1)), None)
 
       val roadwayCombined3 = Roadway(roadwayId3, roadwayNumber3, 9999L,1, RoadType.PublicRoad, Track.apply(0), Discontinuity.Discontinuous, 0, 7, reversed = false, DateTime.now(), None,
         "tester", Some("rd 9999"), 8L, TerminationCode.NoTermination, DateTime.now(), None)
       val linearCombined4 = LinearLocation(linearLocationId4, 1, 12347L, 0.0, 7.0, SideCode.TowardsDigitizing, 86400L,
-        (CalibrationPointsUtils.toCalibrationPointReference(None),
-          CalibrationPointsUtils.toCalibrationPointReference(Some(ProjectLinkCalibrationPoint(12347L, 7.0, 30)))),
+//        (CalibrationPointsUtils.toCalibrationPointReference(None),
+//          CalibrationPointsUtils.toCalibrationPointReference(Some(ProjectLinkCalibrationPoint(12347L, 7.0, 30)))),
+        (None, Some(30)),
         geomTransferRight2, LinkGeomSource.NormalLinkInterface,
         roadwayNumber3, Some(DateTime.now().minusDays(1)), None)
 
@@ -1581,36 +1597,42 @@ Left1 ---<----  ^ Right1
       val roadwayCombined1 =  Roadway(roadwayId1, roadwayNumber1, 9999L,1, RoadType.PublicRoad, Track.apply(0), Discontinuity.Continuous, 0, 13, reversed = false, DateTime.now(), None,
         "tester", Some("rd 9999"), 8L, TerminationCode.NoTermination, DateTime.now(), None)
       val linearCombined1 = LinearLocation(linearLocationId1, 1, 12345L, 0.0, 5.0, SideCode.TowardsDigitizing, 86400L,
-        (CalibrationPointsUtils.toCalibrationPointReference(Some(ProjectLinkCalibrationPoint(12345L, 0.0, 0))),
-          CalibrationPointsUtils.toCalibrationPointReference(None)),
+//        (CalibrationPointsUtils.toCalibrationPointReference(Some(ProjectLinkCalibrationPoint(12345L, 0.0, 0))),
+//          CalibrationPointsUtils.toCalibrationPointReference(None)),
+        (Some(0), None),
         geomTransferCombined1, LinkGeomSource.NormalLinkInterface,
         roadwayNumber1, Some(DateTime.now().minusDays(1)), None)
       val linearCombined2 = LinearLocation(linearLocationId2, 2, 12346L, 0.0, 5.0, SideCode.TowardsDigitizing, 86400L,
-        (CalibrationPointsUtils.toCalibrationPointReference(None),
-          CalibrationPointsUtils.toCalibrationPointReference(None)),
+//        (CalibrationPointsUtils.toCalibrationPointReference(None),
+//          CalibrationPointsUtils.toCalibrationPointReference(None)),
+        (None, None),
         geomTransferRight1, LinkGeomSource.NormalLinkInterface,
         roadwayNumber1, Some(DateTime.now().minusDays(1)), None)
       val linearCombined3 = LinearLocation(linearLocationId3, 3, 12347L, 3.0, 6.0, SideCode.TowardsDigitizing, 86400L,
-        (CalibrationPointsUtils.toCalibrationPointReference(None),
-          CalibrationPointsUtils.toCalibrationPointReference(None)),
+//        (CalibrationPointsUtils.toCalibrationPointReference(None),
+//          CalibrationPointsUtils.toCalibrationPointReference(None)),
+        (None, None),
         geomTransferRight2, LinkGeomSource.NormalLinkInterface,
         roadwayNumber1, Some(DateTime.now().minusDays(1)), None)
 
       val roadwayCombined2 = Roadway(roadwayId2, roadwayNumber2, 9999L,1, RoadType.PublicRoad, Track.apply(0), Discontinuity.EndOfRoad, 13, 25, reversed = false, DateTime.now(), None,
         "tester", Some("rd 9999"), 8L, TerminationCode.NoTermination, DateTime.now(), None)
       val linearCombined4 = LinearLocation(linearLocationId4, 1, 12347L, 0.0, 3.0, SideCode.TowardsDigitizing, 86400L,
-        (CalibrationPointsUtils.toCalibrationPointReference(None),
-          CalibrationPointsUtils.toCalibrationPointReference(None)),
+//        (CalibrationPointsUtils.toCalibrationPointReference(None),
+//          CalibrationPointsUtils.toCalibrationPointReference(None)),
+        (None, None),
         geomTransferRight3, LinkGeomSource.NormalLinkInterface,
         roadwayNumber2, Some(DateTime.now().minusDays(1)), None)
       val linearCombined5 = LinearLocation(linearLocationId5, 2, 12348L, 0.0, 4.0, SideCode.TowardsDigitizing, 86400L,
-        (CalibrationPointsUtils.toCalibrationPointReference(None),
-          CalibrationPointsUtils.toCalibrationPointReference(None)),
+//        (CalibrationPointsUtils.toCalibrationPointReference(None),
+//          CalibrationPointsUtils.toCalibrationPointReference(None)),
+        (None, None),
         geomTransferRight4, LinkGeomSource.NormalLinkInterface,
         roadwayNumber2, Some(DateTime.now().minusDays(1)), None)
       val linearCombined6 = LinearLocation(linearLocationId6, 3, 12349L, 0.0, 5.0, SideCode.TowardsDigitizing, 86400L,
-        (CalibrationPointsUtils.toCalibrationPointReference(None),
-          CalibrationPointsUtils.toCalibrationPointReference(Some(ProjectLinkCalibrationPoint(12349L, 5.0, 20)))),
+//        (CalibrationPointsUtils.toCalibrationPointReference(None),
+//          CalibrationPointsUtils.toCalibrationPointReference(Some(ProjectLinkCalibrationPoint(12349L, 5.0, 20)))),
+        (None, Some(20)),
         geomTransferCombined2, LinkGeomSource.NormalLinkInterface,
         roadwayNumber2, Some(DateTime.now().minusDays(1)), None)
 

--- a/project/build.scala
+++ b/project/build.scala
@@ -41,14 +41,14 @@ object Digiroad2Build extends Build {
         "org.joda" % "joda-convert" % JodaConvertVersion,
         "joda-time" % "joda-time" % JodaTimeVersion,
         "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
-        "javax.media" % "jai_core" % "1.1.3" from "https://download.osgeo.org/webdav/geotools/javax/media/jai_core/1.1.3/jai_core-1.1.3.jar",
+        "javax.media" % "jai_core" % "1.1.3" from "https://repo.osgeo.org/repository/release/javax/media/jai_core/1.1.3/jai_core-1.1.3.jar",
         "org.geotools" % "gt-graph" % "19.0" from "http://livibuild04.vally.local/nexus/repository/maven-public/org/geotools/gt-graph/19.0/gt-graph-19.0.jar",
         "org.geotools" % "gt-main" % "19.0" from "http://livibuild04.vally.local/nexus/repository/maven-public/org/geotools/gt-main/19.0/gt-main-19.0.jar",
         "org.geotools" % "gt-api" % "19.0" from "http://livibuild04.vally.local/nexus/repository/maven-public/org/geotools/gt-api/19.0/gt-api-19.0.jar",
         "org.geotools" % "gt-referencing" % "19.0" from "http://livibuild04.vally.local/nexus/repository/maven-public/org/geotools/gt-referencing/19.0/gt-referencing-19.0.jar",
         "org.geotools" % "gt-metadata" % "19.0" from "http://livibuild04.vally.local/nexus/repository/maven-public/org/geotools/gt-metadata/19.0/gt-metadata-19.0.jar",
         "org.geotools" % "gt-opengis" % "19.0" from "http://livibuild04.vally.local/nexus/repository/maven-public/org/geotools/gt-opengis/19.0/gt-opengis-19.0.jar",
-        "jgridshift" % "jgridshift" % "1.0" from "http://download.osgeo.org/webdav/geotools/jgridshift/jgridshift/1.0/jgridshift-1.0.jar",
+        "jgridshift" % "jgridshift" % "1.0" from "https://repo.osgeo.org/repository/release/jgridshift/jgridshift/1.0/jgridshift-1.0.jar",
         "com.vividsolutions" % "jts-core" % "1.14.0" from "http://livibuild04.vally.local/nexus/repository/maven-public/com/vividsolutions/jts-core/1.14.0/jts-core-1.14.0.jar",
   "org.scalatest" % "scalatest_2.11" % ScalaTestVersion % "test"
   )

--- a/viite-UI/src/model/SelectedProjectLink.js
+++ b/viite-UI/src/model/SelectedProjectLink.js
@@ -1,152 +1,148 @@
 (function(root) {
-    root.SelectedProjectLink = function(projectLinkCollection) {
+  root.SelectedProjectLink = function(projectLinkCollection) {
 
-        var current = [];
-        var me = this;
-        var featuresToKeep = [];
-        var dirty = false;
-        var nearest = null;
+    var current = [];
+    var me = this;
+    var featuresToKeep = [];
+    var dirty = false;
+    var nearest = null;
 
-        var open = function (id, multiSelect) {
-            if (!multiSelect) {
-                current = projectLinkCollection.getProjectLink([id]);
-                me.ids = [id];
-            } else {
-                me.ids = projectLinkCollection.getMultiProjectLinks(id);
-                current = projectLinkCollection.getProjectLink(me.ids);
-            }
-            eventbus.trigger('projectLink:clicked', get(id));
-        };
-
-        var openWithErrorMessage = function (ids, errorMessage) {
-            current = projectLinkCollection.getProjectLink(ids);
-            me.ids = ids;
-            if (!_.isUndefined(current[0].getData().connectedLinkId) && current.length > 2) {
-                openSplit(me.ids[0], true);
-            } else {
-                eventbus.trigger('projectLink:errorClicked', get(ids[0]), errorMessage);
-            }
-        };
-
-        var isDirty = function() {
-            return dirty;
-        };
-
-        var setDirty = function(value) {
-            dirty = value;
-        };
-
-        var openCtrl = function(linkIds) {
-            if (linkIds.length === 0) {
-                cleanIds();
-                close();
-            } else {
-                var added = _.difference(linkIds, me.ids);
-                me.ids = linkIds;
-                current = _.filter(current, function(link) {
-                        return _.includes(linkIds, link.getData().id || link.getData().linkId);
-                    }
-                );
-                current = current.concat(projectLinkCollection.getProjectLink(added));
-                eventbus.trigger('projectLink:clicked', get());
-            }
-        };
-
-        var get = function(id) {
-            var clicked = _.filter(current, function (c) {
-                if (c.getData().id > 0) {
-                    return c.getData().id === id;
-                } else {
-                    return c.getData().linkId === id;
-                }
-            });
-            var others = _.filter(_.map(current, function(projectLink) { return projectLink.getData(); }), function (link) {
-                if (link.id > 0) {
-                    return link.id !== id;
-                } else {
-                    return link.linkId !== id;
-                }
-            });
-            if (!_.isUndefined(clicked[0])) {
-                return [clicked[0].getData()].concat(others);
-            }
-            return others;
-        };
-
-        var setCurrent = function(newSelection) {
-            current = newSelection;
-        };
-
-        var getCurrent = function () {
-            return _.map(current, function(curr) {
-                return curr.getData();
-            });
-        };
-
-        var getFeaturesToKeep = function(){
-          return featuresToKeep;
-        };
-
-        var addToFeaturesToKeep = function(data4Display){
-          if(_.isArray(data4Display)){
-            featuresToKeep = featuresToKeep.concat(data4Display);
-          } else {
-            featuresToKeep.push(data4Display);
-          }
-        };
-
-        var clearFeaturesToKeep = function() {
-          featuresToKeep = [];
-        };
-
-        var isSelected = function(linkId) {
-            return _.includes(me.ids, linkId);
-        };
-
-        var clean = function() {
-            current = [];
-        };
-
-        var cleanIds = function() {
-            me.ids = [];
-        };
-
-        var close = function() {
-            current = [];
-            eventbus.trigger('layer:enableButtons', true);
-        };
-
-        var setNearestPoint = function(point) {
-            nearest = point;
-        };
-
-        var isSplit = function () {
-            return get().length > 1 && !_.isUndefined(get()[0].connectedLinkId);
-        };
-
-        var isMultiLink = function () {
-            return get().length > 1 && _.isUndefined(get()[0].connectedLinkId);
-        };
-
-        return {
-            open: open,
-            openWithErrorMessage: openWithErrorMessage,
-            openCtrl: openCtrl,
-            get: get,
-            clean: clean,
-            cleanIds: cleanIds,
-            close: close,
-            isSelected: isSelected,
-            setCurrent: setCurrent,
-            getCurrent: getCurrent,
-            getFeaturesToKeep: getFeaturesToKeep,
-            addToFeaturesToKeep: addToFeaturesToKeep,
-            clearFeaturesToKeep: clearFeaturesToKeep,
-            isSplit: isSplit,
-            isMultiLink: isMultiLink,
-            isDirty: isDirty,
-            setDirty: setDirty,
-            setNearestPoint: setNearestPoint
-        };
+    var open = function (id, multiSelect) {
+      if (!multiSelect) {
+        current = projectLinkCollection.getProjectLink([id]);
+        me.ids = [id];
+      } else {
+        me.ids = projectLinkCollection.getMultiProjectLinks(id);
+        current = projectLinkCollection.getProjectLink(me.ids);
+      }
+      eventbus.trigger('projectLink:clicked', get(id));
     };
+
+    var openWithErrorMessage = function (ids, errorMessage) {
+      current = projectLinkCollection.getProjectLink(ids);
+      me.ids = ids;
+      eventbus.trigger('projectLink:errorClicked', get(ids[0]), errorMessage);
+    };
+
+    var isDirty = function() {
+      return dirty;
+    };
+
+    var setDirty = function(value) {
+      dirty = value;
+    };
+
+    var openCtrl = function(linkIds) {
+      if (linkIds.length === 0) {
+        cleanIds();
+        close();
+      } else {
+        var added = _.difference(linkIds, me.ids);
+        me.ids = linkIds;
+        current = _.filter(current, function(link) {
+            return _.includes(linkIds, link.getData().id || link.getData().linkId);
+          }
+        );
+        current = current.concat(projectLinkCollection.getProjectLink(added));
+        eventbus.trigger('projectLink:clicked', get());
+      }
+    };
+
+    var get = function(id) {
+      var clicked = _.filter(current, function (c) {
+        if (c.getData().id > 0) {
+          return c.getData().id === id;
+        } else {
+          return c.getData().linkId === id;
+        }
+      });
+      var others = _.filter(_.map(current, function(projectLink) { return projectLink.getData(); }), function (link) {
+        if (link.id > 0) {
+          return link.id !== id;
+        } else {
+          return link.linkId !== id;
+        }
+      });
+      if (!_.isUndefined(clicked[0])) {
+        return [clicked[0].getData()].concat(others);
+      }
+      return others;
+    };
+
+    var setCurrent = function(newSelection) {
+      current = newSelection;
+    };
+
+    var getCurrent = function () {
+      return _.map(current, function(curr) {
+        return curr.getData();
+      });
+    };
+
+    var getFeaturesToKeep = function(){
+      return featuresToKeep;
+    };
+
+    var addToFeaturesToKeep = function(data4Display){
+      if(_.isArray(data4Display)){
+        featuresToKeep = featuresToKeep.concat(data4Display);
+      } else {
+        featuresToKeep.push(data4Display);
+      }
+    };
+
+    var clearFeaturesToKeep = function() {
+      featuresToKeep = [];
+    };
+
+    var isSelected = function(linkId) {
+      return _.includes(me.ids, linkId);
+    };
+
+    var clean = function() {
+      current = [];
+    };
+
+    var cleanIds = function() {
+      me.ids = [];
+    };
+
+    var close = function() {
+      current = [];
+      eventbus.trigger('layer:enableButtons', true);
+    };
+
+    var setNearestPoint = function(point) {
+      nearest = point;
+    };
+
+    var isSplit = function () {
+      return get().length > 1 && !_.isUndefined(get()[0].connectedLinkId);
+    };
+
+    var isMultiLink = function () {
+      return get().length > 1 && _.isUndefined(get()[0].connectedLinkId);
+    };
+
+    return {
+      open: open,
+      openWithErrorMessage: openWithErrorMessage,
+      openCtrl: openCtrl,
+      get: get,
+      clean: clean,
+      cleanIds: cleanIds,
+      close: close,
+      isSelected: isSelected,
+      setCurrent: setCurrent,
+      getCurrent: getCurrent,
+      getFeaturesToKeep: getFeaturesToKeep,
+      addToFeaturesToKeep: addToFeaturesToKeep,
+      clearFeaturesToKeep: clearFeaturesToKeep,
+      isSplit: isSplit,
+      isMultiLink: isMultiLink,
+      isDirty: isDirty,
+      setDirty: setDirty,
+      setNearestPoint: setNearestPoint
+    };
+  };
 })(this);

--- a/viite-UI/src/view/LinkPropertyLayer.js
+++ b/viite-UI/src/view/LinkPropertyLayer.js
@@ -68,8 +68,8 @@
       source: geometryChangedVector,
       name: 'geometryChangedLayer',
       style: function(feature) {
-          return [roadLinkStyler.getRoadLinkStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)}),
-              roadLinkStyler.getOverlayStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)})];
+        return [roadLinkStyler.getRoadLinkStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)}),
+          roadLinkStyler.getOverlayStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)})];
       },
       zIndex: RoadZIndex.GeometryChangedLayer.value
     });
@@ -100,8 +100,8 @@
       source: pickRoadsLayerVector,
       name: 'pickRoadsLayer',
       style: function(feature) {
-          return [roadLinkStyler.getRoadLinkStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)}),
-              roadLinkStyler.getOverlayStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)})];
+        return [roadLinkStyler.getRoadLinkStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)}),
+          roadLinkStyler.getOverlayStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)})];
       }
     });
     pickRoadsLayer.set('name', 'pickRoadsLayer');
@@ -110,8 +110,8 @@
       source: simulationVector,
       name: 'simulatedRoadsLayer',
       style: function(feature) {
-          return [roadLinkStyler.getRoadLinkStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)}),
-              roadLinkStyler.getOverlayStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)})];
+        return [roadLinkStyler.getRoadLinkStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)}),
+          roadLinkStyler.getOverlayStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)})];
       }
     });
     simulatedRoadsLayer.set('name', 'simulatedRoadsLayer');
@@ -121,8 +121,8 @@
       source: underConstructionRoadLayerVector,
       name: 'underConstructionRoadLayer',
       style: function(feature) {
-          return [roadLinkStyler.getBorderStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)}), roadLinkStyler.getRoadLinkStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)}),
-              roadLinkStyler.getOverlayStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)})];
+        return [roadLinkStyler.getBorderStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)}), roadLinkStyler.getRoadLinkStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)}),
+          roadLinkStyler.getOverlayStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)})];
       }
     });
     underConstructionRoadLayer.set('name', 'underConstructionRoadLayer');
@@ -142,8 +142,8 @@
       source: historicRoadsVector,
       name: 'historicRoadsLayer',
       style: function(feature) {
-          return [roadLinkStyler.getRoadLinkStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)}),
-              roadLinkStyler.getOverlayStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)})];
+        return [roadLinkStyler.getRoadLinkStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)}),
+          roadLinkStyler.getOverlayStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)})];
       },
       zIndex: RoadZIndex.HistoricRoadLayer.value
     });
@@ -171,7 +171,7 @@
      * This interaction is restricted to a double click.
      * @type {ol.interaction.Select}
      *
-     * 
+     *
      */
     var selectDoubleClick = new ol.interaction.Select({
       //Multi is the one en charge of defining if we select just the feature we clicked or all the overlapping
@@ -182,9 +182,9 @@
       condition: ol.events.condition.doubleClick,
       //The new/temporary layer needs to have a style function as well, we define it here.
       style: function(feature) {
-          return [roadLinkStyler.getBorderStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)}),
-            roadLinkStyler.getRoadLinkStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)}),
-              roadLinkStyler.getOverlayStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)})];
+        return [roadLinkStyler.getBorderStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)}),
+          roadLinkStyler.getRoadLinkStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)}),
+          roadLinkStyler.getOverlayStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)})];
       }
     });
 
@@ -212,8 +212,8 @@
         if (!_.isUndefined(selectedF)) {
           var selection = selectedF.linkData;
           if (selection.floating === SelectionType.Floating.value) {
-              selectedLinkProperty.openFloating(selection, true, visibleFeatures);
-              floatingMarkerLayer.setOpacity(1);
+            selectedLinkProperty.openFloating(selection, true, visibleFeatures);
+            floatingMarkerLayer.setOpacity(1);
           } else {
             selectedLinkProperty.open(selection, false, visibleFeatures);
           }
@@ -261,9 +261,9 @@
         }
       },
       style: function(feature) {
-          return [roadLinkStyler.getBorderStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)}),
-            roadLinkStyler.getRoadLinkStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)}),
-            roadLinkStyler.getOverlayStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)})];
+        return [roadLinkStyler.getBorderStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)}),
+          roadLinkStyler.getRoadLinkStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)}),
+          roadLinkStyler.getOverlayStyle().getStyle(feature.linkData, {zoomLevel:zoomlevels.getViewZoom(map)})];
       }
     });
     selectSingleClick.set('name','selectSingleClickInteractionLPL');
@@ -281,7 +281,7 @@
       var visibleFeatures = getVisibleFeatures(true, true, true, true, true, true, true, true, true);
       selectDoubleClick.getFeatures().clear();
       var selectedF =  _.find(event.selected, function (selectionTarget) {
-          return !_.isUndefined(selectionTarget.linkData);
+        return !_.isUndefined(selectionTarget.linkData);
       });
 
       if (!_.isUndefined(selectedF)) {
@@ -290,10 +290,10 @@
           setGeneralOpacity(0.2);
         }
         if (selection.floating === SelectionType.Floating.value && !applicationModel.isReadOnly()) {
-            selectedLinkProperty.close();
-            selectedLinkProperty.openFloating(selection, true, visibleFeatures);
-            floatingMarkerLayer.setOpacity(1);
-            anomalousMarkerLayer.setOpacity(1);
+          selectedLinkProperty.close();
+          selectedLinkProperty.openFloating(selection, true, visibleFeatures);
+          floatingMarkerLayer.setOpacity(1);
+          anomalousMarkerLayer.setOpacity(1);
         } else if (selection.floating !== SelectionType.Floating.value && applicationModel.selectionTypeIs(SelectionType.Floating) && !applicationModel.isReadOnly() && event.deselected.length !== 0) {
           var floatings = event.deselected;
           var nonFloatings = event.selected;
@@ -314,7 +314,7 @@
         if (applicationModel.selectionTypeIs(SelectionType.Unknown) && selection.floating !== SelectionType.Floating.value && (selection.anomaly === Anomaly.NoAddressGiven.value || selection.anomaly === Anomaly.GeometryChanged.value)) {
           greenRoadLayer.setOpacity(1);
           var anomalousFeatures = _.uniq(_.filter(selectedLinkProperty.getFeaturesToKeep(), function (ft) {
-              return ft.anomaly === Anomaly.NoAddressGiven.value;
+            return ft.anomaly === Anomaly.NoAddressGiven.value;
           }));
           anomalousFeatures.forEach(function (fmf) {
             editFeatureDataForGreen(fmf);
@@ -432,38 +432,6 @@
       });
     };
 
-    // var drawIndicators = function(links) {
-    //   var features = [];
-    //
-    //   var markerContainer = function(link, position) {
-    //     var style = new ol.style.Style({
-    //       image : new ol.style.Icon({
-    //         src: 'images/center-marker2.svg'
-    //       }),
-    //       text : new ol.style.Text({
-    //         text : link.marker,
-    //         fill: new ol.style.Fill({
-    //           color: '#ffffff'
-    //         }),
-    //         font : '12px sans-serif'
-    //       })
-    //     });
-    //     var marker = new ol.Feature({
-    //       geometry : new ol.geom.Point([position.x, position.y])
-    //     });
-    //     marker.setStyle(style);
-    //     features.push(marker);
-    //   };
-    //
-    //   var indicators = function() {
-    //     return me.mapOverLinkMiddlePoints(links, function(link, middlePoint) {
-    //       markerContainer(link, middlePoint);
-    //     });
-    //   };
-    //   indicators();
-    //   indicatorLayer.getSource().addFeatures(features);
-    // };
-
     var redraw = function() {
       cachedMarker = new LinkPropertyMarker(selectedLinkProperty);
       removeSelectInteractions();
@@ -512,12 +480,12 @@
           return value.linkId;
         }), 'startAddressM');
         _.each(floatingGroups, function(floatGroup) {
-            _.each(floatGroup, function(floating) {
-              cachedMarker.createMarker(floating, function (marker) {
-                if (applicationModel.getCurrentAction() !== applicationModel.actionCalculated && !_.includes(linkIdsToRemove, marker.linkData.linkId))
-                  floatingMarkerLayer.getSource().addFeature(marker);
-              });
+          _.each(floatGroup, function(floating) {
+            cachedMarker.createMarker(floating, function (marker) {
+              if (applicationModel.getCurrentAction() !== applicationModel.actionCalculated && !_.includes(linkIdsToRemove, marker.linkData.linkId))
+                floatingMarkerLayer.getSource().addFeature(marker);
             });
+          });
         });
 
         var geometryChangedRoadMarkers = _.filter(roadLinks, function(roadlink){
@@ -526,29 +494,29 @@
 
         _.each(geometryChangedRoadMarkers, function(geometryChangedLink) {
 
-            var newLinkData = Object.assign({}, geometryChangedLink);
-            newLinkData.roadClass = 99;
-            newLinkData.roadLinkSource = 99;
-            newLinkData.sideCode = 99;
-            newLinkData.linkType = 99;
-            newLinkData.constructionType = 0;
-            newLinkData.roadLinkType = 0;
-            newLinkData.id = 0;
-            newLinkData.startAddressM = "";
-            newLinkData.endAddressM = "";
-            newLinkData.anomaly = Anomaly.NoAddressGiven.value;
-            newLinkData.points = newLinkData.newGeometry;
+          var newLinkData = Object.assign({}, geometryChangedLink);
+          newLinkData.roadClass = 99;
+          newLinkData.roadLinkSource = 99;
+          newLinkData.sideCode = 99;
+          newLinkData.linkType = 99;
+          newLinkData.constructionType = 0;
+          newLinkData.roadLinkType = 0;
+          newLinkData.id = 0;
+          newLinkData.startAddressM = "";
+          newLinkData.endAddressM = "";
+          newLinkData.anomaly = Anomaly.NoAddressGiven.value;
+          newLinkData.points = newLinkData.newGeometry;
 
-            cachedMarker.createMarker(newLinkData, function (marker) {
-              geometryChangedLayer.getSource().addFeature(marker);
-            });
+          cachedMarker.createMarker(newLinkData, function (marker) {
+            geometryChangedLayer.getSource().addFeature(marker);
+          });
 
-            var points = _.map(newLinkData.newGeometry, function (point) {
+          var points = _.map(newLinkData.newGeometry, function (point) {
             return [point.x, point.y];
           });
           var feature = new ol.Feature({ geometry: new ol.geom.LineString(points)});
-            feature.linkData = newLinkData;
-            roadCollection.addTmpRoadLinkGroups(newLinkData);
+          feature.linkData = newLinkData;
+          roadCollection.addTmpRoadLinkGroups(newLinkData);
           geometryChangedLayer.getSource().addFeature(feature);
         });
 
@@ -584,9 +552,6 @@
       var visibleFeatures = getVisibleFeatures(true, true, true, true, true, true, true);
       var indicators = adjacents;
       indicatorLayer.getSource().clear();
-      // if(indicators.length !== 0){
-      //   drawIndicators(indicators);
-      // }
 
       if (applicationModel.selectionTypeIs(SelectionType.Unknown) && targetFeature.linkData.floating !== SelectionType.Floating.value && targetFeature.linkData.anomaly === Anomaly.NoAddressGiven.value) {
         if (applicationModel.isReadOnly()) {
@@ -714,17 +679,17 @@
         });
         var ol3underConstructionRoads =
           _.map(partitioned[0], function(road) {
-          var roadData = road.getData();
-          var points = _.map(roadData.points, function (point) {
-            return [point.x, point.y];
-          });
-          var feature = new ol.Feature({
-            geometry: new ol.geom.LineString(points)
-          });
+            var roadData = road.getData();
+            var points = _.map(roadData.points, function (point) {
+              return [point.x, point.y];
+            });
+            var feature = new ol.Feature({
+              geometry: new ol.geom.LineString(points)
+            });
             feature.linkData = roadData;
-          return feature;
-        });
-
+            return feature;
+          });
+        underConstructionRoadLayer.getSource().clear();
         underConstructionRoadLayer.getSource().addFeatures(ol3underConstructionRoads);
 
         var ol3noInfoRoads =
@@ -746,17 +711,18 @@
         console.log(" eventbus, 'unAddressedRoadLinks:fetched'");
 
         var ol3noInfoRoads =
-            _.map(_.flatten(unAddressedRoads), function(road) {
-              var roadData = road.getData();
-              var points = _.map(roadData.points, function (point) {
-                return [point.x, point.y];
-              });
-              var feature = new ol.Feature({
-                geometry: new ol.geom.LineString(points)
-              });
-              feature.linkData = roadData;
-              return feature;
+          _.map(_.flatten(unAddressedRoads), function(road) {
+            var roadData = road.getData();
+            var points = _.map(roadData.points, function (point) {
+              return [point.x, point.y];
             });
+            var feature = new ol.Feature({
+              geometry: new ol.geom.LineString(points)
+            });
+            feature.linkData = roadData;
+            return feature;
+          });
+        unAddressedRoadLayer.getSource().clear();
         unAddressedRoadLayer.getSource().addFeatures(ol3noInfoRoads);
       });
       eventListener.listenTo(eventbus, 'unAddressedRoads:toggleVisibility', function(visibility){
@@ -769,21 +735,16 @@
       eventListener.listenTo(eventbus, 'linkProperty:visibilityChanged', function () {
         //Exclude underConstruction layers from toggle
         me.toggleLayersVisibility([roadLayer.layer, floatingMarkerLayer, anomalousMarkerLayer, directionMarkerLayer, geometryChangedLayer, calibrationPointLayer,
-        indicatorLayer, greenRoadLayer, pickRoadsLayer, simulatedRoadsLayer, reservedRoadLayer, historicRoadsLayer], applicationModel.getRoadVisibility());
+          indicatorLayer, greenRoadLayer, pickRoadsLayer, simulatedRoadsLayer, reservedRoadLayer, historicRoadsLayer], applicationModel.getRoadVisibility());
       });
       eventListener.listenTo(eventbus, 'linkProperties:dataset:changed', redraw);
       eventListener.listenTo(eventbus, 'linkProperties:updateFailed', cancelSelection);
       eventListener.listenTo(eventbus, 'adjacents:nextSelected', function(sources, adjacents, targets) {
         applicationModel.addSpinner();
-        // if (applicationModel.getCurrentAction() !== applicationModel.actionCalculated) {
-        //   drawIndicators(adjacents);
-        //   selectedLinkProperty.addTargets(targets, adjacents);
-        // }
         redrawNextSelectedTarget(targets, adjacents);
       });
       eventListener.listenTo(eventbus, 'adjacents:added', function(sources, targets) {
         clearIndicators();
-        // drawIndicators(targets);
         _.map(_.filter(selectedLinkProperty.getFeaturesToKeep(), function(link) {
           return link.roadNumber === 0;
         }), function (roads) {
@@ -792,14 +753,12 @@
       });
 
       eventListener.listenTo(eventbus, 'adjacents:floatingAdded', function(sources, targets) {
-          clearIndicators();
-          // drawIndicators(targets);
+        clearIndicators();
       });
 
       eventListener.listenTo(eventbus, 'adjacents:floatingAdded', function(floatings) {
         var visibleFeatures = getVisibleFeatures(true, true, true, true, true, true,true);
         selectedLinkProperty.processOLFeatures(visibleFeatures);
-        // drawIndicators(floatings);
       });
 
       eventListener.listenTo(eventbus, 'linkProperties:clearIndicators', function(){
@@ -849,15 +808,15 @@
 
     var redrawNextSelectedTarget = function(targets, adjacents) {
       _.find(roadLayer.layer.getSource().getFeatures(), function(feature) {
-          return targets !== 0 && feature.linkData.linkId === parseInt(targets);
+        return targets !== 0 && feature.linkData.linkId === parseInt(targets);
       }).linkData.gapTransfering = true;
       var targetFeature = _.find(geometryChangedLayer.getSource().getFeatures(), function(feature) {
-          return targets !== 0 && feature.linkData.linkId === parseInt(targets);
+        return targets !== 0 && feature.linkData.linkId === parseInt(targets);
       });
       if(_.isUndefined(targetFeature))
       {
         targetFeature = _.find(roadLayer.layer.getSource().getFeatures(), function (feature) {
-            return targets !== 0 && feature.linkData.linkId === parseInt(targets);
+          return targets !== 0 && feature.linkData.linkId === parseInt(targets);
         });
       }
       reselectRoadLink(targetFeature, adjacents);
@@ -867,17 +826,17 @@
 
     var reHighlightGreen = function() {
       var greenFeaturesLinkId = _.map(greenRoadLayer.getSource().getFeatures(), function(gf){
-          return gf.linkData.linkId;
+        return gf.linkData.linkId;
       });
 
       if (greenFeaturesLinkId.length !== 0) {
         var features =[];
         _.each(roadLayer.layer.getSource().getFeatures(), function (feature) {
-            if (_.includes(greenFeaturesLinkId, feature.linkData.linkId)) {
+          if (_.includes(greenFeaturesLinkId, feature.linkData.linkId)) {
 
-                feature.linkData.prevAnomaly = feature.linkData.anomaly;
-                feature.linkData.gapTransfering = true;
-                var greenRoadStyle = roadLinkStyler.getRoadLinkStyle().getStyle(feature.linkData, {zoomLevel: zoomlevels.getViewZoom(map)});
+            feature.linkData.prevAnomaly = feature.linkData.anomaly;
+            feature.linkData.gapTransfering = true;
+            var greenRoadStyle = roadLinkStyler.getRoadLinkStyle().getStyle(feature.linkData, {zoomLevel: zoomlevels.getViewZoom(map)});
             feature.setStyle(greenRoadStyle);
             features.push(feature);
           }
@@ -890,35 +849,35 @@
       var features =[];
       if(targets !== 0){
         var targetFeature = _.find(greenRoadLayer.getSource().getFeatures(), function(greenFeature){
-            return targets.linkId !== 0 && greenFeature.linkData.linkId === parseInt(targets.linkId);
+          return targets.linkId !== 0 && greenFeature.linkData.linkId === parseInt(targets.linkId);
         });
         if(!targetFeature){
           _.map(roadLayer.layer.getSource().getFeatures(), function(feature){
-              if (feature.linkData.linkId === targets.linkId) {
+            if (feature.linkData.linkId === targets.linkId) {
               var pickAnomalousMarker;
-                  if (feature.linkData.anomaly === Anomaly.GeometryChanged.value) {
-                      var roadLink = feature.linkData;
+              if (feature.linkData.anomaly === Anomaly.GeometryChanged.value) {
+                var roadLink = feature.linkData;
                 var points = _.map(roadLink.newGeometry, function (point) {
                   return [point.x, point.y];
                 });
                 feature = new ol.Feature({geometry: new ol.geom.LineString(points)});
-                      feature.linkData = roadLink;
+                feature.linkData = roadLink;
                 pickAnomalousMarker = _.filter(geometryChangedLayer.getSource().getFeatures(), function(marker){
-                    return marker.linkData.linkId === feature.linkData.linkId;
+                  return marker.linkData.linkId === feature.linkData.linkId;
                 });
                 _.each(pickAnomalousMarker, function(pickRoads){
                   geometryChangedLayer.getSource().removeFeature(pickRoads);
                 });
               }
 
-                  feature.linkData.prevAnomaly = feature.linkData.anomaly;
-                  feature.linkData.gapTransfering = true;
-                  var greenRoadStyle = roadLinkStyler.getRoadLinkStyle().getStyle(feature.linkData, {zoomLevel: zoomlevels.getViewZoom(map)});
+              feature.linkData.prevAnomaly = feature.linkData.anomaly;
+              feature.linkData.gapTransfering = true;
+              var greenRoadStyle = roadLinkStyler.getRoadLinkStyle().getStyle(feature.linkData, {zoomLevel: zoomlevels.getViewZoom(map)});
               feature.setStyle(greenRoadStyle);
               features.push(feature);
               roadCollection.addPreMovedRoadAddresses(feature.data);
               pickAnomalousMarker = _.filter(pickRoadsLayer.getSource().getFeatures(), function(markersPick){
-                  return markersPick.linkData.linkId === feature.linkData.linkId;
+                return markersPick.linkData.linkId === feature.linkData.linkId;
               });
               _.each(pickAnomalousMarker, function(pickRoads){
                 pickRoadsLayer.getSource().removeFeature(pickRoads);
@@ -969,7 +928,7 @@
     var highlightAnomalousFeaturesByFloating = function() {
       var allFeatures = roadLayer.layer.getSource().getFeatures().concat(anomalousMarkerLayer.getSource().getFeatures()).concat(floatingMarkerLayer.getSource().getFeatures());
       _.each(allFeatures, function(feature){
-          if (feature.linkData.anomaly === Anomaly.NoAddressGiven.value || feature.linkData.anomaly === Anomaly.GeometryChanged.value || feature.linkData.floating === SelectionType.Floating.value)
+        if (feature.linkData.anomaly === Anomaly.NoAddressGiven.value || feature.linkData.anomaly === Anomaly.GeometryChanged.value || feature.linkData.floating === SelectionType.Floating.value)
           pickRoadsLayer.getSource().addFeature(feature);
       });
       pickRoadsLayer.setOpacity(1);
@@ -981,7 +940,7 @@
       var selectedFloatingIds = _.map(selectedLinkProperty.getFeaturesToKeepFloatings(), 'linkId');
 
       _.each(allFeatures, function(feature){
-          if (feature.linkData.anomaly === Anomaly.NoAddressGiven.value || (_.includes(selectedFloatingIds, feature.linkData.linkId) && feature.linkData.floating === SelectionType.Floating.value))
+        if (feature.linkData.anomaly === Anomaly.NoAddressGiven.value || (_.includes(selectedFloatingIds, feature.linkData.linkId) && feature.linkData.floating === SelectionType.Floating.value))
           pickRoadsLayer.getSource().addFeature(feature);
       });
       pickRoadsLayer.setOpacity(1);
@@ -1007,7 +966,7 @@
       });
 
       var olUids = _.reject(_.map(pickRoadsLayer.getSource().getFeatures(), function(pickFeature){
-          if (_.includes(FeaturesToKeepFloatings, pickFeature.linkData.linkId))
+        if (_.includes(FeaturesToKeepFloatings, pickFeature.linkData.linkId))
           return pickFeature.ol_uid;
         else return undefined;
       }), function(featuresNotToKeep){
@@ -1042,7 +1001,7 @@
        * Clean from roadLayer floatings selected
        */
       var olUidsRoadLayer = _.reject(_.map(roadLayer.layer.getSource().getFeatures(), function(featureRoadLayer){
-          if (_.includes(FeaturesToKeepFloatings, featureRoadLayer.linkData.linkId))
+        if (_.includes(FeaturesToKeepFloatings, featureRoadLayer.linkData.linkId))
           return featureRoadLayer.ol_uid;
         else return undefined;
       }), function(featuresNotToKeep){
@@ -1063,7 +1022,7 @@
        * Clean from floatingMarkerLayer markers from selected floatings
        */
       var olUidsFloatingLayer = _.reject(_.map(floatingMarkerLayer.getSource().getFeatures(), function(feature){
-          if (_.includes(FeaturesToKeepFloatings, feature.linkData.linkId))
+        if (_.includes(FeaturesToKeepFloatings, feature.linkData.linkId))
           return feature.ol_uid;
         else return undefined;
       }), function(featuresNotToKeep){
@@ -1101,7 +1060,7 @@
       //Clean from anomalousMarkerLayer
 
       var olUidsAnomalousMarkerLayer = _.reject(_.map(anomalousMarkerLayer.getSource().getFeatures(),function(anomalousMarkerLayerFeature){
-          if (_.includes(unknownFeaturesToKeep, anomalousMarkerLayerFeature.linkData.linkId)) {
+        if (_.includes(unknownFeaturesToKeep, anomalousMarkerLayerFeature.linkData.linkId)) {
           return anomalousMarkerLayerFeature.ol_uid;
         } else return undefined;
       }), function(featuresNotToKeep){
@@ -1182,7 +1141,7 @@
         var feature = new ol.Feature({
           geometry: new ol.geom.LineString(points)
         });
-          feature.linkData = link;
+        feature.linkData = link;
         return feature;
       });
       historicRoadsLayer.getSource().addFeatures(historyFeatures);
@@ -1281,7 +1240,7 @@
       reservedRoadLayer.getSource().clear();
       applicationModel.setReadOnly(true);
     });
-    
+
     var showLayer = function(){
       me.start();
       me.layerStarted(me.eventListener);

--- a/viite-UI/src/view/LinkPropertyLayer.js
+++ b/viite-UI/src/view/LinkPropertyLayer.js
@@ -432,37 +432,37 @@
       });
     };
 
-    var drawIndicators = function(links) {
-      var features = [];
-
-      var markerContainer = function(link, position) {
-        var style = new ol.style.Style({
-          image : new ol.style.Icon({
-            src: 'images/center-marker2.svg'
-          }),
-          text : new ol.style.Text({
-            text : link.marker,
-            fill: new ol.style.Fill({
-              color: '#ffffff'
-            }),
-            font : '12px sans-serif'
-          })
-        });
-        var marker = new ol.Feature({
-          geometry : new ol.geom.Point([position.x, position.y])
-        });
-        marker.setStyle(style);
-        features.push(marker);
-      };
-
-      var indicators = function() {
-        return me.mapOverLinkMiddlePoints(links, function(link, middlePoint) {
-          markerContainer(link, middlePoint);
-        });
-      };
-      indicators();
-      indicatorLayer.getSource().addFeatures(features);
-    };
+    // var drawIndicators = function(links) {
+    //   var features = [];
+    //
+    //   var markerContainer = function(link, position) {
+    //     var style = new ol.style.Style({
+    //       image : new ol.style.Icon({
+    //         src: 'images/center-marker2.svg'
+    //       }),
+    //       text : new ol.style.Text({
+    //         text : link.marker,
+    //         fill: new ol.style.Fill({
+    //           color: '#ffffff'
+    //         }),
+    //         font : '12px sans-serif'
+    //       })
+    //     });
+    //     var marker = new ol.Feature({
+    //       geometry : new ol.geom.Point([position.x, position.y])
+    //     });
+    //     marker.setStyle(style);
+    //     features.push(marker);
+    //   };
+    //
+    //   var indicators = function() {
+    //     return me.mapOverLinkMiddlePoints(links, function(link, middlePoint) {
+    //       markerContainer(link, middlePoint);
+    //     });
+    //   };
+    //   indicators();
+    //   indicatorLayer.getSource().addFeatures(features);
+    // };
 
     var redraw = function() {
       cachedMarker = new LinkPropertyMarker(selectedLinkProperty);
@@ -584,9 +584,9 @@
       var visibleFeatures = getVisibleFeatures(true, true, true, true, true, true, true);
       var indicators = adjacents;
       indicatorLayer.getSource().clear();
-      if(indicators.length !== 0){
-        drawIndicators(indicators);
-      }
+      // if(indicators.length !== 0){
+      //   drawIndicators(indicators);
+      // }
 
       if (applicationModel.selectionTypeIs(SelectionType.Unknown) && targetFeature.linkData.floating !== SelectionType.Floating.value && targetFeature.linkData.anomaly === Anomaly.NoAddressGiven.value) {
         if (applicationModel.isReadOnly()) {
@@ -775,15 +775,15 @@
       eventListener.listenTo(eventbus, 'linkProperties:updateFailed', cancelSelection);
       eventListener.listenTo(eventbus, 'adjacents:nextSelected', function(sources, adjacents, targets) {
         applicationModel.addSpinner();
-        if (applicationModel.getCurrentAction() !== applicationModel.actionCalculated) {
-          drawIndicators(adjacents);
-          selectedLinkProperty.addTargets(targets, adjacents);
-        }
+        // if (applicationModel.getCurrentAction() !== applicationModel.actionCalculated) {
+        //   drawIndicators(adjacents);
+        //   selectedLinkProperty.addTargets(targets, adjacents);
+        // }
         redrawNextSelectedTarget(targets, adjacents);
       });
       eventListener.listenTo(eventbus, 'adjacents:added', function(sources, targets) {
         clearIndicators();
-        drawIndicators(targets);
+        // drawIndicators(targets);
         _.map(_.filter(selectedLinkProperty.getFeaturesToKeep(), function(link) {
           return link.roadNumber === 0;
         }), function (roads) {
@@ -793,13 +793,13 @@
 
       eventListener.listenTo(eventbus, 'adjacents:floatingAdded', function(sources, targets) {
           clearIndicators();
-          drawIndicators(targets);
+          // drawIndicators(targets);
       });
 
       eventListener.listenTo(eventbus, 'adjacents:floatingAdded', function(floatings) {
         var visibleFeatures = getVisibleFeatures(true, true, true, true, true, true,true);
         selectedLinkProperty.processOLFeatures(visibleFeatures);
-        drawIndicators(floatings);
+        // drawIndicators(floatings);
       });
 
       eventListener.listenTo(eventbus, 'linkProperties:clearIndicators', function(){

--- a/viite-UI/src/view/ProjectEditForm.js
+++ b/viite-UI/src/view/ProjectEditForm.js
@@ -358,12 +358,7 @@
       });
 
       rootElement.on('click','.changeDirection', function () {
-        // if(!_.isUndefined(selectedProjectLinkProperty.get()[0]) && !_.isUndefined(selectedProjectLinkProperty.get()[0].connectedLinkId) && selectedProjectLinkProperty.get()[0].connectedLinkId !== 0) {
-        //   projectCollection.changeNewProjectLinkCutDirection(projectCollection.getCurrentProject().project.id, selectedProjectLinkProperty.get());
-        // }
-        // else{
         projectCollection.changeNewProjectLinkDirection(projectCollection.getCurrentProject().project.id, selectedProjectLinkProperty.get());
-        // }
       });
 
       eventbus.on('roadAddress:projectLinksSaveFailed', function (result) {

--- a/viite-UI/src/view/ProjectEditForm.js
+++ b/viite-UI/src/view/ProjectEditForm.js
@@ -358,12 +358,12 @@
       });
 
       rootElement.on('click','.changeDirection', function () {
-        if(!_.isUndefined(selectedProjectLinkProperty.get()[0]) && !_.isUndefined(selectedProjectLinkProperty.get()[0].connectedLinkId) && selectedProjectLinkProperty.get()[0].connectedLinkId !== 0) {
-          projectCollection.changeNewProjectLinkCutDirection(projectCollection.getCurrentProject().project.id, selectedProjectLinkProperty.get());
-        }
-        else{
-          projectCollection.changeNewProjectLinkDirection(projectCollection.getCurrentProject().project.id, selectedProjectLinkProperty.get());
-        }
+        // if(!_.isUndefined(selectedProjectLinkProperty.get()[0]) && !_.isUndefined(selectedProjectLinkProperty.get()[0].connectedLinkId) && selectedProjectLinkProperty.get()[0].connectedLinkId !== 0) {
+        //   projectCollection.changeNewProjectLinkCutDirection(projectCollection.getCurrentProject().project.id, selectedProjectLinkProperty.get());
+        // }
+        // else{
+        projectCollection.changeNewProjectLinkDirection(projectCollection.getCurrentProject().project.id, selectedProjectLinkProperty.get());
+        // }
       });
 
       eventbus.on('roadAddress:projectLinksSaveFailed', function (result) {

--- a/viite-UI/src/view/ProjectLinkLayer.js
+++ b/viite-UI/src/view/ProjectLinkLayer.js
@@ -615,8 +615,6 @@
       me.redraw();
       _.defer(function () {
         highlightFeatures();
-        if (selectedProjectLinkProperty.isSplit())
-          drawIndicators(selectedProjectLinkProperty.get());
       });
     });
 

--- a/viite-UI/src/view/ProjectLinkLayer.js
+++ b/viite-UI/src/view/ProjectLinkLayer.js
@@ -157,11 +157,11 @@
         selectedProjectLinkProperty.clean();
         projectCollection.setTmpDirty([]);
         projectCollection.setDirty([]);
-        if(!_.isUndefined(selection.linkData.connectedLinkId)){
-          selectedProjectLinkProperty.openSplit(selection.linkData.linkId, true);
-        } else {
+        // if(!_.isUndefined(selection.linkData.connectedLinkId)){
+        //   selectedProjectLinkProperty.openSplit(selection.linkData.linkId, true);
+        // } else {
           selectedProjectLinkProperty.open(getSelectedId(selection.linkData), true);
-        }
+        // }
       } else {
         eventbus.trigger('roadAddressProject:discardChanges'); // Background map was clicked so discard changes
       }
@@ -219,11 +219,11 @@
         selectedProjectLinkProperty.clean();
         projectCollection.setTmpDirty([]);
         projectCollection.setDirty([]);
-        if (!_.isUndefined(selection.linkData.connectedLinkId)) {
-          selectedProjectLinkProperty.openSplit(selection.linkData.linkId, true);
-        } else {
+        // if (!_.isUndefined(selection.linkData.connectedLinkId)) {
+        //   selectedProjectLinkProperty.openSplit(selection.linkData.linkId, true);
+        // } else {
           selectedProjectLinkProperty.open(getSelectedId(selection.linkData));
-        }
+        // }
       }
     };
 

--- a/viite-UI/src/view/ProjectLinkLayer.js
+++ b/viite-UI/src/view/ProjectLinkLayer.js
@@ -287,8 +287,11 @@
       clearHighlights();
       var featuresToHighlight = [];
       _.each(projectLinkVector.getFeatures().concat(underConstructionRoadProjectLayer.getSource().getFeatures()).concat(unAddressedRoadsProjectLayer.getSource().getFeatures()), function (feature) {
-        var canIHighlight = ((!_.isUndefined(feature.linkData.linkId) && _.isUndefined(feature.linkData.connectedLinkId)) ||
-        (!_.isUndefined(feature.linkData.connectedLinkId) && feature.linkData.status === LinkStatus.Terminated.value) ?
+        // var canIHighlight = ((!_.isUndefined(feature.linkData.linkId) && _.isUndefined(feature.linkData.connectedLinkId)) ||
+        // (!_.isUndefined(feature.linkData.connectedLinkId) && feature.linkData.status === LinkStatus.Terminated.value) ?
+        //   selectedProjectLinkProperty.isSelected(getSelectedId(feature.linkData)) : false);
+
+        var canIHighlight = (!_.isUndefined(feature.linkData.linkId) || feature.linkData.status === LinkStatus.Terminated.value ?
           selectedProjectLinkProperty.isSelected(getSelectedId(feature.linkData)) : false);
         if (canIHighlight) {
           featuresToHighlight.push(feature);

--- a/viite-UI/src/view/ProjectLinkLayer.js
+++ b/viite-UI/src/view/ProjectLinkLayer.js
@@ -231,46 +231,6 @@
     map.addInteraction(selectSingleClick);
     map.addInteraction(selectDoubleClick);
 
-    var drawIndicators = function (links) {
-      var features = [];
-
-      var markerContainer = function (link, position) {
-        var imageSettings = {src: 'images/center-marker2.svg'};
-        var textSettings = {
-          text: link.marker,
-          fill: new ol.style.Fill({
-            color: '#ffffff'
-          }),
-          font: '12px sans-serif'
-        };
-        var style = new ol.style.Style({
-          image: new ol.style.Icon(imageSettings),
-          text: new ol.style.Text(textSettings),
-          zIndex: 11
-        });
-        var marker = new ol.Feature({
-          geometry: new ol.geom.Point([position.x, position.y]),
-          type: 'cutter'
-        });
-        marker.setStyle(style);
-        features.push(marker);
-      };
-
-      var indicatorsForSplit = function () {
-        return _.map(_.filter(links, function (fl) {
-          return !_.isUndefined(fl.middlePoint);
-        }), function (link) {
-          markerContainer(link, link.middlePoint);
-        });
-      };
-
-      var indicators = function () {
-        return indicatorsForSplit();
-      };
-      indicators();
-      addFeaturesToSelection(features);
-    };
-
     var canBeAddedToSelection = function(selectionData) {
       if (selectedProjectLinkProperty.get().length === 0) {
         return true;
@@ -456,10 +416,7 @@
       projectLinkVector.clear();
       directionMarkerLayer.getSource().clear();
       me.eventListener.listenToOnce(eventbus, 'roadAddressProject:fetched', function () {
-        if (selectedProjectLinkProperty.isSplit())
-          selectedProjectLinkProperty.openSplit(selectedProjectLinkProperty.get()[0].linkId, true);
-        else
-          selectedProjectLinkProperty.open(getSelectedId(selectedProjectLinkProperty.get()[0]), selectedProjectLinkProperty.isMultiLink());
+        selectedProjectLinkProperty.open(getSelectedId(selectedProjectLinkProperty.get()[0]), selectedProjectLinkProperty.isMultiLink());
       });
       projectCollection.fetch(map.getView().calculateExtent(map.getSize()).join(','), zoomlevels.getViewZoom(map) + 1, undefined, projectCollection.getPublishableStatus());
     });

--- a/viite-UI/src/view/ProjectLinkLayer.js
+++ b/viite-UI/src/view/ProjectLinkLayer.js
@@ -157,11 +157,7 @@
         selectedProjectLinkProperty.clean();
         projectCollection.setTmpDirty([]);
         projectCollection.setDirty([]);
-        // if(!_.isUndefined(selection.linkData.connectedLinkId)){
-        //   selectedProjectLinkProperty.openSplit(selection.linkData.linkId, true);
-        // } else {
-          selectedProjectLinkProperty.open(getSelectedId(selection.linkData), true);
-        // }
+        selectedProjectLinkProperty.open(getSelectedId(selection.linkData), true);
       } else {
         eventbus.trigger('roadAddressProject:discardChanges'); // Background map was clicked so discard changes
       }
@@ -219,11 +215,7 @@
         selectedProjectLinkProperty.clean();
         projectCollection.setTmpDirty([]);
         projectCollection.setDirty([]);
-        // if (!_.isUndefined(selection.linkData.connectedLinkId)) {
-        //   selectedProjectLinkProperty.openSplit(selection.linkData.linkId, true);
-        // } else {
-          selectedProjectLinkProperty.open(getSelectedId(selection.linkData));
-        // }
+        selectedProjectLinkProperty.open(getSelectedId(selection.linkData));
       }
     };
 
@@ -247,10 +239,6 @@
       clearHighlights();
       var featuresToHighlight = [];
       _.each(projectLinkVector.getFeatures().concat(underConstructionRoadProjectLayer.getSource().getFeatures()).concat(unAddressedRoadsProjectLayer.getSource().getFeatures()), function (feature) {
-        // var canIHighlight = ((!_.isUndefined(feature.linkData.linkId) && _.isUndefined(feature.linkData.connectedLinkId)) ||
-        // (!_.isUndefined(feature.linkData.connectedLinkId) && feature.linkData.status === LinkStatus.Terminated.value) ?
-        //   selectedProjectLinkProperty.isSelected(getSelectedId(feature.linkData)) : false);
-
         var canIHighlight = (!_.isUndefined(feature.linkData.linkId) || feature.linkData.status === LinkStatus.Terminated.value ?
           selectedProjectLinkProperty.isSelected(getSelectedId(feature.linkData)) : false);
         if (canIHighlight) {


### PR DESCRIPTION
**Command used**: git cherry-pick --ff VIITE-2358_split_link_to_have_same_roadway_numbers_amount_on_each_track_section ^master

**Conflicts resolved on**:
- VIITE-2360 added creation for link if new
- VIITE-2360 fixes to have update in connected link id.
- VIITE-2384 removed commented code

**Note**:
Added one last commit, to handle some changes since we're not including _VIITE-2344_ - but when this task goes up, this last commit must be reverted. Shouldn't be better to **merge** also _VIITE-2344_?