### PR TITLE
VIITE-2533 Nodes are missing from TR

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/NodesAndJunctionsService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/NodesAndJunctionsService.scala
@@ -979,26 +979,28 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
           nodePointDAO.fetchAddrMForAverage(roadPartInfo.roadNumber, roadPartInfo.roadPartNumber)
         }
         val addrMValueAVG = nodePointDAO.fetchAverageAddrM(roadPartInfo.roadNumber, roadPartInfo.roadPartNumber, nodeNumber)
-        val beforeAfterValue = if (roadPartInfo.endAddrM == addrMValueAVG) {
-          BeforeAfter.Before
-        } else if (roadPartInfo.startAddrM == addrMValueAVG) {
-          BeforeAfter.After
-        } else {
-          BeforeAfter.UnknownBeforeAfter
-        }
-        val existingRoadwayPoint = roadwayPointDAO.fetch(roadPartInfo.roadwayNumber, addrMValueAVG)
-        val rwPoint = if (existingRoadwayPoint.nonEmpty) {
-          existingRoadwayPoint.get.id
-        } else {
-          roadwayPointDAO.create(roadPartInfo.roadwayNumber, addrMValueAVG, username)
-        }
-        if (beforeAfterValue == BeforeAfter.UnknownBeforeAfter) {
-          nodePointDAO.insertCalculatedNodePoint(rwPoint, BeforeAfter.Before, nodeNumber, username)
-          nodePointDAO.insertCalculatedNodePoint(rwPoint, BeforeAfter.After, nodeNumber, username)
-          nodePointCount = nodePointCount + 2
-        } else {
-          nodePointDAO.insertCalculatedNodePoint(rwPoint, beforeAfterValue, nodeNumber, username)
-          nodePointCount = nodePointCount + 1
+        if (roadPartInfo.startAddrM <= addrMValueAVG && addrMValueAVG <= roadPartInfo.endAddrM) {
+          val beforeAfterValue = if (roadPartInfo.endAddrM == addrMValueAVG) {
+            BeforeAfter.Before
+          } else if (roadPartInfo.startAddrM == addrMValueAVG) {
+            BeforeAfter.After
+          } else {
+            BeforeAfter.UnknownBeforeAfter
+          }
+          val existingRoadwayPoint = roadwayPointDAO.fetch(roadPartInfo.roadwayNumber, addrMValueAVG)
+          val rwPoint = if (existingRoadwayPoint.nonEmpty) {
+            existingRoadwayPoint.get.id
+          } else {
+            roadwayPointDAO.create(roadPartInfo.roadwayNumber, addrMValueAVG, username)
+          }
+          if (beforeAfterValue == BeforeAfter.UnknownBeforeAfter) {
+            nodePointDAO.insertCalculatedNodePoint(rwPoint, BeforeAfter.Before, nodeNumber, username)
+            nodePointDAO.insertCalculatedNodePoint(rwPoint, BeforeAfter.After, nodeNumber, username)
+            nodePointCount = nodePointCount + 2
+          } else {
+            nodePointDAO.insertCalculatedNodePoint(rwPoint, beforeAfterValue, nodeNumber, username)
+            nodePointCount = nodePointCount + 1
+          }
         }
       }
     }


### PR DESCRIPTION
When updating Node on a road part that has both single and dual tracks, viite incorrectly places the node point on a single track roadway (results are ordered by track ASC). In some cases the point address then becomes invalid because the point M value does not belong to the possible roadway M values. TR does not find an address for the track 0 and therefore ignores the node point.

Added validation of the M value to be incuded in the roadway that the node point is going to be added.