### PR TITLE
Viite-2564 Extra Nodepoint

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/NodesAndJunctionsService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/NodesAndJunctionsService.scala
@@ -691,7 +691,8 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
           roadTypeSections.foreach { section =>
 
             val headProjectLink = section.head
-            val headReversed = roadwayChanges.exists(ch => ch.changeInfo.target.startAddressM.nonEmpty && headProjectLink.startAddrMValue == ch.changeInfo.target.startAddressM.get && ch.changeInfo.reversed)
+            val headReversed = roadwayChanges.exists(ch => ch.changeInfo.target.startAddressM.nonEmpty && headProjectLink.startAddrMValue == ch.changeInfo.target.startAddressM.get
+              && ch.changeInfo.target.endAddressM.nonEmpty && headProjectLink.endAddrMValue == ch.changeInfo.target.endAddressM.get && ch.changeInfo.reversed)
 
             val headNodePoint: Option[NodePoint] = mappedRoadwayNumbers.find { rl =>
               headProjectLink.startAddrMValue == rl.newStartAddr && headProjectLink.endAddrMValue == rl.newEndAddr && headProjectLink.roadwayNumber == rl.newRoadwayNumber


### PR DESCRIPTION
headReversed flag now also checks endAddrM of the projectlink when determining if the link has been reversed. Earlier version only checked the startAddrM which was = 0. This resulted the flag to be set true when in reality it should've been false. The code checked another links startMValue and when it was also 0, it thought it had found the project link in question and set the flag to be True because the wrong project link had been reversed. This fixed issue Viite-2564 where an extra nodepoint was created due to Viite not finding the old one because of the headReversed flag being at incorrect state when fetching the nodepoint.