### PR TITLE
VIITE-2490 Fix katunimi query parameter escape bug when calling viitekehysmuunnin/muunna

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
@@ -293,7 +293,10 @@ class RoadAddressService(roadLinkService: RoadLinkService, roadwayDAO: RoadwayDA
           if (address.size > 1) MunicipalityDAO.getMunicipalityIdByName(address.last.trim).headOption.map(_._1) else None
         }
         val (streetName, streetNumber) = address.head.split(" ").partition(_.matches(("\\D+")))
-        searchResult = viiteVkmClient.get("/viitekehysmuunnin/muunna", Map(("kuntakoodi", municipalityId.getOrElse("").toString), ("katunimi", streetName.mkString("%20")), ("katunumero", streetNumber.headOption.getOrElse(defaultStreetNumber.toString)))) match {
+        searchResult = viiteVkmClient.get("/viitekehysmuunnin/muunna", Map(
+          ("kuntakoodi", municipalityId.getOrElse("").toString),
+          ("katunimi", streetName.mkString(" ")), // parameter expected to be unescaped; pad with space only
+          ("katunumero", streetNumber.headOption.getOrElse(defaultStreetNumber.toString)))) match {
           case Left(result) => Seq(result)
           case Right(error) => throw new VkmException(error.toString)
         }

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ViiteVkmClient.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ViiteVkmClient.scala
@@ -31,6 +31,11 @@ class ViiteVkmClient {
 
   private val client = HttpClientBuilder.create().build
 
+  /**
+    * Builds http query fom given parts, executes the query, and returns the result (or error if http>=400).
+    * @param params query parameters. Parameters are expected to be unescaped.
+    * @return The query result, or VKMError in case the response was http>=400.
+    */
   def get(path: String, params: Map[String, String]): Either[Any, VKMError] = {
 
     val builder = new URIBuilder(getRestEndPoint + path)


### PR DESCRIPTION
(katunimi mkstring concatenation replaced with plain " ", instead of previous readily escaped %20, which broke functionality offered by UriBuilder.addParameter)