### PR TITLE
Viite 2579 oag refs from backend to env vars

### DIFF
--- a/aws/task-definition/dev/task-definition.json
+++ b/aws/task-definition/dev/task-definition.json
@@ -23,7 +23,7 @@
                 { "name": "municipalityProvider", "value": "fi.liikennevirasto.digiroad2.dao.PostGISMunicipalityProvider" },
                 { "name": "eventBus", "value": "fi.liikennevirasto.digiroad2.DigiroadEventBus" },
                 { "name": "vvhServiceHost", "value": "haproxy.vayla.fi" },
-                { "name": "oagProxyServer", "value": "http://oag.vayla.fi" },
+                { "name": "oagProxyServer", "value": "oag.vayla.fi" },
                 { "name": "rasterServiceURL", "value": "http://oag.vayla.fi/rasteripalvelu-mml" },
                 { "name": "vvhRestApiEndPoint", "value": "https://haproxy.vayla.fi:2027/vvhdata/" },
                 { "name": "vvhRoadlink.frozen", "value": "true" },

--- a/aws/task-definition/dev/task-definition.json
+++ b/aws/task-definition/dev/task-definition.json
@@ -24,6 +24,7 @@
                 { "name": "eventBus", "value": "fi.liikennevirasto.digiroad2.DigiroadEventBus" },
                 { "name": "vvhServiceHost", "value": "haproxy.vayla.fi" },
                 { "name": "oagProxyServer", "value": "oag.vayla.fi" },
+                { "name": "oagProxyURL", "value": "https://oag.vayla.fi" },
                 { "name": "rasterServiceURL", "value": "http://oag.vayla.fi/rasteripalvelu-mml" },
                 { "name": "vvhRestApiEndPoint", "value": "https://haproxy.vayla.fi:2027/vvhdata/" },
                 { "name": "vvhRoadlink.frozen", "value": "true" },

--- a/aws/task-definition/dev/task-definition.json
+++ b/aws/task-definition/dev/task-definition.json
@@ -23,6 +23,8 @@
                 { "name": "municipalityProvider", "value": "fi.liikennevirasto.digiroad2.dao.PostGISMunicipalityProvider" },
                 { "name": "eventBus", "value": "fi.liikennevirasto.digiroad2.DigiroadEventBus" },
                 { "name": "vvhServiceHost", "value": "haproxy.vayla.fi" },
+                { "name": "oagProxyServer", "value": "http://oag.vayla.fi" },
+                { "name": "rasterServiceURL", "value": "http://oag.vayla.fi/rasteripalvelu-mml" },
                 { "name": "vvhRestApiEndPoint", "value": "https://haproxy.vayla.fi:2027/vvhdata/" },
                 { "name": "vvhRoadlink.frozen", "value": "true" },
                 { "name": "vkmUrl", "value": "http://oag.vayla.fi" },

--- a/conf/env.properties
+++ b/conf/env.properties
@@ -32,5 +32,5 @@ vkmUrl=http://localhost:8997
 vvhRestApiEndPoint=http://172.17.204.39:6080/arcgis/rest/services/VVH_OTH/
 vvhRoadlink.frozen=true
 vvhServiceHost=172.17.204.39:6080
-oagProxyServer=http://oag.vayla.fi
+oagProxyServer=oag.vayla.fi
 rasterServiceURL=http://oag.vayla.fi/rasteripalvelu-mml

--- a/conf/env.properties
+++ b/conf/env.properties
@@ -33,4 +33,5 @@ vvhRestApiEndPoint=http://172.17.204.39:6080/arcgis/rest/services/VVH_OTH/
 vvhRoadlink.frozen=true
 vvhServiceHost=172.17.204.39:6080
 oagProxyServer=oag.vayla.fi
+oagProxyURL=http://oag.vayla.fi
 rasterServiceURL=http://oag.vayla.fi/rasteripalvelu-mml

--- a/conf/env.properties
+++ b/conf/env.properties
@@ -32,3 +32,5 @@ vkmUrl=http://localhost:8997
 vvhRestApiEndPoint=http://172.17.204.39:6080/arcgis/rest/services/VVH_OTH/
 vvhRoadlink.frozen=true
 vvhServiceHost=172.17.204.39:6080
+oagProxyServer=http://oag.vayla.fi
+rasterServiceURL=http://oag.vayla.fi/rasteripalvelu-mml

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/ViiteProperties.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/ViiteProperties.scala
@@ -11,6 +11,7 @@ trait ViiteProperties {
   val useVVHGeometry: String
   val vvhServiceHost: String
   val oagProxyServer: String
+  val oagProxyURL: String
   val rasterServiceURL: String
   val vvhRestApiEndPoint: String
   val vvhRoadlinkFrozen: Boolean
@@ -64,6 +65,7 @@ class ViitePropertiesFromEnv extends ViiteProperties {
   val useVVHGeometry: String = scala.util.Properties.envOrElse("useVVHGeometry", null)
   val vvhServiceHost: String = scala.util.Properties.envOrElse("vvhServiceHost", null)
   val oagProxyServer: String = scala.util.Properties.envOrElse("oagProxyServer", null)
+  val oagProxyURL: String = scala.util.Properties.envOrElse("oagProxyURL", null)
   val rasterServiceURL: String = scala.util.Properties.envOrElse("rasterServiceURL", null)
   val vvhRestApiEndPoint: String = scala.util.Properties.envOrElse("vvhRestApiEndPoint", null)
   val vvhRoadlinkFrozen: Boolean = scala.util.Properties.envOrElse("vvhRoadlink.frozen", "false").toBoolean
@@ -150,6 +152,7 @@ class ViitePropertiesFromFile extends ViiteProperties {
   override val useVVHGeometry: String = envProps.getProperty("useVVHGeometry")
   override val vvhServiceHost: String = scala.util.Properties.envOrElse("vvhServiceHost", envProps.getProperty("vvhServiceHost"))
   override val oagProxyServer: String = scala.util.Properties.envOrElse("oagProxyServer", envProps.getProperty("oagProxyServer"))
+  override val oagProxyURL:  String = scala.util.Properties.envOrElse("oagProxyURL", envProps.getProperty("oagProxyURL"))
   override val rasterServiceURL: String = scala.util.Properties.envOrElse("rasterServiceURL", envProps.getProperty("rasterServiceURL"))
   override val vvhRestApiEndPoint: String = scala.util.Properties.envOrElse("vvhRestApiEndPoint", envProps.getProperty("vvhRestApiEndPoint"))
   override val vvhRoadlinkFrozen: Boolean = envProps.getProperty("vvhRoadlink.frozen", "false").toBoolean
@@ -233,6 +236,7 @@ object ViiteProperties {
   lazy val useVVHGeometry: String = properties.useVVHGeometry
   lazy val vvhServiceHost: String = properties.vvhServiceHost
   lazy val oagProxyServer: String = properties.oagProxyServer
+  lazy val oagProxyURL: String = properties.oagProxyURL
   lazy val rasterServiceURL: String = properties.rasterServiceURL
   lazy val vvhRestApiEndPoint: String = properties.vvhRestApiEndPoint
   lazy val vvhRoadlinkFrozen: Boolean = properties.vvhRoadlinkFrozen

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/ViiteProperties.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/ViiteProperties.scala
@@ -10,6 +10,8 @@ trait ViiteProperties {
   val eventBus: String
   val useVVHGeometry: String
   val vvhServiceHost: String
+  val oagProxyServer: String
+  val rasterServiceURL: String
   val vvhRestApiEndPoint: String
   val vvhRoadlinkFrozen: Boolean
   val vkmUrl: String
@@ -61,6 +63,8 @@ class ViitePropertiesFromEnv extends ViiteProperties {
   val eventBus: String = scala.util.Properties.envOrElse("eventBus", null)
   val useVVHGeometry: String = scala.util.Properties.envOrElse("useVVHGeometry", null)
   val vvhServiceHost: String = scala.util.Properties.envOrElse("vvhServiceHost", null)
+  val oagProxyServer: String = scala.util.Properties.envOrElse("oagProxyServer", null)
+  val rasterServiceURL: String = scala.util.Properties.envOrElse("rasterServiceURL", null)
   val vvhRestApiEndPoint: String = scala.util.Properties.envOrElse("vvhRestApiEndPoint", null)
   val vvhRoadlinkFrozen: Boolean = scala.util.Properties.envOrElse("vvhRoadlink.frozen", "false").toBoolean
   val vkmUrl: String = scala.util.Properties.envOrElse("vkmUrl", null)
@@ -145,6 +149,8 @@ class ViitePropertiesFromFile extends ViiteProperties {
   override val eventBus: String = envProps.getProperty("eventBus")
   override val useVVHGeometry: String = envProps.getProperty("useVVHGeometry")
   override val vvhServiceHost: String = scala.util.Properties.envOrElse("vvhServiceHost", envProps.getProperty("vvhServiceHost"))
+  override val oagProxyServer: String = scala.util.Properties.envOrElse("oagProxyServer", envProps.getProperty("oagProxyServer"))
+  override val rasterServiceURL: String = scala.util.Properties.envOrElse("rasterServiceURL", envProps.getProperty("rasterServiceURL"))
   override val vvhRestApiEndPoint: String = scala.util.Properties.envOrElse("vvhRestApiEndPoint", envProps.getProperty("vvhRestApiEndPoint"))
   override val vvhRoadlinkFrozen: Boolean = envProps.getProperty("vvhRoadlink.frozen", "false").toBoolean
   override val vkmUrl: String = scala.util.Properties.envOrElse("vkmUrl", envProps.getProperty("vkmUrl"))
@@ -226,6 +232,8 @@ object ViiteProperties {
   lazy val eventBus: String = properties.eventBus
   lazy val useVVHGeometry: String = properties.useVVHGeometry
   lazy val vvhServiceHost: String = properties.vvhServiceHost
+  lazy val oagProxyServer: String = properties.oagProxyServer
+  lazy val rasterServiceURL: String = properties.rasterServiceURL
   lazy val vvhRestApiEndPoint: String = properties.vvhRestApiEndPoint
   lazy val vvhRoadlinkFrozen: Boolean = properties.vvhRoadlinkFrozen
   lazy val vkmUrl: String = properties.vkmUrl

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ViiteVkmClient.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ViiteVkmClient.scala
@@ -49,7 +49,7 @@ class ViiteVkmClient {
 
     if (builder.getHost == "localhost") {
       // allow ssh port forward for developing
-      request.setHeader("Host", "testioag.vayla.fi")
+      request.setHeader("Host", ViiteProperties.oagProxyServer)
     }
 
     val response = client.execute(request)
@@ -79,7 +79,7 @@ class ViiteVkmClient {
     val url = new URL(getRestEndPoint)
     if (url.getHost == "localhost") {
       // allow ssh port forward for developing
-      post.setHeader("Host", "oag.liikennevirasto.fi")
+      post.setHeader("Host", ViiteProperties.oagProxyServer)
     }
     var response: CloseableHttpResponse = null
     try {

--- a/src/main/scala/fi/liikennevirasto/digiroad2/DigiroadServer.scala
+++ b/src/main/scala/fi/liikennevirasto/digiroad2/DigiroadServer.scala
@@ -56,7 +56,7 @@ class OAGProxyServlet extends ProxyServlet {
   override def rewriteURI(req: HttpServletRequest): java.net.URI = {
     val uri = req.getRequestURI
     val url = s"${ViiteProperties.rasterServiceURL}$uri"
-    logger.info(s"OAGProxyServlet: $url")
+    logger.debug(url)
     java.net.URI.create(url)
   }
 
@@ -72,7 +72,7 @@ class OAGRasterServiceProxyServlet extends ProxyServlet {
   override def rewriteURI(req: HttpServletRequest): java.net.URI = {
     val uri = req.getRequestURI
     val url = s"${ViiteProperties.oagProxyURL}$uri?${req.getQueryString}"
-    logger.info(s"OAGRasterServiceProxyServlet: $url")
+    logger.debug(url)
     java.net.URI.create(url)
   }
 
@@ -88,7 +88,7 @@ class ArcGisProxyServlet extends ProxyServlet {
   override def rewriteURI(req: HttpServletRequest): java.net.URI = {
     val uri = req.getRequestURI
     val url = s"http://aineistot.esri.fi$uri"
-    logger.info(url)
+    logger.debug(url)
     java.net.URI.create(url)
   }
 

--- a/src/main/scala/fi/liikennevirasto/digiroad2/DigiroadServer.scala
+++ b/src/main/scala/fi/liikennevirasto/digiroad2/DigiroadServer.scala
@@ -51,9 +51,13 @@ trait DigiroadServer {
 
 class OAGProxyServlet extends ProxyServlet {
 
+  private val logger = LoggerFactory.getLogger(getClass)
+
   override def rewriteURI(req: HttpServletRequest): java.net.URI = {
     val uri = req.getRequestURI
-    java.net.URI.create(s"http://oag.liikennevirasto.fi/rasteripalvelu-mml$uri")
+    val url = s"${ViiteProperties.rasterServiceURL}$uri"
+    logger.info(s"OAGProxyServlet: $url")
+    java.net.URI.create(url)
   }
 
   override def sendProxyRequest(clientRequest: HttpServletRequest, proxyResponse: HttpServletResponse, proxyRequest: Request): Unit = {
@@ -67,8 +71,8 @@ class OAGRasterServiceProxyServlet extends ProxyServlet {
 
   override def rewriteURI(req: HttpServletRequest): java.net.URI = {
     val uri = req.getRequestURI
-    val url = s"http://oag.liikennevirasto.fi$uri?${req.getQueryString}"
-    logger.info(url)
+    val url = s"${ViiteProperties.oagProxyServer}$uri?${req.getQueryString}"
+    logger.info(s"OAGRasterServiceProxyServlet: $url")
     java.net.URI.create(url)
   }
 

--- a/src/main/scala/fi/liikennevirasto/digiroad2/DigiroadServer.scala
+++ b/src/main/scala/fi/liikennevirasto/digiroad2/DigiroadServer.scala
@@ -71,7 +71,7 @@ class OAGRasterServiceProxyServlet extends ProxyServlet {
 
   override def rewriteURI(req: HttpServletRequest): java.net.URI = {
     val uri = req.getRequestURI
-    val url = s"${ViiteProperties.oagProxyServer}$uri?${req.getQueryString}"
+    val url = s"${ViiteProperties.oagProxyURL}$uri?${req.getQueryString}"
     logger.info(s"OAGRasterServiceProxyServlet: $url")
     java.net.URI.create(url)
   }


### PR DESCRIPTION
Note: using still http protocol instead of https (tested: SSL protocol to work does not work with proxy without other changes).