### PR TITLE
Viite-2588 Select whole roadpart with single click (katselutilassa)

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
@@ -69,6 +69,11 @@ class RoadLinkService(val vvhClient: VVHClient, val eventbus: DigiroadEventBus, 
     else Seq.empty[VVHRoadlink]
   }
 
+  def fetchVVHComplementaryLinksFromVVH(linkIds: Set[Long]): Seq[VVHRoadlink] = {
+    if (linkIds.nonEmpty) vvhClient.complementaryData.fetchByLinkIds(linkIds)
+    else Seq.empty[VVHRoadlink]
+  }
+
   private def fetchVVHFrozenRoadLinksAndComplementaryFromVVH(linkIds: Set[Long]): Seq[VVHRoadlink] = {
     if (linkIds.nonEmpty) vvhClient.frozenTimeRoadLinkData.fetchByLinkIds(linkIds) ++ vvhClient.complementaryData.fetchByLinkIds(linkIds)
     else Seq.empty[VVHRoadlink]
@@ -314,6 +319,14 @@ class RoadLinkService(val vvhClient: VVHClient, val eventbus: DigiroadEventBus, 
         link.modifiedAt.map(DateTimePropertyFormat.print),
         None, link.attributes, link.constructionType, link.linkSource)
     }
+  }
+
+  def getComplementaryRoadLinksFromVVHByLinkIds(linkIds: Set[Long]): Seq[RoadLink] = {
+    val links = {
+      if (linkIds.nonEmpty) fetchVVHComplementaryLinksFromVVH(linkIds)
+      else Seq.empty[VVHRoadlink]
+    }
+    (enrichRoadLinksFromVVH(links), Seq())._1
   }
 
   def getComplementaryRoadLinksFromVVH(bounds: BoundingRectangle, municipalities: Set[Int] = Set()): Seq[RoadLink] = {

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
@@ -104,8 +104,7 @@ class RoadAddressService(roadLinkService: RoadLinkService, roadwayDAO: RoadwayDA
 
     // get all the roadways in the roadpart(s)(not just the roadwaynumbers that are on the linearlocations that we got from the boundingbox)
     val allRoadwaysInRoadParts =  {
-      val roadways = roadAndPartNumbers.flatMap(rp => roadwayDAO.fetchAllByRoadAndPart(rp._1, rp._2)).distinct
-      roadways
+      roadAndPartNumbers.flatMap(rp => roadwayDAO.fetchAllByRoadAndPart(rp._1, rp._2)).distinct
     }
 
     // get all the roadwayNumbers from the roadways

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/RoadAddressServiceSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/RoadAddressServiceSpec.scala
@@ -124,8 +124,10 @@ class RoadAddressServiceSpec extends FunSuite with Matchers{
     )
 
     when(mockLinearLocationDAO.fetchLinearLocationByBoundingBox(any[BoundingRectangle], any[Seq[(Int,Int)]])).thenReturn(linearLocations)
+    when(mockLinearLocationDAO.fetchByRoadwayNumber(any[Iterable[Long]])).thenReturn(linearLocations.toList)
 
     when(mockRoadwayDAO.fetchAllByRoadwayNumbers(any[Set[Long]], any[Boolean])).thenReturn(roadways)
+    when(mockRoadwayDAO.fetchAllByRoadAndPart(any[Long], any[Long], any[Boolean], any[Boolean])).thenReturn(roadways)
 
     //Road Link service mocks
     when(mockRoadLinkService.getChangeInfoFromVVHF(any[Set[Long]])).thenReturn(Future(Seq.empty))

--- a/viite-UI/src/model/RoadCollection.js
+++ b/viite-UI/src/model/RoadCollection.js
@@ -78,10 +78,16 @@
       return _.flatten(roadLinkGroups);
     };
 
+    var selectedRoadNumber = 0;
+    var selectedRoadPartNumber = 0;
     var getSelectedRoadLinks = function () {
-      return _.filter(roadLinks().concat(underConstructionRoadLinks()), function (roadLink) {
+      var selected_road = _.find(roadLinks() , function (roadLink) {
         return roadLink.isSelected() && roadLink.getData().anomaly === Anomaly.None.value;
       });
+      if (selected_road) {
+        selectedRoadNumber = selected_road.getData().roadNumber;
+        selectedRoadPartNumber = selected_road.getData().roadPartNumber;
+      }
     };
 
     this.getDate = function () {

--- a/viite-UI/src/view/LinkPropertyLayer.js
+++ b/viite-UI/src/view/LinkPropertyLayer.js
@@ -277,7 +277,7 @@
      * sending them to the selectedLinkProperty.open for further processing.
      */
     selectSingleClick.on('select', function (event) {
-      var visibleFeatures = getVisibleFeatures(true, true, true, true, true, true, true, true, true);
+      var allFeatures = getAllFeatures(true, true, true, true, true, true, true, true, true);
       selectDoubleClick.getFeatures().clear();
       var selectedF = _.find(event.selected, function (selectionTarget) {
         return !_.isUndefined(selectionTarget.linkData);
@@ -290,7 +290,7 @@
         }
         if (selection.floating === SelectionType.Floating.value && !applicationModel.isReadOnly()) {
           selectedLinkProperty.close();
-          selectedLinkProperty.openFloating(selection, true, visibleFeatures);
+          selectedLinkProperty.openFloating(selection, true, allFeatures);
           floatingMarkerLayer.setOpacity(1);
           anomalousMarkerLayer.setOpacity(1);
         } else if (selection.floating !== SelectionType.Floating.value && applicationModel.selectionTypeIs(SelectionType.Floating) && !applicationModel.isReadOnly() && event.deselected.length !== 0) {
@@ -300,7 +300,7 @@
           addFeaturesToSelection(floatings);
         } else if (applicationModel.selectionTypeIs(SelectionType.Unknown) && !applicationModel.isReadOnly()) {
           if ((selection.anomaly === Anomaly.NoAddressGiven.value || selection.anomaly === Anomaly.GeometryChanged.value) && selection.roadLinkType !== SelectionType.Floating.value) {
-            selectedLinkProperty.openUnknown(selection, visibleFeatures);
+            selectedLinkProperty.openUnknown(selection, allFeatures);
           } else {
             removeFeaturesFromSelection(event.selected);
             addFeaturesToSelection(event.deselected);
@@ -308,7 +308,8 @@
         } else {
           selectedLinkProperty.close();
           setGeneralOpacity(0.2);
-          selectedLinkProperty.open(selection, true, visibleFeatures);
+          selectedLinkProperty.open(selection, true, allFeatures);
+
         }
         if (applicationModel.selectionTypeIs(SelectionType.Unknown) && selection.floating !== SelectionType.Floating.value && (selection.anomaly === Anomaly.NoAddressGiven.value || selection.anomaly === Anomaly.GeometryChanged.value)) {
           greenRoadLayer.setOpacity(1);
@@ -399,6 +400,19 @@
       var visibleGeometryChanged = withGeometryChanged ? geometryChangedLayer.getSource().getFeaturesInExtent(extent) : [];
       return visibleRoads.concat(visibleAnomalyMarkers).concat(visibleFloatingMarkers).concat(visibleGreenRoadLayer).concat(visibleDirectionalMarkers).concat(visibleUnderConstructionMarkers).concat(visibleUnderConstructionRoads).concat(visibleUnAddressedRoads).concat(visibleGeometryChanged);
     };
+
+    var getAllFeatures = function (withRoads, withAnomalyMarkers, withFloatingMarkers, withGreenRoads, withPickRoads, withDirectionalMarkers, withunderConstructionRoads, withGeometryChanged, withVisibleUnAddressedRoads) {
+      var Roads = withRoads ? roadLayer.layer.getSource().getFeatures() : [];
+      var AnomalyMarkers = withAnomalyMarkers ? anomalousMarkerLayer.getSource().getFeatures() : [];
+      var FloatingMarkers = withFloatingMarkers ? floatingMarkerLayer.getSource().getFeatures() : [];
+      var GreenRoadLayer = withGreenRoads ? greenRoadLayer.getSource().getFeatures() : [];
+      var DirectionalMarkers = withDirectionalMarkers ? directionMarkerLayer.getSource().getFeatures() : [];
+      var UnderConstructionMarkers = withDirectionalMarkers ? underConstructionMarkerLayer.getSource().getFeatures() : [];
+      var UnderConstructionRoads = withunderConstructionRoads ? underConstructionRoadLayer.getSource().getFeatures() : [];
+      var UnAddressedRoads = withVisibleUnAddressedRoads ? unAddressedRoadLayer.getSource().getFeatures() : [];
+      var GeometryChanged = withGeometryChanged ? geometryChangedLayer.getSource().getFeatures() : [];
+      return Roads.concat(AnomalyMarkers).concat(FloatingMarkers).concat(GreenRoadLayer).concat(DirectionalMarkers).concat(UnderConstructionMarkers).concat(UnderConstructionRoads).concat(UnAddressedRoads).concat(GeometryChanged);
+    }
 
     /**
      * This will add all the following interactions from the map:


### PR DESCRIPTION
Single click selects whole roadpart and not just the visible part of the roadpart (boundingbox).

 RoadAddressService now gets the linearlocations from the bounding box and based on those linearlocations Viite will get data of the whole roadpart and pass it to the UI.

UI will then get all the features instead of the visible features it used to get and selects the whole roadpart when its clicked.

Fixed test (added mock functions)