### PR TITLE
Viite-2616 move project calculation to its own button 

### DIFF
--- a/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
+++ b/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
@@ -933,22 +933,21 @@ class ViiteApi(val roadLinkService: RoadLinkService, val vVHClient: VVHClient,
 
   get("/project/recalculateProject/:projectId", operation(recalculateAndValidateProject)) {
     val projectId = params("projectId").toLong
-    try {
-      withDynTransaction {
-        val project = projectService.fetchProjectById(projectId).get
-        projectService.recalculateProjectLinks(projectId, project.modifiedBy)
-      }
-    } catch {
-      case ex: RoadAddressException =>
-        logger.info("Road address Exception: " + ex.getMessage)
-      case ex: ProjectValidationException => Some(ex.getMessage)
-      case ex: Exception => Some(ex.getMessage)
-    }
-
     time(logger, s"GET request for /project/recalculateProject/$projectId") {
-      val validationErrors = projectService.validateProjectById(projectId).map(errorPartsToApi)
-      // return validation errors
-      Map("validationErrors" -> validationErrors)
+      try {
+        withDynTransaction {
+          val project = projectService.fetchProjectById(projectId).get
+          projectService.recalculateProjectLinks(projectId, project.modifiedBy)
+        }
+        val validationErrors = projectService.validateProjectById(projectId).map(errorPartsToApi)
+        // return validation errors
+        Map("validationErrors" -> validationErrors)
+      } catch {
+        case ex: RoadAddressException =>
+          logger.info("Road address Exception: " + ex.getMessage)
+        case ex: ProjectValidationException => Some(ex.getMessage)
+        case ex: Exception => Some(ex.getMessage)
+      }
     }
   }
 

--- a/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
+++ b/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
@@ -779,7 +779,7 @@ class ViiteApi(val roadLinkService: RoadLinkService, val vVHClient: VVHClient,
             Some(links.coordinates)) match {
             case Some(errorMessage) => Map("success" -> false, "errorMessage" -> errorMessage)
             case None =>
-              val projectErrors = projectService.validateProjectById(links.projectId).map(errorPartsToApi)
+              val projectErrors = projectService.validateProjectByIdHighPriorityOnly(links.projectId).map(errorPartsToApi)
               val project = projectService.getSingleProjectById(links.projectId).get
               Map("success" -> true, "id" -> links.projectId,
                 "publishable" -> projectErrors.isEmpty,

--- a/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
+++ b/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
@@ -923,17 +923,16 @@ class ViiteApi(val roadLinkService: RoadLinkService, val vVHClient: VVHClient,
   }
 
   private val recalculateAndValidateProject: SwaggerSupportSyntax.OperationBuilder =(
-    apiOperation[Map[String, Any]]("validateProjectAndValidateProject")
+    apiOperation[Map[String, Any]]("recalculateAndValidateProject")
       .parameters(
         pathParam[Long]("projectId").description("Id of a project")
       )
       tags "ViiteAPI - Project"
-      summary "Given a valid projectId, this will run recalculate() and the validations to the project in question."
+      summary "Given a valid projectId, this will run recalculation and the validations to the project in question."
     )
 
   get("/project/recalculateProject/:projectId", operation(recalculateAndValidateProject)) {
     val projectId = params("projectId").toLong
-    logger.info(s"---------GET request for /project/recalculateProject/$projectId")
     try {
       withDynTransaction {
         val project = projectService.fetchProjectById(projectId).get
@@ -948,10 +947,10 @@ class ViiteApi(val roadLinkService: RoadLinkService, val vVHClient: VVHClient,
 
     time(logger, s"GET request for /project/recalculateProject/$projectId") {
       val validationErrors = projectService.validateProjectById(projectId).map(errorPartsToApi)
+      // return validation errors
       Map("validationErrors" -> validationErrors)
     }
   }
-
 
   //  private val splitSuravageLinkByLinkId: SwaggerSupportSyntax.OperationBuilder = (
   //    apiOperation[Map[String, Any]]("splitSuravageLinkByLinkId")

--- a/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
+++ b/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
@@ -941,12 +941,17 @@ class ViiteApi(val roadLinkService: RoadLinkService, val vVHClient: VVHClient,
         }
         val validationErrors = projectService.validateProjectById(projectId).map(errorPartsToApi)
         // return validation errors
-        Map("validationErrors" -> validationErrors)
+        Map("success" -> true, "validationErrors" -> validationErrors)
       } catch {
         case ex: RoadAddressException =>
           logger.info("Road address Exception: " + ex.getMessage)
-        case ex: ProjectValidationException => Some(ex.getMessage)
-        case ex: Exception => Some(ex.getMessage)
+          Map("success" -> false, "errorMessage" -> ex.getMessage)
+        case ex: ProjectValidationException =>
+          Some(ex.getMessage)
+          Map("success" -> false, "errorMessage" -> ex.getMessage)
+        case ex: Exception =>
+          Some(ex.getMessage)
+          Map("success" -> false, "errorMessage" -> ex.getMessage)
       }
     }
   }

--- a/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
+++ b/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
@@ -947,7 +947,7 @@ class ViiteApi(val roadLinkService: RoadLinkService, val vVHClient: VVHClient,
     }
 
     time(logger, s"GET request for /project/recalculateProject/$projectId") {
-      val validationErrors = projectService.validateProjectById(projectId).map(mapValidationIssues)
+      val validationErrors = projectService.validateProjectById(projectId).map(errorPartsToApi)
       Map("validationErrors" -> validationErrors)
     }
   }

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -474,7 +474,7 @@ class ProjectService(roadAddressService: RoadAddressService, roadLinkService: Ro
                 Map("success" -> false, "errorMessage" -> errorMessage)
               }
               case None => {
-                Map("success" -> true, "projectErrors" -> validateProjectById(projectId, newSession = false))
+                Map("success" -> true, "projectErrors" -> validateProjectByIdHighPriorityOnly(projectId, newSession = false))
               }
             }
           }

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -2265,6 +2265,17 @@ class ProjectService(roadAddressService: RoadAddressService, roadLinkService: Ro
     }
   }
 
+  def validateProjectByIdHighPriorityOnly(projectId: Long, newSession: Boolean = true): Seq[projectValidator.ValidationErrorDetails] = {
+    if (newSession) {
+      withDynSession {
+        projectValidator.projectLinksHighPriorityValidation(fetchProjectById(projectId).get, projectLinkDAO.fetchProjectLinks(projectId))
+      }
+    }
+    else {
+      projectValidator.projectLinksHighPriorityValidation(fetchProjectById(projectId).get, projectLinkDAO.fetchProjectLinks(projectId))
+    }
+  }
+
   def validateLinkTrack(track: Int): Boolean = {
     Track.values.filterNot(_.value == Track.Unknown.value).exists(_.value == track)
   }

--- a/viite-UI/src/less/core/buttons.less
+++ b/viite-UI/src/less/core/buttons.less
@@ -545,6 +545,7 @@
   background-color: @orange;
 }
 
+.btn-recalculate,
 .btn-show-changes,
 .btn-attach-node {
 	height: 30px;

--- a/viite-UI/src/less/core/buttons.less
+++ b/viite-UI/src/less/core/buttons.less
@@ -589,4 +589,3 @@
 	float: right !important;
 	cursor: pointer;        /* make the cursor like hovering over an <a> element */
 }
-

--- a/viite-UI/src/less/core/buttons.less
+++ b/viite-UI/src/less/core/buttons.less
@@ -589,3 +589,4 @@
 	float: right !important;
 	cursor: pointer;        /* make the cursor like hovering over an <a> element */
 }
+

--- a/viite-UI/src/less/core/forms.less
+++ b/viite-UI/src/less/core/forms.less
@@ -618,6 +618,10 @@ form.node .control-label-small {
     line-height: @line-height-modifier * 3;
     font-size: @font-size-xs;
   }
+
+  .validation-text {
+    margin-bottom: 50px;
+  }
 }
 
 // Inverted colors

--- a/viite-UI/src/model/ProjectCollection.js
+++ b/viite-UI/src/model/ProjectCollection.js
@@ -73,7 +73,6 @@
     };
 
     this.fetch = function (boundingBox, zoom, projectId, isPublishable) {
-      console.log("project collection fetch()");
       var id = projectId;
       if (typeof id === 'undefined' && typeof projectInfo !== 'undefined')
         id = projectInfo.id;
@@ -222,7 +221,7 @@
             publishableProject = response.publishable;
             me.setProjectErrors(response.projectErrors);
             me.setFormedParts(response.formedInfo);
-            eventbus.trigger('projectLink:revertedChanges');
+            eventbus.trigger('projectLink:revertedChanges', response);
           } else {
             if (response.status === INTERNAL_SERVER_ERROR_500 || response.status === BAD_REQUEST_400) {
               eventbus.trigger('roadAddress:projectLinksUpdateFailed', response.status);

--- a/viite-UI/src/model/ProjectCollection.js
+++ b/viite-UI/src/model/ProjectCollection.js
@@ -280,9 +280,6 @@
           } else {
             backend.updateProjectLinks(dataJson, function (successObject) {
               if (successObject.success) {
-                console.log("success object");
-                console.log(successObject);
-                // jos projektissa ei ole käsittelemättömiä linkkejä (succesObject.projectErrors._.errorCode != 8) voidaan enabloida "Laske projekti" painike
                 publishableProject = successObject.publishable;
                 me.setProjectErrors(successObject.projectErrors);
                 me.setFormedParts(successObject.formedInfo);

--- a/viite-UI/src/model/ProjectCollection.js
+++ b/viite-UI/src/model/ProjectCollection.js
@@ -73,6 +73,7 @@
     };
 
     this.fetch = function (boundingBox, zoom, projectId, isPublishable) {
+      console.log("project collection fetch()");
       var id = projectId;
       if (typeof id === 'undefined' && typeof projectInfo !== 'undefined')
         id = projectInfo.id;
@@ -280,6 +281,9 @@
           } else {
             backend.updateProjectLinks(dataJson, function (successObject) {
               if (successObject.success) {
+                console.log("success object");
+                console.log(successObject);
+                // jos projektissa ei ole käsittelemättömiä linkkejä (succesObject.projectErrors._.errorCode != 8) voidaan enabloida "Laske projekti" painike
                 publishableProject = successObject.publishable;
                 me.setProjectErrors(successObject.projectErrors);
                 me.setFormedParts(successObject.formedInfo);

--- a/viite-UI/src/utils/backend-utils.js
+++ b/viite-UI/src/utils/backend-utils.js
@@ -316,11 +316,9 @@
       $.getJSON('api/viite/project/getchangetable/' + id, callback);
     }, 500);
 
-
-    this.recalculateProject = function (id, callback) {
+    this.recalculateAndValidateProject = function (id, callback) {
       $.getJSON('api/viite/project/recalculateProject/' + id, callback);
     };
-
 
     this.getUserRoles = function () {
       $.get('api/viite/user', function (response) {

--- a/viite-UI/src/utils/backend-utils.js
+++ b/viite-UI/src/utils/backend-utils.js
@@ -317,6 +317,11 @@
     }, 500);
 
 
+    this.recalculateProject = function (id, callback) {
+      $.getJSON('api/viite/project/recalculateProject/' + id, callback);
+    };
+
+
     this.getUserRoles = function () {
       $.get('api/viite/user', function (response) {
         eventbus.trigger('userData:fetched', response);

--- a/viite-UI/src/view/FormCommon.js
+++ b/viite-UI/src/view/FormCommon.js
@@ -27,25 +27,25 @@
     };
 
     const projectButtons = function () {
-      return '<button class="recalculate btn btn-block btn-recalculate">Laske projekti</button>' +
+      return '<button class="recalculate btn btn-block btn-recalculate">Päivitä etäisyyslukemat</button>' +
         '<button class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
         '<button id ="send-button" class="send btn btn-block btn-send">Lähetä muutosilmoitus Tierekisteriin</button>';
     };
 
     const projectButtonsRecalculateAndChanges = function () {
-      return  '<button class="recalculate btn btn-block btn-recalculate">Laske projekti</button>' +
+      return  '<button class="recalculate btn btn-block btn-recalculate">Päivitä etäisyyslukemat</button>' +
           '<button class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
           '<button disabled id ="send-button" class="send btn btn-block btn-send">Lähetä muutosilmoitus Tierekisteriin</button>';
     };
 
     const projectButtonsRecalculate = function () {
-      return  '<button class="recalculate btn btn-block btn-recalculate">Laske projekti</button>' +
+      return  '<button class="recalculate btn btn-block btn-recalculate">Päivitä etäisyyslukemat</button>' +
           '<button disabled class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
           '<button disabled id ="send-button" class="send btn btn-block btn-send">Lähetä muutosilmoitus Tierekisteriin</button>';
     };
 
     const projectButtonsDisabled = function () {
-      return  '<button disabled class="recalculate btn btn-block btn-recalculate">Laske projekti</button>' +
+      return  '<button disabled class="recalculate btn btn-block btn-recalculate">Päivitä etäisyyslukemat</button>' +
           '<button disabled class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
           '<button disabled id ="send-button" class="send btn btn-block btn-send">Lähetä muutosilmoitus Tierekisteriin</button>';
     };
@@ -282,7 +282,7 @@
 
     const sendRoadAddressChangeButton = function (localPrefix) {
       return '<div class="' + localPrefix + 'form form-controls">' +
-          '<button class="recalculate btn btn-block btn-recalculate">Laske projekti</button>' +
+          '<button class="recalculate btn btn-block btn-recalculate">Päivitä etäisyyslukemat</button>' +
           '<button class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
           '<button id ="send-button" class="send btn btn-block btn-send">Lähetä muutosilmoitus Tierekisteriin</button></div>';
     };

--- a/viite-UI/src/view/FormCommon.js
+++ b/viite-UI/src/view/FormCommon.js
@@ -31,6 +31,17 @@
         '<button disabled id ="send-button" class="send btn btn-block btn-send">Lähetä muutosilmoitus Tierekisteriin</button>';
     };
 
+    const projectButtons2 = function () {
+      return  '<button id = "recalculate-button" class="recalculate btn btn-block btn-recalculate">Laske Projekti (2)</button>' +
+          '<button class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
+          '<button disabled id ="send-button" class="send btn btn-block btn-send">Lähetä muutosilmoitus Tierekisteriin</button>';
+    };
+
+    const projectButtons3 = function () {
+      return  '<button class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
+              '<button disabled id ="send-button" class="send btn btn-block btn-send">Lähetä muutosilmoitus Tierekisteriin</button>';
+    };
+
     const newRoadAddressInfo = function (project, selected, links, road) {
       const roadNumber = road.roadNumber;
       const part = road.roadPartNumber;
@@ -256,15 +267,16 @@
     const setInformationContent = function () {
       $('#information-content').html('' +
         '<div class="form form-horizontal">' +
-        '<p>Validointi ok. Voit tehdä tieosoitteenmuutosilmoituksen<br>' +
+        '<p class = "validation-text">Validointi ok. Voit tehdä tieosoitteenmuutosilmoituksen<br>' +
         'tai jatkaa muokkauksia.</p>' +
         '</div>');
     };
 
     const sendRoadAddressChangeButton = function (localPrefix) {
       return '<div class="' + localPrefix + 'form form-controls">' +
-        '<button class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
-        '<button id ="send-button" class="send btn btn-block btn-send">Lähetä muutosilmoitus Tierekisteriin</button></div>';
+          '<button id = "recalculate-button" class="recalculate btn btn-block btn-recalculate">Laske projekti (3)</button>' +
+          '<button class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
+          '<button id ="send-button" class="send btn btn-block btn-send">Lähetä muutosilmoitus Tierekisteriin</button></div>';
     };
 
     const distanceValue = function () {
@@ -358,6 +370,8 @@
       titleWithEditingTool: titleWithEditingTool,
       captionTitle: captionTitle,
       projectButtons: projectButtons,
+      projectButtons2: projectButtons2,
+      projectButtons3: projectButtons2,
       staticField: staticField,
       getProjectErrors: getProjectErrors
     };

--- a/viite-UI/src/view/FormCommon.js
+++ b/viite-UI/src/view/FormCommon.js
@@ -28,11 +28,11 @@
 
     const projectButtons = function () {
       return '<button class="recalculate btn btn-block btn-recalculate">Laske projekti</button>' +
-      '<button class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
+        '<button class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
         '<button id ="send-button" class="send btn btn-block btn-send">Lähetä muutosilmoitus Tierekisteriin</button>';
     };
 
-    const projectButtonsSend = function () {
+    const projectButtonsRecalculateAndChanges = function () {
       return  '<button class="recalculate btn btn-block btn-recalculate">Laske projekti</button>' +
           '<button class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
           '<button disabled id ="send-button" class="send btn btn-block btn-send">Lähetä muutosilmoitus Tierekisteriin</button>';
@@ -45,11 +45,10 @@
     };
 
     const projectButtonsDisabled = function () {
-      return  '<button disabled id = "recalculate-button" class="recalculate btn btn-block btn-recalculate">Laske projekti</button>' +
+      return  '<button disabled class="recalculate btn btn-block btn-recalculate">Laske projekti</button>' +
           '<button disabled class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
           '<button disabled id ="send-button" class="send btn btn-block btn-send">Lähetä muutosilmoitus Tierekisteriin</button>';
     };
-
 
     const newRoadAddressInfo = function (project, selected, links, road) {
       const roadNumber = road.roadNumber;
@@ -276,15 +275,15 @@
     const setInformationContent = function () {
       $('#information-content').html('' +
         '<div class="form form-horizontal">' +
-        '<p class = "validation-text">Validointi ok. Voit tehdä tieosoitteenmuutosilmoituksen<br>' +
+        '<p class="validation-text">Validointi ok. Voit tehdä tieosoitteenmuutosilmoituksen<br>' +
         'tai jatkaa muokkauksia.</p>' +
         '</div>');
     };
 
     const sendRoadAddressChangeButton = function (localPrefix) {
       return '<div class="' + localPrefix + 'form form-controls">' +
-          '<button id = "recalculate-button" class="recalculate btn btn-block btn-recalculate">Laske projekti</button>' +
-          '<button id = "show-changes-button" class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
+          '<button class="recalculate btn btn-block btn-recalculate">Laske projekti</button>' +
+          '<button class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
           '<button id ="send-button" class="send btn btn-block btn-send">Lähetä muutosilmoitus Tierekisteriin</button></div>';
     };
 
@@ -381,7 +380,7 @@
       projectButtons: projectButtons,
       projectButtonsDisabled: projectButtonsDisabled,
       projectButtonsRecalculate: projectButtonsRecalculate,
-      projectButtonsSend: projectButtonsSend,
+      projectButtonsRecalculateAndChanges: projectButtonsRecalculateAndChanges,
       staticField: staticField,
       getProjectErrors: getProjectErrors
     };

--- a/viite-UI/src/view/FormCommon.js
+++ b/viite-UI/src/view/FormCommon.js
@@ -27,20 +27,29 @@
     };
 
     const projectButtons = function () {
-      return '<button class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
-        '<button disabled id ="send-button" class="send btn btn-block btn-send">Lähetä muutosilmoitus Tierekisteriin</button>';
+      return '<button class="recalculate btn btn-block btn-recalculate">Laske projekti</button>' +
+      '<button class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
+        '<button id ="send-button" class="send btn btn-block btn-send">Lähetä muutosilmoitus Tierekisteriin</button>';
     };
 
-    const projectButtons2 = function () {
-      return  '<button id = "recalculate-button" class="recalculate btn btn-block btn-recalculate">Laske Projekti (2)</button>' +
+    const projectButtonsSend = function () {
+      return  '<button class="recalculate btn btn-block btn-recalculate">Laske projekti</button>' +
           '<button class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
           '<button disabled id ="send-button" class="send btn btn-block btn-send">Lähetä muutosilmoitus Tierekisteriin</button>';
     };
 
-    const projectButtons3 = function () {
-      return  '<button class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
-              '<button disabled id ="send-button" class="send btn btn-block btn-send">Lähetä muutosilmoitus Tierekisteriin</button>';
+    const projectButtonsRecalculate = function () {
+      return  '<button class="recalculate btn btn-block btn-recalculate">Laske projekti</button>' +
+          '<button disabled class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
+          '<button disabled id ="send-button" class="send btn btn-block btn-send">Lähetä muutosilmoitus Tierekisteriin</button>';
     };
+
+    const projectButtonsDisabled = function () {
+      return  '<button disabled id = "recalculate-button" class="recalculate btn btn-block btn-recalculate">Laske projekti</button>' +
+          '<button disabled class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
+          '<button disabled id ="send-button" class="send btn btn-block btn-send">Lähetä muutosilmoitus Tierekisteriin</button>';
+    };
+
 
     const newRoadAddressInfo = function (project, selected, links, road) {
       const roadNumber = road.roadNumber;
@@ -274,8 +283,8 @@
 
     const sendRoadAddressChangeButton = function (localPrefix) {
       return '<div class="' + localPrefix + 'form form-controls">' +
-          '<button id = "recalculate-button" class="recalculate btn btn-block btn-recalculate">Laske projekti (3)</button>' +
-          '<button class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
+          '<button id = "recalculate-button" class="recalculate btn btn-block btn-recalculate">Laske projekti</button>' +
+          '<button id = "show-changes-button" class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
           '<button id ="send-button" class="send btn btn-block btn-send">Lähetä muutosilmoitus Tierekisteriin</button></div>';
     };
 
@@ -370,8 +379,9 @@
       titleWithEditingTool: titleWithEditingTool,
       captionTitle: captionTitle,
       projectButtons: projectButtons,
-      projectButtons2: projectButtons2,
-      projectButtons3: projectButtons2,
+      projectButtonsDisabled: projectButtonsDisabled,
+      projectButtonsRecalculate: projectButtonsRecalculate,
+      projectButtonsSend: projectButtonsSend,
       staticField: staticField,
       getProjectErrors: getProjectErrors
     };

--- a/viite-UI/src/view/ProjectEditForm.js
+++ b/viite-UI/src/view/ProjectEditForm.js
@@ -345,7 +345,7 @@
         }
       });
 
-      eventbus.on('roadAddress:projectLinksUpdated', function (data) {
+      eventbus.on('roadAddress:projectLinksUpdated', function (response) {
         //eventbus.trigger('projectChangeTable:refresh');
         projectCollection.setTmpDirty([]);
         projectCollection.setDirty([]);
@@ -353,7 +353,7 @@
         selectedProjectLinkProperty.setDirty(false);
         selectedProjectLink = false;
         selectedProjectLinkProperty.cleanIds();
-        var projectErrors = data.projectErrors;
+        var projectErrors = response.projectErrors;
         if (Object.keys(projectErrors).length > 0) {
           // if there is validation errors (only high priority errors are returned when updating project links) after updating project links then show disabled buttons
           rootElement.html(emptyTemplateDisabledButtons(projectCollection.getCurrentProject().project));
@@ -363,8 +363,8 @@
         }
         formCommon.toggleAdditionalControls();
         applicationModel.removeSpinner();
-        if (typeof data !== 'undefined' && typeof data.publishable !== 'undefined' && data.publishable) {
-          eventbus.trigger('roadAddressProject:projectLinkSaved', data.id, data.publishable);
+        if (typeof response !== 'undefined' && typeof response.publishable !== 'undefined' && response.publishable) {
+          eventbus.trigger('roadAddressProject:projectLinkSaved', response.id, response.publishable);
         } else {
           eventbus.trigger('roadAddressProject:projectLinkSaved');
         }

--- a/viite-UI/src/view/ProjectEditForm.js
+++ b/viite-UI/src/view/ProjectEditForm.js
@@ -646,14 +646,14 @@
         // add spinner
         applicationModel.addSpinner();
         // fire backend call to recalculate and validate the current project with the project id
-        backend.recalculateAndValidateProject(currentProject.project.id, function (successObject) {
+        backend.recalculateAndValidateProject(currentProject.project.id, function (response) {
           // if recalculation and validation did not throw exceptions in the backend
-          if (successObject.success) {
+          if (response.success) {
             // set project errors that were returned by the backend validations
-            projectCollection.setProjectErrors(successObject.validationErrors);
+            projectCollection.setProjectErrors(response.validationErrors);
             // display the validation errors
             eventbus.trigger('roadAddressProject:writeProjectErrors');
-            if (Object.keys(successObject.validationErrors).length === 0) {
+            if (Object.keys(response.validationErrors).length === 0) {
               // if no validation errors are present, show recalculate button and changes button
               $('footer').html(projectButtonsRecalculateAndChanges);
             }
@@ -661,7 +661,7 @@
           }
           // if something went wrong during recalculation or validation, show error to user
           else {
-            new ModalConfirm(successObject.errorMessage);
+            new ModalConfirm(response.errorMessage);
             applicationModel.removeSpinner();
           }
         });

--- a/viite-UI/src/view/ProjectEditForm.js
+++ b/viite-UI/src/view/ProjectEditForm.js
@@ -14,15 +14,27 @@
 
     var endDistanceOriginalValue = '--';
 
-    var showProjectChangeButton = function () {
+    var showProjectButtons = function () {
       return '<div class="project-form form-controls">' +
         formCommon.projectButtons() + '</div>';
     };
 
     var showProjectRecalculateButton = function () {
       return '<div class="project-form form-controls">' +
-          formCommon.projectButtons2() + '</div>';
+          formCommon.projectButtonsRecalculate() + '</div>';
     };
+
+    var showProjectDisabledButtons = function () {
+      return '<div class="project-form form-controls">' +
+          formCommon.projectButtonsDisabled() + '</div>';
+    };
+
+    var showProjectSendButtons = function () {
+      return '<div class="project-form form-controls">' +
+          formCommon.projectButtonsSend() + '</div>';
+    };
+
+
 
     var transitionModifiers = function (targetStatus, currentStatus) {
       var mod;
@@ -150,8 +162,49 @@
         '<label class="highlighted">JATKA VALITSEMALLA KOHDE KARTALTA.</label>' +
         '<div class="form-group" id="project-errors"></div>' +
         '</div></div></br></br>' +
-        //'<footer>' + showProjectChangeButton() + '</footer>');
+          '<footer>' + showProjectButtons() + '</footer>');
+    };
+
+    var emptyTemplateDisabledButtons = function (project) {
+      console.log("aseta napit");
+      return _.template('' +
+          '<header>' +
+          formCommon.titleWithEditingTool(project) +
+          '</header>' +
+          '<div class="wrapper read-only">' +
+          '<div class="form form-horizontal form-dark">' +
+          '<label class="highlighted">JATKA VALITSEMALLA KOHDE KARTALTA.</label>' +
+          '<div class="form-group" id="project-errors"></div>' +
+          '</div></div></br></br>' +
+          '<footer>' + showProjectDisabledButtons() + '</footer>');
+    };
+
+    var emptyTemplateRecalculateButtons = function (project) {
+      console.log("aseta napit");
+      return _.template('' +
+          '<header>' +
+          formCommon.titleWithEditingTool(project) +
+          '</header>' +
+          '<div class="wrapper read-only">' +
+          '<div class="form form-horizontal form-dark">' +
+          '<label class="highlighted">JATKA VALITSEMALLA KOHDE KARTALTA.</label>' +
+          '<div class="form-group" id="project-errors"></div>' +
+          '</div></div></br></br>' +
           '<footer>' + showProjectRecalculateButton() + '</footer>');
+    };
+
+    var emptyTemplateSendButtons = function (project) {
+      console.log("aseta napit");
+      return _.template('' +
+          '<header>' +
+          formCommon.titleWithEditingTool(project) +
+          '</header>' +
+          '<div class="wrapper read-only">' +
+          '<div class="form form-horizontal form-dark">' +
+          '<label class="highlighted">JATKA VALITSEMALLA KOHDE KARTALTA.</label>' +
+          '<div class="form-group" id="project-errors"></div>' +
+          '</div></div></br></br>' +
+          '<footer>' + showProjectSendButtons() + '</footer>');
     };
 
     var isProjectPublishable = function () {
@@ -330,6 +383,8 @@
       });
 
       eventbus.on('roadAddress:projectLinksUpdated', function (data) {
+        console.log("roadAddress:projectLinksUpdated");
+        console.log("TALLENNA NAPPI");
         //eventbus.trigger('projectChangeTable:refresh');
         projectCollection.setTmpDirty([]);
         projectCollection.setDirty([]);
@@ -337,7 +392,30 @@
         selectedProjectLinkProperty.setDirty(false);
         selectedProjectLink = false;
         selectedProjectLinkProperty.cleanIds();
-        rootElement.html(emptyTemplate(projectCollection.getCurrentProject().project));
+        console.log("data");
+        console.log(data);
+        var projectErrors = data.projectErrors;
+
+        if (Object.keys(projectErrors).length > 0) {
+          projectErrors.forEach((error) => {
+            if (error.errorCode === 8 ) {
+              console.log(" löytyi koodi 8");
+              rootElement.html(emptyTemplateDisabledButtons(projectCollection.getCurrentProject().project));
+            } else {
+              console.log("ei löytynyt koodia 8");
+              console.log("enable recalculate button");
+              rootElement.html(emptyTemplateRecalculateButtons(projectCollection.getCurrentProject().project));
+
+            }
+          });
+        } else {
+          console.log("ei erroreita length 0");
+          console.log("enable reacalculate button");
+          rootElement.html(emptyTemplateRecalculateButtons(projectCollection.getCurrentProject().project));
+        }
+
+
+
         formCommon.toggleAdditionalControls();
         applicationModel.removeSpinner();
         if (typeof data !== 'undefined' && typeof data.publishable !== 'undefined' && data.publishable) {
@@ -606,7 +684,7 @@
       rootElement.on('click', '.project-form button.show-changes', function () {
         $(this).empty();
         projectChangeTable.show();
-        var projectChangesButton = showProjectChangeButton();
+        var projectChangesButton = showProjectSendButtons();
         if (isProjectPublishable() && isProjectEditable()) {
           formCommon.setInformationContent();
           $('footer').html(formCommon.sendRoadAddressChangeButton('project-', projectCollection.getCurrentProject()));
@@ -620,10 +698,9 @@
         // remove the button after click
         //$(this).empty();
         //projectChangeTable.show();
-        var projectChangesButton = showProjectRecalculateButton();
+        var projectChangesButton = showProjectSendButtons();
         // get current project
         var currentProject = projectCollection.getCurrentProject();
-        console.log(currentProject);
         // add spinner
         applicationModel.addSpinner();
         // fire backend call to recalculate the current project with the project id

--- a/viite-UI/src/view/ProjectEditForm.js
+++ b/viite-UI/src/view/ProjectEditForm.js
@@ -14,11 +14,6 @@
 
     var endDistanceOriginalValue = '--';
 
-    var showProjectButtons = function () {
-      return '<div class="project-form form-controls">' +
-        formCommon.projectButtons() + '</div>';
-    };
-
     var showProjectButtonRecalculate = function () {
       return '<div class="project-form form-controls">' +
           formCommon.projectButtonsRecalculate() + '</div>';

--- a/viite-UI/src/view/ProjectEditForm.js
+++ b/viite-UI/src/view/ProjectEditForm.js
@@ -1,5 +1,5 @@
 (function (root) {
-  root.ProjectEditForm = function (map, projectCollection, selectedProjectLinkProperty, projectLinkLayer, projectChangeTable, backend) {
+  root.ProjectEditForm = function (map, projectCollection, selectedProjectLinkProperty, projectLinkLayer, projectChangeTable, backend, projectForm) {
     var LinkStatus = LinkValues.LinkStatus;
     var CalibrationCode = LinkValues.CalibrationCode;
     var editableStatus = [LinkValues.ProjectStatus.Incomplete.value, LinkValues.ProjectStatus.ErrorInTR.value, LinkValues.ProjectStatus.Unknown.value];
@@ -17,6 +17,11 @@
     var showProjectChangeButton = function () {
       return '<div class="project-form form-controls">' +
         formCommon.projectButtons() + '</div>';
+    };
+
+    var showProjectRecalculateButton = function () {
+      return '<div class="project-form form-controls">' +
+          formCommon.projectButtons2() + '</div>';
     };
 
     var transitionModifiers = function (targetStatus, currentStatus) {
@@ -135,6 +140,7 @@
     };
 
     var emptyTemplate = function (project) {
+      console.log("aseta napit");
       return _.template('' +
         '<header>' +
         formCommon.titleWithEditingTool(project) +
@@ -144,7 +150,8 @@
         '<label class="highlighted">JATKA VALITSEMALLA KOHDE KARTALTA.</label>' +
         '<div class="form-group" id="project-errors"></div>' +
         '</div></div></br></br>' +
-        '<footer>' + showProjectChangeButton() + '</footer>');
+        //'<footer>' + showProjectChangeButton() + '</footer>');
+          '<footer>' + showProjectRecalculateButton() + '</footer>');
     };
 
     var isProjectPublishable = function () {
@@ -606,6 +613,37 @@
         } else {
           $('footer').html(projectChangesButton);
         }
+      });
+
+      // when recalculate button is clicked
+      rootElement.on('click', '.project-form button.recalculate', function () {
+        // remove the button after click
+        //$(this).empty();
+        //projectChangeTable.show();
+        var projectChangesButton = showProjectRecalculateButton();
+        // get current project
+        var currentProject = projectCollection.getCurrentProject();
+        console.log(currentProject);
+        // add spinner
+        applicationModel.addSpinner();
+        // fire backend call to recalculate the current project with the project id
+        backend.recalculateProject(currentProject.project.id, function (errors) {
+          if (Object.keys(errors.validationErrors).length === 0) {
+            $('footer').html(projectChangesButton);
+          }
+
+          // remove spinner after calculations are done and we are in a callback function
+          applicationModel.removeSpinner();
+        });
+
+
+        //var projectChangesButton = showProjectChangeButton();
+        //if (isProjectPublishable() && isProjectEditable()) {
+        //formCommon.setInformationContent();
+        //$('footer').html(formCommon.sendRoadAddressChangeButton('project-', projectCollection.getCurrentProject()));
+        //} else {
+        //$('footer').html(projectChangesButton);
+        //}
       });
 
       rootElement.on('change input', '.form-control.small-input', function (event) {

--- a/viite-UI/src/view/ProjectEditForm.js
+++ b/viite-UI/src/view/ProjectEditForm.js
@@ -695,9 +695,6 @@
 
       // when recalculate button is clicked
       rootElement.on('click', '.project-form button.recalculate', function () {
-        // remove the button after click
-        //$(this).empty();
-        //projectChangeTable.show();
         var projectChangesButton = showProjectSendButtons();
         // get current project
         var currentProject = projectCollection.getCurrentProject();
@@ -705,22 +702,13 @@
         applicationModel.addSpinner();
         // fire backend call to recalculate the current project with the project id
         backend.recalculateProject(currentProject.project.id, function (errors) {
+          projectCollection.setProjectErrors(errors.validationErrors);
+          eventbus.trigger('roadAddressProject:writeProjectErrors');
           if (Object.keys(errors.validationErrors).length === 0) {
             $('footer').html(projectChangesButton);
           }
-
-          // remove spinner after calculations are done and we are in a callback function
           applicationModel.removeSpinner();
         });
-
-
-        //var projectChangesButton = showProjectChangeButton();
-        //if (isProjectPublishable() && isProjectEditable()) {
-        //formCommon.setInformationContent();
-        //$('footer').html(formCommon.sendRoadAddressChangeButton('project-', projectCollection.getCurrentProject()));
-        //} else {
-        //$('footer').html(projectChangesButton);
-        //}
       });
 
       rootElement.on('change input', '.form-control.small-input', function (event) {

--- a/viite-UI/src/view/ProjectEditForm.js
+++ b/viite-UI/src/view/ProjectEditForm.js
@@ -646,16 +646,24 @@
         // add spinner
         applicationModel.addSpinner();
         // fire backend call to recalculate and validate the current project with the project id
-        backend.recalculateAndValidateProject(currentProject.project.id, function (errors) {
-          // set project errors that were returned by the backend validations
-          projectCollection.setProjectErrors(errors.validationErrors);
-          // display the validation errors
-          eventbus.trigger('roadAddressProject:writeProjectErrors');
-          if (Object.keys(errors.validationErrors).length === 0) {
-            // if no validation errors are present, show recalculate button and changes button
-            $('footer').html(projectButtonsRecalculateAndChanges);
+        backend.recalculateAndValidateProject(currentProject.project.id, function (successObject) {
+          // if recalculation and validation did not throw exceptions in the backend
+          if (successObject.success) {
+            // set project errors that were returned by the backend validations
+            projectCollection.setProjectErrors(successObject.validationErrors);
+            // display the validation errors
+            eventbus.trigger('roadAddressProject:writeProjectErrors');
+            if (Object.keys(successObject.validationErrors).length === 0) {
+              // if no validation errors are present, show recalculate button and changes button
+              $('footer').html(projectButtonsRecalculateAndChanges);
+            }
+            applicationModel.removeSpinner();
           }
-          applicationModel.removeSpinner();
+          // if something went wrong during recalculation or validation, show error to user
+          else {
+            new ModalConfirm(successObject.errorMessage);
+            applicationModel.removeSpinner();
+          }
         });
       });
 

--- a/viite-UI/src/view/ProjectEditForm.js
+++ b/viite-UI/src/view/ProjectEditForm.js
@@ -360,17 +360,10 @@
         selectedProjectLinkProperty.cleanIds();
         var projectErrors = data.projectErrors;
         if (Object.keys(projectErrors).length > 0) {
-          projectErrors.forEach((error) => {
-            if (error.errorCode === 8 ) {
-              // if notHandled project links error then disable all three buttons (recalculate, changes and send)
-              rootElement.html(emptyTemplateDisabledButtons(projectCollection.getCurrentProject().project));
-            } else {
-              // if there are errors but not error code 8, then show recalculate button
-              rootElement.html(emptyTemplateRecalculateButtons(projectCollection.getCurrentProject().project));
-            }
-          });
+          // if there is validation errors (only high priority errors are returned when updating project links) after updating project links then show disabled buttons
+          rootElement.html(emptyTemplateDisabledButtons(projectCollection.getCurrentProject().project));
         } else {
-          // if no validation errors are present, then show recalculate button
+          // if no (high priority) validation errors are present, then show recalculate button
           rootElement.html(emptyTemplateRecalculateButtons(projectCollection.getCurrentProject().project));
         }
         formCommon.toggleAdditionalControls();

--- a/viite-UI/src/view/ProjectForm.js
+++ b/viite-UI/src/view/ProjectForm.js
@@ -130,6 +130,8 @@
     };
 
     var selectedProjectLinkTemplate = function (project) {
+      console.log("projectErrors");
+      console.log(projectCollection.projectErrors);
       return _.template('' +
         '<header>' +
         title(project.name) +
@@ -156,9 +158,20 @@
 
     var showProjectChangeButton = function () {
       return '<div class="project-form form-controls">' +
-        '<button class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
+          '<button disabled id = "recalculate-button" class="recalculate btn btn-block btn-recalculate">Laske projekti (1)</button>' +
+          '<button disabled id = "show-changes-button" class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
         '<button disabled id ="send-button" class="send btn btn-block btn-send">Lähetä muutosilmoitus Tierekisteriin</button></div>';
     };
+
+    var enableRecalculateButton = function () {
+      document.getElementById('recalculate-button').disabled = false;
+    };
+
+    var enableChangesButton = function () {
+      document.getElementById('show-changes-button').disabled = false;
+    };
+
+
 
     var addSmallLabel = function (label) {
       return '<label class="control-label-small">' + label + '</label>';
@@ -452,6 +465,28 @@
 
       eventbus.on('roadAddressProject:writeProjectErrors', function () {
         $('#project-errors').html(errorsList());
+        console.log("write errors");
+
+        //var errors = formCommon.getProjectErrors();
+        var errors = projectCollection.getProjectErrors();
+        console.log("testi errors");
+        //console.log(errors);
+        console.log(errors);
+        if (Object.keys(errors).length > 0) {
+          errors.forEach((error) => {
+            if (error.errorCode === 8 ) {
+              console.log(" löytyi koodi 8");
+            } else {
+              console.log("ei löytynyt koodia 8");
+              console.log("enable recalc button");
+              enableRecalculateButton();
+            }
+          });
+        } else {
+          console.log("ei löytynyt koodia 8 length 0");
+          console.log("enable recalc button");
+          enableRecalculateButton();
+        }
         applicationModel.removeSpinner();
       });
 
@@ -737,5 +772,8 @@
       });
     };
     bindEvents();
+    return {
+      enableChangesButton: enableChangesButton
+    };
   };
 }(this));

--- a/viite-UI/src/view/ProjectForm.js
+++ b/viite-UI/src/view/ProjectForm.js
@@ -380,12 +380,16 @@
       };
 
       var nextStage = function () {
-        console.log("next stage");
         applicationModel.addSpinner();
         currentProject.isDirty = false;
         jQuery('.modal-overlay').remove();
         eventbus.trigger('roadAddressProject:openProject', currentProject);
-        rootElement.html(selectedProjectLinkTemplateDisabledButtons(currentProject));
+        var projectErrors = projectCollection.getProjectErrors();
+        if (Object.keys(projectErrors).length === 0) {
+          rootElement.html(selectedProjectLinkTemplateRecalculateButton(currentProject));
+        } else {
+          rootElement.html(selectedProjectLinkTemplateDisabledButtons(currentProject));
+        }
         _.defer(function () {
           applicationModel.selectLayer('roadAddressProject');
           toggleAdditionalControls();
@@ -499,27 +503,6 @@
       });
 
       eventbus.on('roadAddressProject:writeProjectErrors', function () {
-        console.log("roadAddressProject:writeProjectErrors");
-        var errors = projectCollection.getProjectErrors();
-        console.log("WRITE ERRORS");
-        console.log(errors);
-        if (Object.keys(errors).length > 0) {
-          errors.forEach((error) => {
-            if (error.errorCode === 8 ) {
-              console.log(" löytyi koodi 8");
-              rootElement.html(selectedProjectLinkTemplateDisabledButtons(currentProject));
-            } else {
-              console.log("ei löytynyt koodia 8");
-              console.log("enable recalc button");
-              //rootElement.html(selectedProjectLinkTemplateRecalculateButton(currentProject));
-              rootElement.html(selectedProjectLinkTemplateSendButton(currentProject));
-            }
-          });
-        } else {
-          console.log("ei erroreita length 0");
-          console.log("enable recalc button");
-          rootElement.html(selectedProjectLinkTemplateRecalculateButton(currentProject));
-        }
         $('#project-errors').html(errorsList());
         applicationModel.removeSpinner();
       });

--- a/viite-UI/src/view/ProjectForm.js
+++ b/viite-UI/src/view/ProjectForm.js
@@ -169,14 +169,14 @@
 
     var showProjectDisabledButtons = function () {
       return '<div class="project-form form-controls">' +
-          '<button disabled class="recalculate btn btn-block btn-recalculate">Laske projekti</button>' +
+          '<button disabled class="recalculate btn btn-block btn-recalculate">Päivitä etäisyyslukemat</button>' +
           '<button disabled id = "show-changes-button" class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
         '<button disabled id ="send-button" class="send btn btn-block btn-send">Lähetä muutosilmoitus Tierekisteriin</button></div>';
     };
 
     var showProjectRecalculateButton = function () {
       return '<div class="project-form form-controls">' +
-          '<button class="recalculate btn btn-block btn-recalculate">Laske projekti</button>' +
+          '<button class="recalculate btn btn-block btn-recalculate">Päivitä etäisyyslukemat</button>' +
           '<button disabled id = "show-changes-button" class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
           '<button disabled id ="send-button" class="send btn btn-block btn-send">Lähetä muutosilmoitus Tierekisteriin</button></div>';
     };

--- a/viite-UI/src/view/ProjectForm.js
+++ b/viite-UI/src/view/ProjectForm.js
@@ -129,19 +129,46 @@
         '<footer>' + actionButtons() + '</footer>');
     };
 
-    var selectedProjectLinkTemplate = function (project) {
-      console.log("projectErrors");
-      console.log(projectCollection.projectErrors);
+    var selectedProjectLinkTemplateDisabledButtons = function (project) {
+      console.log("PROEJKTIN AVAUS disabled");
       return _.template('' +
         '<header>' +
-        title(project.name) +
+          formCommon.titleWithEditingTool(project) +
         '</header>' +
         '<div class="wrapper read-only">' +
         '<div class="form form-horizontal form-dark">' +
         '<label class="highlighted">ALOITA VALITSEMALLA KOHDE KARTALTA.</label>' +
         '<div class="form-group" id="project-errors"></div>' +
         '</div></div></br></br>' +
-        '<footer>' + showProjectChangeButton() + '</footer>');
+        '<footer>' + showProjectDisabledButtons() + '</footer>');
+    };
+
+    var selectedProjectLinkTemplateRecalculateButton = function (project) {
+      console.log("PROEJKTIN AVAUS recalculate");
+      return _.template('' +
+          '<header>' +
+          formCommon.titleWithEditingTool(project) +
+          '</header>' +
+          '<div class="wrapper read-only">' +
+          '<div class="form form-horizontal form-dark">' +
+          '<label class="highlighted">ALOITA VALITSEMALLA KOHDE KARTALTA.</label>' +
+          '<div class="form-group" id="project-errors"></div>' +
+          '</div></div></br></br>' +
+          '<footer>' + showProjectRecalculateButton() + '</footer>');
+    };
+
+    var selectedProjectLinkTemplateSendButton = function (project) {
+      console.log("PROEJKTIN AVAUS send");
+      return _.template('' +
+          '<header>' +
+          formCommon.titleWithEditingTool(project) +
+          '</header>' +
+          '<div class="wrapper read-only">' +
+          '<div class="form form-horizontal form-dark">' +
+          '<label class="highlighted">ALOITA VALITSEMALLA KOHDE KARTALTA.</label>' +
+          '<div class="form-group" id="project-errors"></div>' +
+          '</div></div></br></br>' +
+          '<footer>' + showProjectSendButton() + '</footer>');
     };
 
     var errorsList = function () {
@@ -156,19 +183,25 @@
 
     };
 
-    var showProjectChangeButton = function () {
+    var showProjectDisabledButtons = function () {
       return '<div class="project-form form-controls">' +
-          '<button disabled id = "recalculate-button" class="recalculate btn btn-block btn-recalculate">Laske projekti (1)</button>' +
+          '<button disabled class="recalculate btn btn-block btn-recalculate">Laske projekti</button>' +
           '<button disabled id = "show-changes-button" class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
         '<button disabled id ="send-button" class="send btn btn-block btn-send">Lähetä muutosilmoitus Tierekisteriin</button></div>';
     };
 
-    var enableRecalculateButton = function () {
-      document.getElementById('recalculate-button').disabled = false;
+    var showProjectRecalculateButton = function () {
+      return '<div class="project-form form-controls">' +
+          '<button class="recalculate btn btn-block btn-recalculate">Laske projekti</button>' +
+          '<button disabled id = "show-changes-button" class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
+          '<button disabled id ="send-button" class="send btn btn-block btn-send">Lähetä muutosilmoitus Tierekisteriin</button></div>';
     };
 
-    var enableChangesButton = function () {
-      document.getElementById('show-changes-button').disabled = false;
+    var showProjectSendButton = function () {
+      return '<div class="project-form form-controls">' +
+          '<button class="recalculate btn btn-block btn-recalculate">Laske projekti</button>' +
+          '<button id = "show-changes-button" class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
+          '<button disabled id ="send-button" class="send btn btn-block btn-send">Lähetä muutosilmoitus Tierekisteriin</button></div>';
     };
 
 
@@ -347,11 +380,12 @@
       };
 
       var nextStage = function () {
+        console.log("next stage");
         applicationModel.addSpinner();
         currentProject.isDirty = false;
         jQuery('.modal-overlay').remove();
         eventbus.trigger('roadAddressProject:openProject', currentProject);
-        rootElement.html(selectedProjectLinkTemplate(currentProject));
+        rootElement.html(selectedProjectLinkTemplateDisabledButtons(currentProject));
         _.defer(function () {
           applicationModel.selectLayer('roadAddressProject');
           toggleAdditionalControls();
@@ -368,7 +402,8 @@
             eventbus.trigger('linkProperties:selectedProject', result.projectAddresses.linkId, result.project);
           }
           eventbus.trigger('roadAddressProject:openProject', result.project);
-          rootElement.html(selectedProjectLinkTemplate(currentProject));
+          console.log("create new project");
+          rootElement.html(selectedProjectLinkTemplateDisabledButtons(currentProject));
           _.defer(function () {
             applicationModel.selectLayer('roadAddressProject');
             toggleAdditionalControls();
@@ -464,29 +499,28 @@
       });
 
       eventbus.on('roadAddressProject:writeProjectErrors', function () {
-        $('#project-errors').html(errorsList());
-        console.log("write errors");
-
-        //var errors = formCommon.getProjectErrors();
+        console.log("roadAddressProject:writeProjectErrors");
         var errors = projectCollection.getProjectErrors();
-        console.log("testi errors");
-        //console.log(errors);
+        console.log("WRITE ERRORS");
         console.log(errors);
         if (Object.keys(errors).length > 0) {
           errors.forEach((error) => {
             if (error.errorCode === 8 ) {
               console.log(" löytyi koodi 8");
+              rootElement.html(selectedProjectLinkTemplateDisabledButtons(currentProject));
             } else {
               console.log("ei löytynyt koodia 8");
               console.log("enable recalc button");
-              enableRecalculateButton();
+              //rootElement.html(selectedProjectLinkTemplateRecalculateButton(currentProject));
+              rootElement.html(selectedProjectLinkTemplateSendButton(currentProject));
             }
           });
         } else {
-          console.log("ei löytynyt koodia 8 length 0");
+          console.log("ei erroreita length 0");
           console.log("enable recalc button");
-          enableRecalculateButton();
+          rootElement.html(selectedProjectLinkTemplateRecalculateButton(currentProject));
         }
+        $('#project-errors').html(errorsList());
         applicationModel.removeSpinner();
       });
 
@@ -772,8 +806,5 @@
       });
     };
     bindEvents();
-    return {
-      enableChangesButton: enableChangesButton
-    };
   };
 }(this));

--- a/viite-UI/src/view/ProjectForm.js
+++ b/viite-UI/src/view/ProjectForm.js
@@ -130,7 +130,6 @@
     };
 
     var selectedProjectLinkTemplateDisabledButtons = function (project) {
-      console.log("PROEJKTIN AVAUS disabled");
       return _.template('' +
         '<header>' +
           formCommon.titleWithEditingTool(project) +
@@ -144,7 +143,6 @@
     };
 
     var selectedProjectLinkTemplateRecalculateButton = function (project) {
-      console.log("PROEJKTIN AVAUS recalculate");
       return _.template('' +
           '<header>' +
           formCommon.titleWithEditingTool(project) +
@@ -155,20 +153,6 @@
           '<div class="form-group" id="project-errors"></div>' +
           '</div></div></br></br>' +
           '<footer>' + showProjectRecalculateButton() + '</footer>');
-    };
-
-    var selectedProjectLinkTemplateSendButton = function (project) {
-      console.log("PROEJKTIN AVAUS send");
-      return _.template('' +
-          '<header>' +
-          formCommon.titleWithEditingTool(project) +
-          '</header>' +
-          '<div class="wrapper read-only">' +
-          '<div class="form form-horizontal form-dark">' +
-          '<label class="highlighted">ALOITA VALITSEMALLA KOHDE KARTALTA.</label>' +
-          '<div class="form-group" id="project-errors"></div>' +
-          '</div></div></br></br>' +
-          '<footer>' + showProjectSendButton() + '</footer>');
     };
 
     var errorsList = function () {
@@ -196,15 +180,6 @@
           '<button disabled id = "show-changes-button" class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
           '<button disabled id ="send-button" class="send btn btn-block btn-send">Lähetä muutosilmoitus Tierekisteriin</button></div>';
     };
-
-    var showProjectSendButton = function () {
-      return '<div class="project-form form-controls">' +
-          '<button class="recalculate btn btn-block btn-recalculate">Laske projekti</button>' +
-          '<button id = "show-changes-button" class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>' +
-          '<button disabled id ="send-button" class="send btn btn-block btn-send">Lähetä muutosilmoitus Tierekisteriin</button></div>';
-    };
-
-
 
     var addSmallLabel = function (label) {
       return '<label class="control-label-small">' + label + '</label>';
@@ -406,7 +381,6 @@
             eventbus.trigger('linkProperties:selectedProject', result.projectAddresses.linkId, result.project);
           }
           eventbus.trigger('roadAddressProject:openProject', result.project);
-          console.log("create new project");
           rootElement.html(selectedProjectLinkTemplateDisabledButtons(currentProject));
           _.defer(function () {
             applicationModel.selectLayer('roadAddressProject');

--- a/viite-UI/src/view/ProjectForm.js
+++ b/viite-UI/src/view/ProjectForm.js
@@ -360,6 +360,7 @@
         jQuery('.modal-overlay').remove();
         eventbus.trigger('roadAddressProject:openProject', currentProject);
         var projectErrors = projectCollection.getProjectErrors();
+        // errorCode 8 means there are projectLinks in the project with status "NotHandled"
         var highPriorityProjectErrors = projectErrors.filter((error) => error.errorCode === 8);
         if (highPriorityProjectErrors.length > 0) {
           // high priority errors

--- a/viite-UI/src/view/ProjectForm.js
+++ b/viite-UI/src/view/ProjectForm.js
@@ -360,10 +360,13 @@
         jQuery('.modal-overlay').remove();
         eventbus.trigger('roadAddressProject:openProject', currentProject);
         var projectErrors = projectCollection.getProjectErrors();
-        if (Object.keys(projectErrors).length === 0) {
-          rootElement.html(selectedProjectLinkTemplateRecalculateButton(currentProject));
-        } else {
+        var highPriorityProjectErrors = projectErrors.filter((error) => error.errorCode === 8);
+        if (highPriorityProjectErrors.length > 0) {
+          // high priority errors
           rootElement.html(selectedProjectLinkTemplateDisabledButtons(currentProject));
+        } else {
+          // normal priority errors OR no errors
+          rootElement.html(selectedProjectLinkTemplateRecalculateButton(currentProject));
         }
         _.defer(function () {
           applicationModel.selectLayer('roadAddressProject');

--- a/viite-UI/src/view/ProjectLinkLayer.js
+++ b/viite-UI/src/view/ProjectLinkLayer.js
@@ -421,10 +421,10 @@
       applicationModel.removeSpinner();
     });
 
-    me.eventListener.listenTo(eventbus, 'projectLink:revertedChanges', function (data) {
+    me.eventListener.listenTo(eventbus, 'projectLink:revertedChanges', function (response) {
       isNotEditingData = true;
       selectedProjectLinkProperty.setDirty(false);
-      eventbus.trigger('roadAddress:projectLinksUpdated', data);
+      eventbus.trigger('roadAddress:projectLinksUpdated', response);
       projectCollection.fetch(map.getView().calculateExtent(map.getSize()).join(','), zoomlevels.getViewZoom(map) + 1, undefined, projectCollection.getPublishableStatus());
     });
 

--- a/viite-UI/src/view/ProjectLinkLayer.js
+++ b/viite-UI/src/view/ProjectLinkLayer.js
@@ -411,7 +411,6 @@
       projectLinkVector.clear();
       directionMarkerLayer.getSource().clear();
       me.eventListener.listenToOnce(eventbus, 'roadAddressProject:fetched', function () {
-        console.log("open");
         selectedProjectLinkProperty.open(getSelectedId(selectedProjectLinkProperty.get()[0]), selectedProjectLinkProperty.isMultiLink());
       });
       projectCollection.fetch(map.getView().calculateExtent(map.getSize()).join(','), zoomlevels.getViewZoom(map) + 1, undefined, projectCollection.getPublishableStatus());
@@ -565,7 +564,6 @@
     });
 
     me.eventListener.listenTo(eventbus, 'roadAddressProject:fetched', function () {
-      console.log("redraw");
       me.redraw();
       _.defer(function () {
         highlightFeatures();

--- a/viite-UI/src/view/ProjectLinkLayer.js
+++ b/viite-UI/src/view/ProjectLinkLayer.js
@@ -422,10 +422,10 @@
       applicationModel.removeSpinner();
     });
 
-    me.eventListener.listenTo(eventbus, 'projectLink:revertedChanges', function () {
+    me.eventListener.listenTo(eventbus, 'projectLink:revertedChanges', function (data) {
       isNotEditingData = true;
       selectedProjectLinkProperty.setDirty(false);
-      eventbus.trigger('roadAddress:projectLinksUpdated');
+      eventbus.trigger('roadAddress:projectLinksUpdated', data);
       projectCollection.fetch(map.getView().calculateExtent(map.getSize()).join(','), zoomlevels.getViewZoom(map) + 1, undefined, projectCollection.getPublishableStatus());
     });
 

--- a/viite-UI/src/view/ProjectLinkLayer.js
+++ b/viite-UI/src/view/ProjectLinkLayer.js
@@ -411,6 +411,7 @@
       projectLinkVector.clear();
       directionMarkerLayer.getSource().clear();
       me.eventListener.listenToOnce(eventbus, 'roadAddressProject:fetched', function () {
+        console.log("open");
         selectedProjectLinkProperty.open(getSelectedId(selectedProjectLinkProperty.get()[0]), selectedProjectLinkProperty.isMultiLink());
       });
       projectCollection.fetch(map.getView().calculateExtent(map.getSize()).join(','), zoomlevels.getViewZoom(map) + 1, undefined, projectCollection.getPublishableStatus());
@@ -564,6 +565,7 @@
     });
 
     me.eventListener.listenTo(eventbus, 'roadAddressProject:fetched', function () {
+      console.log("redraw");
       me.redraw();
       _.defer(function () {
         highlightFeatures();


### PR DESCRIPTION
Viite-2616 move project calculation to its own button and redesign the order in which the buttons (recalculate, show project changes and send to TR) can be pressed during the project.  Replaced validations with only high priority validations (check if notHandled project links exist) when creating or updating project links (normal validation is done when clicking the recalculation button).