### PR TITLE
VIITE-2641 Disable Save-button when change table is open

### DIFF
--- a/viite-UI/src/view/FormCommon.js
+++ b/viite-UI/src/view/FormCommon.js
@@ -44,6 +44,20 @@
       $(`#${id}`).attr('title', titleText);
     };
 
+    // Disable form interactions (action dropdown, save and cancel buttons) and set titles
+    var disableFormInteractions = function () {
+      setDisabledAndTitleAttributesById("dropDown_0", true, 'Sulje yhteenvetotaulukko muokataksesi projektia');
+      setDisabledAndTitleAttributesById("saveButton", true, 'Sulje yhteenvetotaulukko muokataksesi projektia');
+      setDisabledAndTitleAttributesById("cancelButton", true, 'Sulje yhteenvetotaulukko muokataksesi projektia');
+    };
+
+    // Enable form interactions (action dropdown, save and cancel buttons) and set titles to empty string
+    var enableFormInteractions = function () {
+      setDisabledAndTitleAttributesById("dropDown_0", false, '');
+      setDisabledAndTitleAttributesById("saveButton", false, '');
+      setDisabledAndTitleAttributesById("cancelButton", false, '');
+    };
+
     const newRoadAddressInfo = function (project, selected, links, road) {
       const roadNumber = road.roadNumber;
       const part = road.roadPartNumber;
@@ -230,8 +244,8 @@
 
     const actionButtons = function (btnPrefix, notDisabled) {
       return '<div class="' + btnPrefix + 'form form-controls" id="actionButtons">' +
-        '<button class="update btn btn-save" ' + (notDisabled ? '' : 'disabled') + ' style="width:auto;">Tallenna</button>' +
-        '<button class="cancelLink btn btn-cancel">Peruuta</button>' +
+        '<button id="saveButton" class="update btn btn-save" ' + (notDisabled ? '' : 'disabled') + ' style="width:auto;">Tallenna</button>' +
+        '<button id="cancelButton" class="cancelLink btn btn-cancel">Peruuta</button>' +
         '</div>';
     };
 
@@ -379,7 +393,9 @@
       projectButtonsDisabled: projectButtonsDisabled,
       staticField: staticField,
       getProjectErrors: getProjectErrors,
-      setDisabledAndTitleAttributesById: setDisabledAndTitleAttributesById
+      setDisabledAndTitleAttributesById: setDisabledAndTitleAttributesById,
+      disableFormInteractions: disableFormInteractions,
+      enableFormInteractions: enableFormInteractions
     };
   };
 }(this));

--- a/viite-UI/src/view/ProjectChangeTable.js
+++ b/viite-UI/src/view/ProjectChangeTable.js
@@ -9,11 +9,17 @@
       'Numerointi',
       'Lakkautettu'
     ];
-
+    // change table is not open in the beginning of the project
+    var changeTableOpen = false;
     var LinkStatus = LinkValues.LinkStatus;
     var ProjectStatus = LinkValues.ProjectStatus;
     var windowMaximized = false;
     var formCommon = new FormCommon('');
+
+    // checks if change table state is open
+    var isChangeTableOpen = function () {
+      return changeTableOpen;
+    };
 
     var changeTable =
       $('<div class="change-table-frame"></div>');
@@ -70,6 +76,10 @@
     }
 
     function hide() {
+      // set change table state
+      changeTableOpen = false;
+      // enable action dropdown, save and cancel buttons
+      formCommon.enableFormInteractions();
       $('#information-content').empty();
       // disable send button and set title attribute
       $('#send-button').attr('disabled', true);
@@ -146,6 +156,8 @@
       }
       $('.row-changes').remove();
       $('.change-table-dimensions').append($(htmlTable));
+      // set change table state to open
+      changeTableOpen = true;
       if (projectChangeData) {
         $('.change-table-header').html($('<div class="font-resize">Validointi ok. Alla näet muutokset projektissa.</div>'));
         var currentProject = projectCollection.getCurrentProject();
@@ -377,7 +389,8 @@
     return {
       show: show,
       hide: hide,
-      bindEvents: bindEvents
+      bindEvents: bindEvents,
+      isChangeTableOpen: isChangeTableOpen
     };
   };
 }(this));

--- a/viite-UI/src/view/ProjectEditForm.js
+++ b/viite-UI/src/view/ProjectEditForm.js
@@ -269,6 +269,10 @@
         rootElement.html(selectedProjectLinkTemplate(currentProject.project, selectedProjectLink));
         formCommon.replaceAddressInfo(backend, selectedProjectLink, currentProject.project.id);
         updateForm();
+        // disable form interactions (action dropdown, save and cancel buttons) if change table is open
+        if (projectChangeTable.isChangeTableOpen()) {
+          formCommon.disableFormInteractions();
+        }
         _.defer(function () {
           $('#beginDistance').on("change", function (changedData) {
             eventbus.trigger('projectLink:editedBeginDistance', changedData.target.value);

--- a/viite-UI/src/view/ProjectForm.js
+++ b/viite-UI/src/view/ProjectForm.js
@@ -341,8 +341,16 @@
         // errorCode 8 means there are projectLinks in the project with status "NotHandled"
         var highPriorityProjectErrors = projectErrors.filter((error) => error.errorCode === 8);
         if (highPriorityProjectErrors.length === 0) {
-          // enable recalculate button and set title text to empty string
-          formCommon.setDisabledAndTitleAttributesById("recalculate-button", false, "");
+          // if change table is open then button titles should tell user to close the change table
+          if ($('.change-table-frame').css('display') === "block") {
+            formCommon.setDisabledAndTitleAttributesById("recalculate-button", true, "Etäisyyslukemia ei voida päivittää yhteenvetotaulukon ollessa auki");
+            formCommon.setDisabledAndTitleAttributesById("changes-button", true, "Yhteenvetotaulukko on jo auki");
+          } else {
+            //if no high priority errors are present and change table is not open enable recalculate button and set title text to empty string
+            // set changes button title
+            formCommon.setDisabledAndTitleAttributesById("recalculate-button", false, "");
+            formCommon.setDisabledAndTitleAttributesById("changes-button", true, "Projektin tulee läpäistä validoinnit");
+          }
         }
         _.defer(function () {
           applicationModel.selectLayer('roadAddressProject');


### PR DESCRIPTION
Prevent user from editing the project links when change table is open. Also disabled Cancel button and Action dropdown if change table is open. After user closes the change table, the buttons and dropdowns become clickable again.