### PR TITLE
Add logback file for tests, to shrink the info lines away from the test set output

### DIFF
--- a/digiroad2-viite/src/test/resources/logback.xml
+++ b/digiroad2-viite/src/test/resources/logback.xml
@@ -1,0 +1,13 @@
+<configuration scan="true" scanPeriod="30 seconds">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>TEST %date %-5level [%thread] %logger{20} [%file:%line] %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="warn">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
 with root level=warn