### PR TITLE
VIITE-2620 ErrorInViite projects appear on top of the project list.

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectDAO.scala
@@ -27,10 +27,9 @@ object ProjectState {
   def apply(value: Long): ProjectState = {
     values.find(_.value == value).getOrElse(Unknown)
   }
-
+  case object ErrorInViite extends ProjectState {def value = 0; def description = "Virhe Viite-sovelluksessa"}
   case object Incomplete extends ProjectState {def value = 1; def description = "Keskeneräinen"}
   case object Deleted extends ProjectState {def value = 7; def description = "Poistettu projekti"}
-  case object ErrorInViite extends ProjectState {def value = 8; def description = "Virhe Viite-sovelluksessa"}
   case object InUpdateQueue extends ProjectState {def value = 10; def description = "Odottaa tieverkolle päivittämistä"}
   case object UpdatingToRoadNetwork extends ProjectState {def value = 11; def description = "Päivitetään tieverkolle"}
   case object Accepted extends ProjectState {def value = 12; def description = "Hyväksytty"}

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/package.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/package.scala
@@ -210,9 +210,9 @@ package object viite {
   val projectStatusStructure = "" +
     "| Status Code |       Project Status       |              Description              |\n" +
     "|:-----------:|:--------------------------:|:-------------------------------------:|\n" +
+    "|      0      |        ErrorInViite        |       Virhe Viite-sovelluksessa       |\n" +
     "|      1      |         Incomplete         |             Keskeneräinen             |\n" +
     "|      7      |           Deleted          |           Poistettu projekti          |\n" +
-    "|      8      |        ErrorInViite        |       Virhe Viite-sovelluksessa       |\n" +
     "|      10     |        InUpdateQueue       |   Odottaa tieverkolle päivittämistä   |\n" +
     "|      11     |    UpdatingToRoadNetwork   |        Päivitetään tieverkolle        |\n" +
     "|      12     |          Accepted          |               Hyväksytty              |\n" +

--- a/viite-UI/src/utils/LinkValues.js
+++ b/viite-UI/src/utils/LinkValues.js
@@ -76,9 +76,9 @@
   };
 
   root.ProjectStatus = {
+    ErrorInViite: {value: 0, description: "Virhe Viite-sovelluksessa"},
     Incomplete: {value: 1, description: "Keskeneräinen"},
     Deleted: {value: 7, description: "Poistettu projekti"},
-    ErrorInViite: {value: 8, description: "Virhe Viite-sovelluksessa"},
     InUpdateQueue: {value: 10, description: "Odottaa tieverkolle päivittämistä"},
     UpdatingToRoadNetwork: {value: 11, description: "Päivitetään tieverkolle"},
     Accepted: {value: 12, description: "Hyväksytty"},

--- a/viite-UI/src/view/navigationpanel/ProjectListModel.js
+++ b/viite-UI/src/view/navigationpanel/ProjectListModel.js
@@ -39,7 +39,7 @@
     };
 
     var orderBy = {
-      id: "sortELY", reversed: false
+      id: "sortStatus", reversed: false
     };
 
     var filterBox = {
@@ -193,7 +193,7 @@
           }
         };
 
-        var html = '<table style="align-content: left; align-items: left; table-layout: fixed; width: 100%;">';
+        var html = '<table style="table-layout: fixed; width: 100%;">';
         // eslint-disable-next-line no-negated-condition
         if (!_.isEmpty(sortedProjects)) {
           var uniqueId = 0;
@@ -207,7 +207,7 @@
               '<td style="width: 100px;" title="' + info + '">' + staticFieldProjectList(proj.statusDescription) + '</td>';
             switch (proj.statusCode) {
               case projectStatus.ErrorInViite.value:
-                html += '<td><button class="project-open btn btn-new-error" style="alignment: right; margin-bottom: 6px; margin-left: 25px; visibility: hidden" data-projectStatus="' + proj.statusCode + '">Avaa uudelleen</button></td>' +
+                html += '<td id="innerOpenProjectButton"><button class="project-open btn btn-new-error" style="alignment: right; margin-bottom: 6px; margin-left: 25px" id="reopen-project-' + proj.id + '" value="' + proj.id + '" data-projectStatus="'+ proj.statusCode + '">Avaa uudelleen</button></td>' +
                   '</tr>';
                 break;
               default:


### PR DESCRIPTION
Projects are ordered by project state (from low to high).

Changed the state ErrorInViite value (8 -> 0) to make them appear on top of the list.

Fixed reopen button bug.

Removed mismatched css property values.