### PR TITLE
VIITE-2552 junction and node point expiration bug fix

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/RoadwayFiller.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/RoadwayFiller.scala
@@ -184,7 +184,7 @@ object RoadwayFiller {
       }
       val continuousGrouped = (continuousParts._1 :+ continuousParts._2).tail
       continuousGrouped.map(pls => {
-        val newRoadwayNumber              = if ((pls.last.endAddrMValue - pls.head.startAddrMValue) == (currentRoadway.endAddrMValue - currentRoadway.startAddrMValue)) currentRoadway.roadwayNumber else Sequences.nextRoadwayNumber
+        val newRoadwayNumber              = if ((pls.last.endAddrMValue - pls.head.startAddrMValue) == (currentRoadway.endAddrMValue - currentRoadway.startAddrMValue)) currentRoadway.roadwayNumber else pls.head.roadwayNumber
         val roadway                       = currentRoadway.copy(id = NewIdValue, roadwayNumber = newRoadwayNumber, endDate = pls.head.endDate, terminated = TerminationCode.Termination, startAddrMValue = pls.head.startAddrMValue, endAddrMValue = pls.last.endAddrMValue, discontinuity = pls.last.discontinuity)
         val currentRoadwayHistoryRoadways = historyRoadways.filter(_.roadwayNumber == currentRoadway.roadwayNumber)
 


### PR DESCRIPTION
Terminated roadway was given a new roadway number (not the same roadway number that project link had) and
roadway points were updated with the project links roadway number.

 That caused a bug where obsolete node and junction points weren't terminated because Viite couldn't find the roadway points that the nodes and junction points were on.