### PR TITLE
VIITE-2663 underconstruction link geometry length not shown on form

### DIFF
--- a/viite-UI/src/model/RoadCollection.js
+++ b/viite-UI/src/model/RoadCollection.js
@@ -225,7 +225,7 @@
         return groupDataSourceFilter(group, LinkSource.HistoryLinkInterface);
       });
 
-      setRoadLinkGroups(nonHistoryConstructionRoadLinkGroups.concat(unaddressedUnderConstructionRoadLinkGroups).concat(floatingRoadLinks));
+      setRoadLinkGroups(nonHistoryConstructionRoadLinkGroups.concat(floatingRoadLinks));
       eventbus.trigger('roadLinks:fetched', nonHistoryConstructionRoadLinkGroups, (!_.isUndefined(drawUnknowns) && drawUnknowns), selectedLinkIds);
       if (historicRoadLinks.length !== 0) {
         eventbus.trigger('linkProperty:fetchedHistoryLinks', historicRoadLinks);


### PR DESCRIPTION
fixed a bug where underconstruction links length was not shown on link form.

geometry length was only shown if selectedLinkPropertyToShow.count() === 1. When RoadLinkGroups are formed, underconstruction links are added to the list of groups twice resulting in selectedLinkPropertyToShow.count() === 2 and the geometry length not being shown on the form.