### PR TITLE
VIITE-2588 fix link group partitioning

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/model/RoadAddressLinkPartitioner.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/model/RoadAddressLinkPartitioner.scala
@@ -10,7 +10,7 @@ object RoadAddressLinkPartitioner extends GraphPartitioner {
   */
   def groupByHomogeneousSection[T <: RoadAddressLinkLike](links: Seq[T]): Seq[Seq[T]] = {
     val linkGroups = links.groupBy { link => (
-      link.anomaly.equals(Anomaly.NoAddressGiven), link.constructionType.equals(ConstructionType.UnderConstruction), link.roadNumber, link.roadPartNumber, link.trackCode,
+      link.anomaly.equals(Anomaly.NoAddressGiven), link.constructionType.equals(ConstructionType.UnderConstruction), link.roadNumber, link.roadPartNumber,
       link.roadLinkSource.equals(LinkGeomSource.ComplementaryLinkInterface)
       )
     }

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/model/RoadAddressLinkPartitionerSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/model/RoadAddressLinkPartitionerSpec.scala
@@ -98,16 +98,18 @@ class RoadAddressLinkPartitionerSpec extends FunSuite with Matchers {
     partitionedRoadLinks.size should be (2)
   }
 
-  test("Test partition When 2 links have at least different TRACK Then they will be in different groups of RoadAddressLinks") {
+  test("Test partition When 2 links have different TRACK and same ROAD NUMBER & ROAD PART NUMBER Then they will be in same RoadAddressLink group") {
+    val roadNumber1 = 1
+    val roadPartNumber1 = 1
     val track1 = 1
     val track2 = 2
 
-    val roadLinks = Seq(RoadAddressLink(0, 0, 5171208, Seq(Point(532837.14110884, 6993543.6296834), Point(533388.14110884, 6994014.1296834)), 0.0, AdministrativeClass.Municipality, UnknownLinkType, InUse, NormalLinkInterface, AdministrativeClass.Municipality, Some("Vt5"), None, BigInt(0), "", None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), 1, 1, track1, 0, 0, 0, 1, "2015-01-01", "2016-01-01", 0.0, 0.0, SideCode.Unknown, None, None, Anomaly.None, 123),
-      RoadAddressLink(0, 0, 5171208, Seq(Point(532837.14110884, 6993543.6296834), Point(533388.14110884, 6994014.1296834)), 0.0, AdministrativeClass.Municipality, UnknownLinkType, InUse, NormalLinkInterface, AdministrativeClass.Municipality, Some("Vt5"), None, BigInt(0), "", None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), 1, 1, track2, 0, 0, 0, 1, "2015-01-01", "2016-01-01", 0.0, 0.0, SideCode.Unknown, None, None, Anomaly.None, 123)
+    val roadLinks = Seq(RoadAddressLink(0, 0, 5171208, Seq(Point(532837.14110884, 6993543.6296834), Point(533388.14110884, 6994014.1296834)), 0.0, AdministrativeClass.Municipality, UnknownLinkType, InUse, NormalLinkInterface, AdministrativeClass.Municipality, Some("Vt5"), None, BigInt(0), "", None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), roadNumber1, roadPartNumber1, track1, 0, 0, 0, 1, "2015-01-01", "2016-01-01", 0.0, 0.0, SideCode.Unknown, None, None, Anomaly.None, 123),
+      RoadAddressLink(0, 0, 5171208, Seq(Point(532837.14110884, 6993543.6296834), Point(533388.14110884, 6994014.1296834)), 0.0, AdministrativeClass.Municipality, UnknownLinkType, InUse, NormalLinkInterface, AdministrativeClass.Municipality, Some("Vt5"), None, BigInt(0), "", None, None, Map("linkId" -> 5171208, "segmentId" -> 63298), roadNumber1, roadPartNumber1, track2, 0, 0, 0, 1, "2015-01-01", "2016-01-01", 0.0, 0.0, SideCode.Unknown, None, None, Anomaly.None, 123)
     )
 
     val partitionedRoadLinks = RoadAddressLinkPartitioner.groupByHomogeneousSection(roadLinks)
-    partitionedRoadLinks.size should be (2)
+    partitionedRoadLinks.size should be (1)
   }
 
   test("Test partition When 1 link have LinkGeomSource.ComplimentaryLinkInterface and other one have any other LinkGeomSource Then they will be in different groups of RoadAddressLinks") {

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/model/RoadAddressLinkPartitionerSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/model/RoadAddressLinkPartitionerSpec.scala
@@ -98,7 +98,7 @@ class RoadAddressLinkPartitionerSpec extends FunSuite with Matchers {
     partitionedRoadLinks.size should be (2)
   }
 
-  test("Test partition When 2 links have different TRACK and same ROAD NUMBER & ROAD PART NUMBER Then they will be in same RoadAddressLink group") {
+  test("Test partition When 2 links have different TRACK and same ROAD NUMBER & ROAD PART NUMBER Then they will be in the same RoadAddressLink group") {
     val roadNumber1 = 1
     val roadPartNumber1 = 1
     val track1 = 1

--- a/viite-UI/src/model/RoadCollection.js
+++ b/viite-UI/src/model/RoadCollection.js
@@ -78,18 +78,12 @@
     var roadLinks = function () {
       return _.flatten(roadLinkGroups);
     };
-    
-    var selectedRoadNumber = 0;
-    var selectedRoadPartNumber = 0;
+
 
     var getSelectedRoadLinks = function () {
-      var selected_road = _.find(roadLinks(), function (roadLink) {
+      return _.filter(roadLinks().concat(underConstructionRoadLinks()), function (roadLink) {
         return roadLink.isSelected() && roadLink.getData().anomaly === Anomaly.None.value;
       });
-      if (selected_road) {
-        selectedRoadNumber = selected_road.getData().roadNumber;
-        selectedRoadPartNumber = selected_road.getData().roadPartNumber;
-      }
     };
 
     var getGroupByLinearLocationId = function (linearLocationId) {
@@ -159,7 +153,7 @@
       fetchProcess(currentAllRoadLinks, currentZoom, true);
     });
 
-    var updateGroupToContainWholeRoadPart = function (fetchedRoadLinks, drawUnknowns) {
+    var updateGroupToContainWholeRoadPart = function (fetchedRoadLinks) {
 
       var fetchedRoadLinkModels = _.map(fetchedRoadLinks, function (roadLinkGroup) {
         return _.map(roadLinkGroup, function (roadLink) {


### PR DESCRIPTION
Fixed a bug where road link duplicates appeared in roadCollection.js roadlinkGroups.

Link groups were partitioned by homogeneous section and if track wasn't same on two different road links then they were put in different groups.
Now that single click selects whole road part regardless of different tracks, we dont have to partition by track anymore.