### PR TITLE
VIITE-2672 remove cname route53 from alb stack, renamings, fixed task…

### DIFF
--- a/aws/cloud-formation/prod/README.md
+++ b/aws/cloud-formation/prod/README.md
@@ -59,6 +59,7 @@ aws cloudformation create-stack \
 ```
 aws cloudformation create-stack \
 --stack-name [esim. viite-prod-taskdefinition] \
+--capabilities CAPABILITY_NAMED_IAM \
 --template-body file://aws/cloud-formation/prod/prod-viite-create-taskdefinition-cloudformation.yaml \
 --parameters ParameterKey=RepositoryURL,ParameterValue=[URL äsken luotuun ECR repositoryyn jossa kontti sijaitsee esim. 012345678910.dkr.ecr.eu-west-1.amazonaws.com]
 ```
@@ -67,7 +68,7 @@ aws cloudformation create-stack \
 ```
 aws cloudformation create-stack \
 --stack-name [esim. viite-prod] \
---on-failure DELETE --capabilities CAPABILITY_NAMED_IAM \
+--on-failure DELETE \
 --template-body file://aws/cloud-formation/viite-alb_ecs.yaml \
 --parameters file://aws/cloud-formation/prod/prod-parameters-viite-alb_ecs.json
 ```

--- a/aws/cloud-formation/prod/prod-parameters-viite-alb_ecs.json
+++ b/aws/cloud-formation/prod/prod-parameters-viite-alb_ecs.json
@@ -1,7 +1,7 @@
 [
   {
     "ParameterKey": "ApplicationName",
-    "ParameterValue": "Viite"
+    "ParameterValue": "Viite-prod"
   },
   {
     "ParameterKey": "ContainerPort",
@@ -21,7 +21,7 @@
   },
   {
     "ParameterKey": "NetworkStackName",
-    "ParameterValue": "viite-prod"
+    "ParameterValue": "ViiteProd"
   },
   {
     "ParameterKey": "Owner",
@@ -34,10 +34,6 @@
   {
     "ParameterKey": "ApiGatewayUrl",
     "ParameterValue": "api.vaylapilvi.fi"
-  },
-  {
-    "ParameterKey": "CNameRecord",
-    "ParameterValue": "viiteprod"
   }
 ]
 

--- a/aws/cloud-formation/prod/prod-viite-create-taskdefinition-cloudformation.yaml
+++ b/aws/cloud-formation/prod/prod-viite-create-taskdefinition-cloudformation.yaml
@@ -5,16 +5,46 @@ Parameters:
     Type: String
     Description: URL to repository, where the container is, e.g. 012345678910.dkr.ecr.eu-west-1.amazonaws.com
 Resources:
-  taskdefinition:
+  # This is a role which is used by the ECS tasks themselves.
+  ECSTaskExecutionRoleForViite:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: [ ecs-tasks.amazonaws.com ]
+            Action: [ 'sts:AssumeRole' ]
+      Path: /
+      Policies:
+        - PolicyName: AmazonECSTaskExecutionRolePolicy
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'ssm:GetParameter'
+                  - 'ssm:GetParameters'
+                  - 'ssm:DescribeParameters'
+                  # Allow the ECS Tasks to download images from ECR
+                  - 'ecr:GetAuthorizationToken'
+                  - 'ecr:BatchCheckLayerAvailability'
+                  - 'ecr:GetDownloadUrlForLayer'
+                  - 'ecr:BatchGetImage'
+
+                  # Allow the ECS tasks to upload logs to CloudWatch
+                  - 'logs:CreateLogStream'
+                  - 'logs:PutLogEvents'
+                Resource: '*'
+  Taskdefinition:
     Type: AWS::ECS::TaskDefinition
     Properties:
-      ExecutionRoleArn: !Sub 'arn:aws:iam::${AWS::AccountId}:role/TaskExecutionRole'
+      ExecutionRoleArn: !GetAtt ECSTaskExecutionRoleForViite.Arn
       ContainerDefinitions:
         -
           LogConfiguration:
             LogDriver: awslogs
             Options:
-              awslogs-group: /ecs/Prod-Viite-ECS-logs
+              awslogs-group: /ecs/Prod-Viite-prod-ECS-logs
               awslogs-region: eu-west-1
               awslogs-stream-prefix: ecs
           PortMappings:

--- a/aws/cloud-formation/qa/README.md
+++ b/aws/cloud-formation/qa/README.md
@@ -52,6 +52,7 @@ aws ssm put-parameter --overwrite --name /Viite/QA/vkmApiKey --type SecureString
 ```
 aws cloudformation create-stack \
 --stack-name [esim. viite-qa-taskdefinition] \
+--capabilities CAPABILITY_NAMED_IAM \
 --template-body file://aws/cloud-formation/qa/qa-viite-create-taskdefinition-cloudformation.yaml \
 --parameters ParameterKey=RepositoryURL,ParameterValue=[URL repositoryyn jossa kontti sijaitsee esim. 012345678910.dkr.ecr.eu-west-1.amazonaws.com]
 ```
@@ -60,9 +61,17 @@ aws cloudformation create-stack \
 ```
 aws cloudformation create-stack \
 --stack-name [esim. viite-qa] \
---on-failure DELETE --capabilities CAPABILITY_NAMED_IAM \
+--on-failure DELETE \
 --template-body file://aws/cloud-formation/viite-alb_ecs.yaml \
 --parameters file://aws/cloud-formation/qa/qa-parameters-viite-alb_ecs.json
+```
+
+### Luo CNAME record-stack
+```
+aws cloudformation create-stack \
+--stack-name [esim. viite-qa-cname-to-route53] \
+--template-body file://aws/cloud-formation/qa/qa-viite-create-cname-record-to-route53.yaml \
+--parameters ParameterKey=CNameRecord,ParameterValue=viitetest ParameterKey=LoadBalancerDNSName,ParameterValue=[Kuormantasaajan DNS nimi esim. internal-viite-Priva-ABCDEFGHIJKL-012345678910.eu-west-1.elb.amazonaws.com]
 ```
 
 # Viite QA, päivitys

--- a/aws/cloud-formation/qa/qa-parameters-viite-alb_ecs.json
+++ b/aws/cloud-formation/qa/qa-parameters-viite-alb_ecs.json
@@ -34,10 +34,6 @@
   {
     "ParameterKey": "ApiGatewayUrl",
     "ParameterValue": "qaapi.testivaylapilvi.fi"
-  },
-  {
-    "ParameterKey": "CNameRecord",
-    "ParameterValue": "viitetest"
   }
 ]
 

--- a/aws/cloud-formation/qa/qa-viite-create-cname-record-to-route53.yaml
+++ b/aws/cloud-formation/qa/qa-viite-create-cname-record-to-route53.yaml
@@ -1,0 +1,19 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Creates CNAME record "alb.<accountName>.vaylapilvi.aws" that points to alb-1234567.eu-west-1.elb.amazonaws.com
+Parameters:
+  CNameRecord:
+    Description: CName of the application (no whitespace or special characters)
+    Type: String
+  LoadBalancerDNSName:
+    Description: DNS name of the load balancer
+    Type: String
+Resources:
+  ViiteCnameRecordToRoute53:
+    Type: Custom::VaylapilviRoute53Record
+    Properties:
+      ServiceToken: arn:aws:sns:eu-west-1:434599271542:Vaylapilvi-Route53-Record
+      Type: CNAME
+      Name: !Ref CNameRecord
+      Records:
+        - !Ref LoadBalancerDNSName
+      Comment: Application load balancer

--- a/aws/cloud-formation/qa/qa-viite-create-taskdefinition-cloudformation.yaml
+++ b/aws/cloud-formation/qa/qa-viite-create-taskdefinition-cloudformation.yaml
@@ -5,10 +5,40 @@ Parameters:
     Type: String
     Description: URL to repository, where the container is, e.g. 012345678910.dkr.ecr.eu-west-1.amazonaws.com
 Resources:
-  taskdefinition:
+  # This is a role which is used by the ECS tasks themselves.
+  ECSTaskExecutionRoleForViite:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: [ ecs-tasks.amazonaws.com ]
+            Action: [ 'sts:AssumeRole' ]
+      Path: /
+      Policies:
+        - PolicyName: AmazonECSTaskExecutionRolePolicy
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'ssm:GetParameter'
+                  - 'ssm:GetParameters'
+                  - 'ssm:DescribeParameters'
+                  # Allow the ECS Tasks to download images from ECR
+                  - 'ecr:GetAuthorizationToken'
+                  - 'ecr:BatchCheckLayerAvailability'
+                  - 'ecr:GetDownloadUrlForLayer'
+                  - 'ecr:BatchGetImage'
+
+                  # Allow the ECS tasks to upload logs to CloudWatch
+                  - 'logs:CreateLogStream'
+                  - 'logs:PutLogEvents'
+                Resource: '*'
+  Taskdefinition:
     Type: AWS::ECS::TaskDefinition
     Properties:
-      ExecutionRoleArn: !Sub 'arn:aws:iam::${AWS::AccountId}:role/TaskExecutionRole'
+      ExecutionRoleArn: !GetAtt ECSTaskExecutionRoleForViite.Arn
       ContainerDefinitions:
         -
           LogConfiguration:
@@ -83,7 +113,6 @@ Resources:
               - CMD-SHELL
               - curl -f http://127.0.0.1:9080/api/ping/ || exit 1
       Memory: '4096'
-      # TaskRoleArn: ''
       Family: QA-viite-test
       RequiresCompatibilities:
         - FARGATE

--- a/aws/cloud-formation/viite-alb_ecs.yaml
+++ b/aws/cloud-formation/viite-alb_ecs.yaml
@@ -28,9 +28,6 @@ Parameters:
   ApiGatewayUrl:
     Type: String
     Description: ApiGateWay Url
-  CNameRecord:
-    Description: CName of the application (no whitespace or special characters)
-    Type: String
 
 Resources:
   LoadBalancerSecurityGroup:
@@ -71,34 +68,6 @@ Resources:
     Properties:
       LogGroupName: !Join ['', ['/ecs/',!Ref Environment,'-', !Ref ApplicationName, '-ECS-logs']]
       RetentionInDays: 14
-
-  # This is a role which is used by the ECS tasks themselves.
-  ECSTaskExecutionRoleForViite:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service: [ecs-tasks.amazonaws.com]
-            Action: ['sts:AssumeRole']
-      Path: /
-      Policies:
-        - PolicyName: AmazonECSTaskExecutionRolePolicy
-          PolicyDocument:
-            Statement:
-              - Effect: Allow
-                Action:
-                  # Allow the ECS Tasks to download images from ECR
-                  - 'ecr:GetAuthorizationToken'
-                  - 'ecr:BatchCheckLayerAvailability'
-                  - 'ecr:GetDownloadUrlForLayer'
-                  - 'ecr:BatchGetImage'
-
-                  # Allow the ECS tasks to upload logs to CloudWatch
-                  - 'logs:CreateLogStream'
-                  - 'logs:PutLogEvents'
-                Resource: '*'
 
   PrivateLoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
@@ -252,17 +221,6 @@ Resources:
       VpcId:
         Fn::ImportValue:
           !Join [ '-', [ !Ref NetworkStackName, 'VPC-Id' ] ]
-
-  # Creates CNAME record "alb.<accountName>.vaylapilvi.aws" that points to alb-1234567.eu-west-1.elb.amazonaws.com
-  ViiteCnameRecordToRoute53:
-    Type: Custom::VaylapilviRoute53Record
-    Properties:
-      ServiceToken: arn:aws:sns:eu-west-1:434599271542:Vaylapilvi-Route53-Record
-      Type: CNAME
-      Name: !Ref CNameRecord
-      Records:
-        - !GetAtt PrivateLoadBalancer.DNSName
-      Comment: Application load balancer
 
 Outputs:
   ALBDNSName:


### PR DESCRIPTION
…ExecutionRole

 Prod cant use cname record feature, so only QA will use it from now on.

 Creation of the taskExecutionRole moved to taskdef stack and it is now being used by the task (wasn't previously...).

 Renamings for prod.