### PR TITLE
VIITE-2708 update the API call

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/postgis/MassQuery.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/postgis/MassQuery.scala
@@ -1,28 +1,39 @@
 package fi.liikennevirasto.digiroad2.postgis
 
+import fi.liikennevirasto.digiroad2.util.LogUtils
+import org.slf4j.LoggerFactory
 import slick.driver.JdbcDriver.backend.Database.dynamicSession
 import slick.jdbc.StaticQuery.interpolation
 
 object MassQuery {
+  val logger = LoggerFactory.getLogger(getClass)
   def withIds[T](ids: Iterable[Long])(f: String => T): T = {
-    sqlu"""
+    LogUtils.time(logger, s"TEST LOG MassQuery withIds ${ids.size}") {
+      LogUtils.time(logger, "TEST LOG create TEMP_ID table") {
+        sqlu"""
       CREATE TEMPORARY TABLE IF NOT EXISTS TEMP_ID (
         ID BIGINT NOT NULL,
 	      CONSTRAINT TEMP_ID_PK PRIMARY KEY (ID)
       ) ON COMMIT DELETE ROWS
     """.execute
-    val insertLinkIdPS = dynamicSession.prepareStatement("insert into temp_id (id) values (?)")
-    try {
-      ids.foreach { id =>
-        insertLinkIdPS.setLong(1, id)
-        insertLinkIdPS.addBatch()
       }
-      insertLinkIdPS.executeBatch()
-      val ret = f("temp_id")
-      sqlu"TRUNCATE TABLE TEMP_ID".execute
-      ret
-    } finally {
-      insertLinkIdPS.close()
+      val insertLinkIdPS = dynamicSession.prepareStatement("insert into temp_id (id) values (?)")
+
+      LogUtils.time(logger, s"TEST LOG insert into TEMP_ID ${ids.size}") {
+        try {
+          ids.foreach { id =>
+            insertLinkIdPS.setLong(1, id)
+            insertLinkIdPS.addBatch()
+          }
+          logger.debug("added {} entries to temporary table", ids.size)
+          insertLinkIdPS.executeBatch()
+          val ret = f("temp_id")
+          sqlu"TRUNCATE TABLE TEMP_ID".execute
+          ret
+        } finally {
+          insertLinkIdPS.close()
+        }
+      }
     }
   }
 }

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/RoadwayAddressMapper.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/RoadwayAddressMapper.scala
@@ -172,7 +172,7 @@ class RoadwayAddressMapper(roadwayDAO: RoadwayDAO, linearLocationDAO: LinearLoca
 
     val groupedLinearLocations = linearLocations.groupBy(_.roadwayNumber)
     val roadwayLinearLocations = groupedLinearLocations.
-      getOrElse(roadway.roadwayNumber, throw new IllegalArgumentException("Any linear locations found that belongs to the given roadway address"))
+      getOrElse(roadway.roadwayNumber, throw new NoSuchElementException("No linear locations found that belongs to the given roadway address"))
 
     //If is a roadway address history should recalculate all the calibration points
     val roadAddresses = recursiveMapRoadAddresses(roadway, if (roadway.endDate.nonEmpty && roadway.terminated == NoTermination) recalculateHistoryCalibrationPoints(roadway, linearLocations) else roadwayLinearLocations)


### PR DESCRIPTION
Added values startAddrValue and endAddrValue
Apply values only when LinearLocation.validTo is None

Fixed bug with MassQuery in RoadwayDAO.withRoadwayNumbers

Copied debugging for MassQuery from digiroad

Changed exception in RoadwayAddressMapper.mapRoadAddresses to not conflict with API call