### PR TITLE
VIITE-2717

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/postgis/MassQuery.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/postgis/MassQuery.scala
@@ -7,7 +7,7 @@ import slick.jdbc.StaticQuery.interpolation
 
 object MassQuery {
   val logger = LoggerFactory.getLogger(getClass)
-  def withIds[T](ids: Iterable[Long])(f: String => T): T = {
+  def withIds[T](ids: Iterable[Long])(function: String => T): T = {
     LogUtils.time(logger, s"TEST LOG MassQuery withIds ${ids.size}") {
       LogUtils.time(logger, "TEST LOG create TEMP_ID table") {
         sqlu"""
@@ -21,6 +21,8 @@ object MassQuery {
 
       LogUtils.time(logger, s"TEST LOG insert into TEMP_ID ${ids.size}") {
         try {
+          //Making sure that the table is empty if called multiple times within a transaction
+          //Emptied at the end of transaction as per TABLE definition above
           sqlu"TRUNCATE TABLE TEMP_ID".execute
           ids.foreach { id =>
             insertLinkIdPS.setLong(1, id)
@@ -28,8 +30,7 @@ object MassQuery {
           }
           logger.debug("added {} entries to temporary table", ids.size)
           insertLinkIdPS.executeBatch()
-          val ret = f("temp_id")
-          ret
+          function("temp_id")
         } finally {
           insertLinkIdPS.close()
         }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/postgis/MassQuery.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/postgis/MassQuery.scala
@@ -21,6 +21,7 @@ object MassQuery {
 
       LogUtils.time(logger, s"TEST LOG insert into TEMP_ID ${ids.size}") {
         try {
+          sqlu"TRUNCATE TABLE TEMP_ID".execute
           ids.foreach { id =>
             insertLinkIdPS.setLong(1, id)
             insertLinkIdPS.addBatch()
@@ -28,7 +29,6 @@ object MassQuery {
           logger.debug("added {} entries to temporary table", ids.size)
           insertLinkIdPS.executeBatch()
           val ret = f("temp_id")
-          sqlu"TRUNCATE TABLE TEMP_ID".execute
           ret
         } finally {
           insertLinkIdPS.close()


### PR DESCRIPTION
Changed MassQuery ordering to ensure table is populated during the execution of the query

Alternative solutions would require refactoring of existing MassQuery.withIds uses. This solution works with the existing methods using MassQuery and doesn't cause issues in situations where multiple MassQuery calls are made within a single transaction block.