### PR TITLE
VIITE-2518 added administrative class changing check to junction point validation

### DIFF
--- a/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
+++ b/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
@@ -915,7 +915,7 @@ class ViiteApi(val roadLinkService: RoadLinkService, val vVHClient: VVHClient,
       val isOnAdministrativeClassChangingSpot = nodesAndJunctionsService.areJunctionPointsOnAdministrativeClassChangingSpot(ids)
       val isOnReservedPart  = nodesAndJunctionsService.areJunctionPointsOnReservedRoadPart(ids)
       val isOnRoadwayChangingSpot = nodesAndJunctionsService.areJunctionPointsOnRoadwayChangingSpot(ids) // TODO remove this check when VIITE-2524 gets implemented
-      val isEditableAndErrorMessage = {
+      val isEditableAndValidationMessage = {
         if (isOnReservedPart)
           (false, "Liittymäkohta sijaitsee tieosalla joka on varattuna tieosoiteprojektiin, liittymäkohdan muokkaus ei ole juuri nyt mahdollista.")
         else if (isOnAdministrativeClassChangingSpot)
@@ -925,7 +925,7 @@ class ViiteApi(val roadLinkService: RoadLinkService, val vVHClient: VVHClient,
         else
           (true, "")
       }
-      Map("success" -> true, "isEditable" -> isEditableAndErrorMessage._1, "errorMessage" -> isEditableAndErrorMessage._2)
+      Map("isEditable" -> isEditableAndValidationMessage._1, "validationMessage" -> isEditableAndValidationMessage._2)
     }
   }
 

--- a/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
+++ b/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
@@ -896,24 +896,36 @@ class ViiteApi(val roadLinkService: RoadLinkService, val vVHClient: VVHClient,
     }
   }
 
-  private val getReservedStatusOfJunctionPoints: SwaggerSupportSyntax.OperationBuilder = (
-    apiOperation[Map[String, Any]]("getReservedStatusOfJunctionPoints")
+  private val getEditableStatusOfJunctionPoints: SwaggerSupportSyntax.OperationBuilder = (
+    apiOperation[Map[String, Any]]("getEditableStatusOfJunctionPoints")
       .parameters(
         queryParam[Long]("ids").description("Junction point id:s")
       )
       tags "ViiteAPI - NodesAndJunctions"
-      summary "Checks if the junction points are on a road part that is reserved to a road address project."
+      summary "Validates if the junction points are editable."
     )
 
-  get("/junctions/getReservedStatusOfJunctionPoints", operation(getReservedStatusOfJunctionPoints)) {
+  get("/junctions/getEditableStatusOfJunctionPoints", operation(getEditableStatusOfJunctionPoints)) {
     response.setHeader("Access-Control-Allow-Headers", "*")
     val ids: Seq[Long] = params.get("ids") match {
       case Some(s) if s != "" => s.split("-").map(_.trim.toLong).toSeq
       case _ => Seq()
     }
-    time(logger, s"GET request for /junctions/getReservedStatusOfJunctionPoints/ (junctionPointIds: ${ids})") {
+    time(logger, s"GET request for /junctions/getEditableStatusOfJunctionPoints/ (junctionPointIds: ${ids})") {
+      val isOnAdministrativeClassChangingSpot = nodesAndJunctionsService.areJunctionPointsOnAdministrativeClassChangingSpot(ids)
       val isOnReservedPart  = nodesAndJunctionsService.areJunctionPointsOnReservedRoadPart(ids)
-      Map("success" -> true, "isOnReservedPart" -> isOnReservedPart)
+      val isOnRoadwayChangingSpot = nodesAndJunctionsService.areJunctionPointsOnRoadwayChangingSpot(ids) // TODO remove this check when VIITE-2524 gets implemented
+      val isEditableAndErrorMessage = {
+        if (isOnReservedPart)
+          (false, "Liittymäkohta sijaitsee tieosalla joka on varattuna tieosoiteprojektiin, liittymäkohdan muokkaus ei ole juuri nyt mahdollista.")
+        else if (isOnAdministrativeClassChangingSpot)
+          (false, "Liittymäkohta sijaitsee hallinnollisen luokan vaihtumiskohdassa, liittymäkohdan muokkaus ei ole sallittua.")
+        else if (isOnRoadwayChangingSpot) // TODO remove this when VIITE-2524 gets implemented
+          (false, "Liittymäkohdan muokkaus ei ole sallittua.")
+        else
+          (true, "")
+      }
+      Map("success" -> true, "isEditable" -> isEditableAndErrorMessage._1, "errorMessage" -> isEditableAndErrorMessage._2)
     }
   }
 

--- a/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
+++ b/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
@@ -902,7 +902,7 @@ class ViiteApi(val roadLinkService: RoadLinkService, val vVHClient: VVHClient,
         queryParam[Long]("ids").description("Junction point id:s")
       )
       tags "ViiteAPI - NodesAndJunctions"
-      summary "Validates if the junction points are editable."
+      summary "Validates the junction points' editability."
     )
 
   get("/junctions/getEditableStatusOfJunctionPoints", operation(getEditableStatusOfJunctionPoints)) {
@@ -917,11 +917,11 @@ class ViiteApi(val roadLinkService: RoadLinkService, val vVHClient: VVHClient,
       val isOnRoadwayChangingSpot = nodesAndJunctionsService.areJunctionPointsOnRoadwayChangingSpot(ids) // TODO remove this check when VIITE-2524 gets implemented
       val isEditableAndValidationMessage = {
         if (isOnReservedPart)
-          (false, "Liittymäkohta sijaitsee tieosalla joka on varattuna tieosoiteprojektiin, liittymäkohdan muokkaus ei ole juuri nyt mahdollista.")
+          (false, "Liittymäkohta sijaitsee tieosalla joka on varattuna tieosoiteprojektiin, liittymäkohdan etäisyyden muokkaus ei ole juuri nyt mahdollista.")
         else if (isOnAdministrativeClassChangingSpot)
-          (false, "Liittymäkohta sijaitsee hallinnollisen luokan vaihtumiskohdassa, liittymäkohdan muokkaus ei ole sallittua.")
+          (false, "Liittymäkohta sijaitsee hallinnollisen luokan vaihtumiskohdassa, liittymäkohdan etäisyyden muokkaus ei ole sallittua.")
         else if (isOnRoadwayChangingSpot) // TODO remove this when VIITE-2524 gets implemented
-          (false, "Liittymäkohdan muokkaus ei ole sallittua.")
+          (false, "Tämän liittymäkohdan etäisyyden muokkaus ei ole mahdollista tien tietojen sisäisestä rakenteesta johtuen. Jos etäisyys on välttämätön muuttaa, ota yhteys Viitteen tukeen.")
         else
           (true, "")
       }

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/NodesAndJunctionsService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/NodesAndJunctionsService.scala
@@ -162,32 +162,27 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
   def areJunctionPointsOnRoadwayChangingSpot(junctionPointIds: Seq[Long]): Boolean = {
     withDynSession {
       val junctionPoints = junctionPointDAO.fetchByIds(junctionPointIds)
-      val roadwayPoints = junctionPoints.map(jp => roadwayPointDAO.fetch(jp.roadwayPointId))
-      val roadwayNumbers = roadwayPoints.map(rwp => rwp.roadwayNumber).toSet
-      val roadways = roadwayDAO.fetchAllByRoadwayNumbers(roadwayNumbers)
-      if (roadways.size < 2) {
+      val roadwayNumbers = junctionPoints.map(jp => jp.roadwayNumber).toSet
+      if (roadwayNumbers.size < 2)
         false
-      } else {
+      else
         true
-      }
     }
   }
 
   def areJunctionPointsOnAdministrativeClassChangingSpot(junctionPointIds: Seq[Long]): Boolean = {
     withDynSession {
       val junctionPoints = junctionPointDAO.fetchByIds(junctionPointIds)
-      val roadwayPoints = junctionPoints.map(jp => roadwayPointDAO.fetch(jp.roadwayPointId))
-      val roadwayNumbers = roadwayPoints.map(rwp => rwp.roadwayNumber).toSet
-      val roadways = roadwayDAO.fetchAllByRoadwayNumbers(roadwayNumbers)
-      if (roadways.size < 2) {
+      val roadwayNumbers = junctionPoints.map(jp => jp.roadwayNumber).toSet
+      if (roadwayNumbers.size < 2)
         false
-      } else {
+      else {
+        val roadways = roadwayDAO.fetchAllByRoadwayNumbers(roadwayNumbers)
         val adminClasses = roadways.map(rw => rw.administrativeClass).toSet
-        if (adminClasses.size > 1) {
+        if (adminClasses.size > 1)
           true
-        } else {
+        else
           false
-        }
       }
     }
   }

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/NodesAndJunctionsService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/NodesAndJunctionsService.scala
@@ -158,11 +158,41 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
     }
   }
 
-  private def handleJunctionPointUpdate(junctionId: Long, oldJunctionPoint: JunctionPoint, newJunctionPoint: JunctionPoint, username: String): JunctionPoint = {
-    // TODO Check that the address change is within acceptable boundaries:
-    // - Less than 10 meters from the address calculated at this point if there were no calibration point here
-    // - Within the address range of the neighbouring links
+  // TODO remove this function and its usages when VIITE-2524 gets implemented
+  def areJunctionPointsOnRoadwayChangingSpot(junctionPointIds: Seq[Long]): Boolean = {
+    withDynSession {
+      val junctionPoints = junctionPointDAO.fetchByIds(junctionPointIds)
+      val roadwayPoints = junctionPoints.map(jp => roadwayPointDAO.fetch(jp.roadwayPointId))
+      val roadwayNumbers = roadwayPoints.map(rwp => rwp.roadwayNumber).toSet
+      val roadways = roadwayDAO.fetchAllByRoadwayNumbers(roadwayNumbers)
+      if (roadways.size < 2) {
+        false
+      } else {
+        true
+      }
+    }
+  }
 
+  def areJunctionPointsOnAdministrativeClassChangingSpot(junctionPointIds: Seq[Long]): Boolean = {
+    withDynSession {
+      val junctionPoints = junctionPointDAO.fetchByIds(junctionPointIds)
+      val roadwayPoints = junctionPoints.map(jp => roadwayPointDAO.fetch(jp.roadwayPointId))
+      val roadwayNumbers = roadwayPoints.map(rwp => rwp.roadwayNumber).toSet
+      val roadways = roadwayDAO.fetchAllByRoadwayNumbers(roadwayNumbers)
+      if (roadways.size < 2) {
+        false
+      } else {
+        val adminClasses = roadways.map(rw => rw.administrativeClass).toSet
+        if (adminClasses.size > 1) {
+          true
+        } else {
+          false
+        }
+      }
+    }
+  }
+
+  private def handleJunctionPointUpdate(junctionId: Long, oldJunctionPoint: JunctionPoint, newJunctionPoint: JunctionPoint, username: String): JunctionPoint = {
     // Update JunctionPoint and CalibrationPoint addresses by pointing them to another RoadwayPoint
     val roadwayPointId = getRoadwayPointId(newJunctionPoint.roadwayNumber, newJunctionPoint.addrM, username)
     CalibrationPointsUtils.updateCalibrationPointAddress(oldJunctionPoint.roadwayPointId, roadwayPointId, username)

--- a/viite-UI/src/utils/backend-utils.js
+++ b/viite-UI/src/utils/backend-utils.js
@@ -274,9 +274,9 @@
       $.getJSON('api/viite/project/recalculateProject/' + id, callback);
     };
 
-    this.getJunctionPointReservedStatus = function (ids, jp) {
-      $.get('api/viite/junctions/getReservedStatusOfJunctionPoints?ids=' + ids, function (response) {
-        eventbus.trigger('junctionPoint:reservedStatusFetched', response, jp);
+    this.getJunctionPointEditableStatus = function (ids, jp) {
+      $.get('api/viite/junctions/getEditableStatusOfJunctionPoints?ids=' + ids, function (response) {
+        eventbus.trigger('junctionPoint:editableStatusFetched', response, jp);
       });
     };
 

--- a/viite-UI/src/view/NodeForm.js
+++ b/viite-UI/src/view/NodeForm.js
@@ -173,14 +173,14 @@
 
 
       /**
-       * If the junction point is on a reserved road part
+       * If the junction point has a validation error
        * set the title attribute to notify the user and keep the input field disabled.
        * Otherwise enable the input field.
        */
-      eventbus.on('junctionPoint:reservedStatusFetched', function(response, jp) {
+      eventbus.on('junctionPoint:editableStatusFetched', function(response, jp) {
         var validationMessage = '';
-        if (response.isOnReservedPart) {
-          validationMessage = 'Liittymäkohta sijaitsee tieosalla joka on varattuna tieosoiteprojektiin, liittymäkohdan muokkaus ei ole juuri nyt mahdollista';
+        if (!response.isEditable) {
+          validationMessage = response.errorMessage;
         }
         var inputField = $('#junction-point-address-input-' + jp.id);
         if(validationMessage.length === 0){
@@ -227,7 +227,7 @@
       };
 
       var junctionPointInputAddr = function (jp) {
-        backend.getJunctionPointReservedStatus(jp.id, jp);
+        backend.getJunctionPointEditableStatus(jp.id, jp);
 
         var range = getAllowedAddrEditRange(jp);
         var minAddr = range.minAddr;

--- a/viite-UI/src/view/NodeForm.js
+++ b/viite-UI/src/view/NodeForm.js
@@ -180,7 +180,7 @@
       eventbus.on('junctionPoint:editableStatusFetched', function(response, jp) {
         var validationMessage = '';
         if (!response.isEditable) {
-          validationMessage = response.errorMessage;
+          validationMessage = response.validationMessage;
         }
         var inputField = $('#junction-point-address-input-' + jp.id);
         if(validationMessage.length === 0){


### PR DESCRIPTION


Disable manual editing of junction point addr values if the junction points are located in between two different administrative classes.

Temporarily disabled junction point addr editing if the junction points are located in between two different roadways. (Until VIITE-2524 is done)

Some refactoring
Removed obsolete TODO comment