### PR TITLE
VIITE-2764 date-parameter for /integration/summary API

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
@@ -275,13 +275,15 @@ class RoadAddressService(roadLinkService: RoadLinkService, roadwayDAO: RoadwayDA
     }
   }
 
- /**
+  /**
+   * @param  date OPTIONAL: Fetches summary data for the road address information
+   *         of the whole road network at a specific time.
    * @return Returns summary data for the road address information
    *         of the whole road network.
    */
-  def getAllRoadAddresses(): Seq[RoadwayNetworkSummaryRow] = {
+  def getRoadwayNetworkSummary(date: Option[DateTime] = None): Seq[RoadwayNetworkSummaryRow] = {
     withDynSession {
-      roadNetworkDAO.fetchRoadwayNetworkSummary
+      roadNetworkDAO.fetchRoadwayNetworkSummary(date)
     }
   }
 

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadNetworkDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadNetworkDAO.scala
@@ -124,16 +124,20 @@ class RoadNetworkDAO {
     */
   def fetchRoadwayNetworkSummary(date: Option[DateTime] = None): Seq[RoadwayNetworkSummaryRow] = {
     time(logger, "Get whole network summary") {
-      val (dateFilter, roadnameTable) = date match {
+      val dateFilter = date match {
         case Some(date) =>
           val dateString = date.toString("yyyy-MM-dd")
-          val datefilter =  s"r.START_DATE <= to_date('$dateString', 'yyyy-MM-dd') " +
+          s"r.START_DATE <= to_date('$dateString', 'yyyy-MM-dd') " +
           s"AND (r.END_DATE IS NULL OR to_date('$dateString', 'yyyy-MM-dd') <= r.END_DATE) "
+        case None => "r.END_DATE IS NULL"
+      }
 
-          val roadnamefilter = s"(SELECT * FROM ROAD_NAME rn WHERE rn.START_DATE <= to_date('$dateString', 'yyyy-MM-dd')" +
-            s"AND (rn.END_DATE IS NULL OR to_date('$dateString', 'yyyy-MM-dd') <= rn.END_DATE) and rn.VALID_TO IS NULL)"
-          (datefilter, roadnamefilter)
-        case None => ("r.END_DATE IS NULL", "(SELECT * FROM ROAD_NAME rn WHERE rn.END_DATE IS NULL)")
+      val roadnameTable = date match {
+        case Some(date) =>
+          val dateString = date.toString("yyyy-MM-dd")
+          s"(SELECT * FROM ROAD_NAME rn WHERE rn.START_DATE <= to_date('$dateString', 'yyyy-MM-dd')" +
+          s"AND (rn.END_DATE IS NULL OR to_date('$dateString', 'yyyy-MM-dd') <= rn.END_DATE) and rn.VALID_TO IS NULL)"
+        case None => "(SELECT * FROM ROAD_NAME rn WHERE rn.END_DATE IS NULL)"
       }
 
       val query = s"""


### PR DESCRIPTION
Road_name table contains multiple entries for roadnumbers so there is a need to ensure that only one road_name table entry is selected for each roadnumber in order to avoid duplicates in the roadway network summary.