### PR TITLE
VIITE-2760 Fix roadways history to prevent duplicates and split when change only…

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadwayDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadwayDAO.scala
@@ -1,15 +1,13 @@
 package fi.liikennevirasto.viite.dao
 
 import com.github.tototoshi.slick.MySQLJodaSupport._
-import fi.liikennevirasto.digiroad2.GeometryUtils
+import fi.liikennevirasto.digiroad2.{GeometryUtils, Point, Vector3d}
+import fi.liikennevirasto.digiroad2.asset.{AdministrativeClass, LinkGeomSource, SideCode}
 import fi.liikennevirasto.digiroad2.asset.SideCode.AgainstDigitizing
-import fi.liikennevirasto.digiroad2.asset.{LinkGeomSource, SideCode}
 import fi.liikennevirasto.digiroad2.dao.{Queries, Sequences}
 import fi.liikennevirasto.digiroad2.postgis.MassQuery
 import fi.liikennevirasto.digiroad2.util.LogUtils.time
 import fi.liikennevirasto.digiroad2.util.Track
-import fi.liikennevirasto.digiroad2.{Point, Vector3d}
-import fi.liikennevirasto.viite.AddressConsistencyValidator.{AddressError, AddressErrorDetails}
 import fi.liikennevirasto.viite._
 import fi.liikennevirasto.viite.dao.CalibrationPointDAO.CalibrationPointType
 import fi.liikennevirasto.viite.dao.CalibrationPointDAO.CalibrationPointType.NoCP
@@ -21,9 +19,8 @@ import org.joda.time.DateTime
 import org.joda.time.format.{DateTimeFormatter, ISODateTimeFormat}
 import org.slf4j.LoggerFactory
 import slick.driver.JdbcDriver.backend.Database.dynamicSession
-import slick.jdbc.StaticQuery.interpolation
 import slick.jdbc.{GetResult, PositionedResult, StaticQuery => Q}
-import fi.liikennevirasto.digiroad2.asset.AdministrativeClass
+import slick.jdbc.StaticQuery.interpolation
 
 //JATKUVUUS (1 = Tien loppu, 2 = epäjatkuva (esim. vt9 välillä Akaa-Tampere), 3 = ELY:n raja, 4 = Lievä epäjatkuvuus (esim kiertoliittymä), 5 = jatkuva)
 sealed trait Discontinuity {
@@ -1002,7 +999,7 @@ class RoadwayDAO extends BaseDAO {
       roadwayPS.setInt(5, address.track.value)
       roadwayPS.setLong(6, address.startAddrMValue)
       roadwayPS.setLong(7, address.endAddrMValue)
-      roadwayPS.setInt(8, if (address.reversed && !address.endDate.isEmpty) 1 else 0)
+      roadwayPS.setInt(8, if (address.reversed) 1 else 0)
       roadwayPS.setInt(9, address.discontinuity.value)
       roadwayPS.setDate(10, new java.sql.Date(address.startDate.getMillis))
       if (address.endDate.isDefined) {


### PR DESCRIPTION
Fix roadways history to prevent duplicates and split when change only part of the roadway i.e. Administrative class change in the middle.