### PR TITLE
VIITE-2714 allow reversing when the change type is New

### DIFF
--- a/viite-UI/src/view/FormCommon.js
+++ b/viite-UI/src/view/FormCommon.js
@@ -214,7 +214,7 @@
       const reversedInGroup = _.uniq(_.map(selected, 'reversed'));
       const isPartialReversed = reversedInGroup.length > 1;
       return '<div hidden class="' + prefix + 'form-group changeDirectionDiv" style="margin-top:15px">' +
-        '<button disabled title="Tieosoitteen kääntö ominaisuus on tilapäisesti poissa käytöstä" id="changeDirectionButton" class="' + prefix + 'form-group changeDirection btn btn-primary">Käännä tieosan kasvusuunta</button>' +
+        '<button id="changeDirectionButton" class="' + prefix + 'form-group changeDirection btn btn-primary">Käännä tieosan kasvusuunta</button>' +
         directionChangedInfo(selected, isPartialReversed) +
         '</div>';
     };

--- a/viite-UI/src/view/ProjectEditForm.js
+++ b/viite-UI/src/view/ProjectEditForm.js
@@ -201,6 +201,7 @@
         case LinkStatus.Transfer.value:
           dropdown_0_new.prop('disabled', true);
           $("#dropDown_0 option[value=" + LinkStatus.Transfer.description + "]").attr('selected', 'selected').change();
+          rootElement.find('.changeDirectionDiv').prop("hidden", true); // TODO remove this line when Velho integration can handle road reversing
           break;
         case LinkStatus.Numbering.value:
           $("#dropDown_0 option[value=" + LinkStatus.Numbering.description + "]").attr('selected', 'selected').change();


### PR DESCRIPTION
Reversing is temporarily disabled. Fixed the code to enable reversing when the change type is New and hide the reverse button if the change type is Transfer.