### PR TITLE
VIITE-2777 temporarily block user from making a "repair project"

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -339,6 +339,11 @@ class ProjectService(roadAddressService: RoadAddressService, roadLinkService: Ro
       filterNot(_._2.isEmpty).foreach {
       case ((roadNumber, roadPartNumber), value) =>
         val (startDate, endDate) = value.map(v => (v._6, v._7)).get
+        // TODO remove this when VIITE-2772 is fixed
+        if (startDate.nonEmpty && startDate.get.isEqual(date))
+          return Option(s"Tieosalla TIE $roadNumber OSA $roadPartNumber alkupäivämäärä " +
+          s"${startDate.get.toString("dd.MM.yyyy")} on sama kuin tieosoiteprojektin alkupäivämäärä " +
+          s"${date.toString("dd.MM.yyyy")}. Tieosoite projektin korjaus -ominaisuus on tilapäisesti poissa käytöstä. Ota yhteys Viite tukeen.")
         if (startDate.nonEmpty && startDate.get.isAfter(date))
           return Option(s"Tieosalla TIE $roadNumber OSA $roadPartNumber alkupäivämäärä " +
             s"${startDate.get.toString("dd.MM.yyyy")} on myöhempi kuin tieosoiteprojektin alkupäivämäärä " +

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
@@ -3028,7 +3028,7 @@ class ProjectServiceSpec extends FunSuite with Matchers with BeforeAndAfter {
       linearLocationDAO.create(linearLocations)
 
       val rap = Project(0L, ProjectState.apply(1), "TestProject", "TestUser", DateTime.now(),
-        "TestUser", DateTime.now(), DateTime.now(), "Some additional info",
+        "TestUser", DateTime.now().plusDays(5), DateTime.now(), "Some additional info",
         Seq(), Seq(), None)
       val project = projectService.createRoadLinkProject(rap)
       val project_id = project.id


### PR DESCRIPTION
Disabled the ability to reserve road part if the project start date is the same as the road parts' start date.

Fixed tests' project start date to be 5 days in to the future compared to the road parts start date.