### PR TITLE
VIITE-2806 fix obsolete history row bug

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/RoadwayFiller.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/RoadwayFiller.scala
@@ -191,10 +191,20 @@ object RoadwayFiller {
         currentRoadway.copy(id = NewIdValue, endDate = Some(projectStartDate.minusDays(1)), reversed = true) +: historyRoadways.map(hr => {
           hr.copy(id = NewIdValue, reversed = !hr.reversed)
         })
-      } else {
-        Seq(Roadway(NewIdValue, roadwayNumber, currentRoadway.roadNumber, currentRoadway.roadPartNumber, oldAdministrativeClass, currentRoadway.track, lastProjectLink.originalDiscontinuity, newStartAddressM, newEndAddressM, reversed, currentRoadway.startDate, Some(projectStartDate.minusDays(1)), createdBy = currentRoadway.createdBy, currentRoadway.roadName, currentRoadway.ely, NoTermination, currentRoadway.validFrom, currentRoadway.validTo)) ++ updateAddrMValuesOfHistoryRows(projectLinks, currentRoadway, historyRoadways).map { historyRoadway =>
-          historyRoadway.copy(id = NewIdValue, roadwayNumber = newRoadway.roadwayNumber, createdBy = currentRoadway.createdBy, validFrom = newRoadway.validFrom)
-        }
+      }
+      else if (headProjectLink.roadNumber == currentRoadway.roadNumber && headProjectLink.roadPartNumber == currentRoadway.roadPartNumber && headProjectLink.track == currentRoadway.track
+                && projectLinks.head.startAddrMValue == newStartAddressM && projectLinks.last.endAddrMValue == newEndAddressM && !reversed && projectLinks.last.discontinuity == lastProjectLink.originalDiscontinuity
+                && headProjectLink.administrativeClass == oldAdministrativeClass && headProjectLink.ely == currentRoadway.ely) {
+                  // if there is no need for new history row then return empty Seq() and add existing history to it
+                  Seq() ++ updateAddrMValuesOfHistoryRows(projectLinks, currentRoadway, historyRoadways).map { historyRoadway =>
+                    historyRoadway.copy(id = NewIdValue, roadwayNumber = newRoadway.roadwayNumber, createdBy = currentRoadway.createdBy, validFrom = newRoadway.validFrom)
+                  }
+      }
+      else {
+          // create new history row and add existing history to it
+          Seq(Roadway(NewIdValue, roadwayNumber, currentRoadway.roadNumber, currentRoadway.roadPartNumber, oldAdministrativeClass, currentRoadway.track, lastProjectLink.originalDiscontinuity, newStartAddressM, newEndAddressM, reversed, currentRoadway.startDate, Some(projectStartDate.minusDays(1)), createdBy = currentRoadway.createdBy, currentRoadway.roadName, currentRoadway.ely, NoTermination, currentRoadway.validFrom, currentRoadway.validTo)) ++ updateAddrMValuesOfHistoryRows(projectLinks, currentRoadway, historyRoadways).map { historyRoadway =>
+            historyRoadway.copy(id = NewIdValue, roadwayNumber = newRoadway.roadwayNumber, createdBy = currentRoadway.createdBy, validFrom = newRoadway.validFrom)
+          }
       }
     }
 

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/RoadwayFillerSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/RoadwayFillerSpec.scala
@@ -639,8 +639,8 @@ class RoadwayFillerSpec extends FunSuite with Matchers with BeforeAndAfter {
     }
   }
   test("Test RoadwayFiller.applyRoadwayChanges()" +
-    "When a single roadway (without history) is split to two roadways" +
-    "Then both split roadways will get a history row of their own") {
+    "When a single roadway (without history) is split to two roadways, but the first roadway has no changes" +
+    "Then only the roadway with the changes will get a history row") {
 
     /**
       * BEFORE PROJECT
@@ -652,7 +652,7 @@ class RoadwayFillerSpec extends FunSuite with Matchers with BeforeAndAfter {
       *                 Roadway Number 1                                    Roadway Number 2
       *  0 |----------------RoadPart 1------------------> 370    0 |---------RoadPart 2-------------> 175   New current roadways
       *
-      *  0 |----------------RoadPart 1------------------> 370  370 |---------RoadPart 1-------------> 545   After project created history roadways
+      *                                                        370 |---------RoadPart 1-------------> 545   After project created history roadway
       *
       * */
 
@@ -685,7 +685,7 @@ class RoadwayFillerSpec extends FunSuite with Matchers with BeforeAndAfter {
       val splitRoadways1 = resultRoadways.filter(rw => rw.roadwayNumber == newRoadwayNumber1)
       val splitRoadways2 = resultRoadways.filter(rw => rw.roadwayNumber == newRoadwayNumber2)
 
-      splitRoadways1 should have size 2
+      splitRoadways1 should have size 1
       splitRoadways2 should have size 2
 
       val (newSplitRoadway1, historyRoadway1) = splitRoadways1.partition(rw => rw.endDate.isEmpty && rw.validTo.isEmpty)
@@ -696,10 +696,7 @@ class RoadwayFillerSpec extends FunSuite with Matchers with BeforeAndAfter {
       newSplitRoadway1.head.endAddrMValue should be (370)
       newSplitRoadway1.head.roadPartNumber should be (1)
 
-      historyRoadway1 should have size 1
-      historyRoadway1.head.startAddrMValue should be (0)
-      historyRoadway1.head.endAddrMValue should be (370)
-      historyRoadway1.head.roadPartNumber should be (1)
+      historyRoadway1 should have size 0
 
       newSplitRoadway2 should have size 1
       newSplitRoadway2.head.startAddrMValue should be (0)
@@ -776,7 +773,7 @@ class RoadwayFillerSpec extends FunSuite with Matchers with BeforeAndAfter {
 
   test("Test RoadwayFiller.applyRoadwayChanges()" +
     "When a single roadway (that has two history history rows) is split in to two roadways" +
-    "Then the history roadways should also be split to those two new roadways, and new history roadway should also be created for both of the split roadways") {
+    "Then the history roadways should also be split to those two new roadways, and new history roadway should be created for the roadway that had changes in the project") {
 
     /**
       * BEFORE PROJECT
@@ -792,8 +789,8 @@ class RoadwayFillerSpec extends FunSuite with Matchers with BeforeAndAfter {
       *         RoadwayNumber 1         RoadwayNumber 2
       *     0 |------RP3----> 120     0 |-------RP4-----> 55  Current Roadways (rw 99 is split in two)
       *
-      *     0 |----- RP3----> 120   120 |-------RP3-----> 175 After project created history rows
-      *     0 |------RP2----> 120   120 |-------RP2-----> 175 Second oldest history rows
+      *                             120 |-------RP3-----> 175 After project created new history row for Rw2
+      *     0 |------RP2----> 120   120 |-------RP2-----> 175 Rw1 newest history row and Rw2 second oldest history row
       *   370 |------RP1----> 490   490 |-------RP1-----> 545 Oldest history rows
       *
       *
@@ -828,24 +825,20 @@ class RoadwayFillerSpec extends FunSuite with Matchers with BeforeAndAfter {
       val resultRoadways = result.head._1
 
       val (roadwaysForRoadPart3, roadwaysForRoadPart4) = resultRoadways.partition(rw => rw.roadwayNumber == 1)
-      roadwaysForRoadPart3 should have size 4
+      roadwaysForRoadPart3 should have size 3
       roadwaysForRoadPart4 should have size 4
 
       val (roadPart3newRoadway, roadPart3HistoryRows) = roadwaysForRoadPart3.partition(rw => rw.endDate.isEmpty && rw.validTo.isEmpty)
       roadPart3newRoadway should have size 1
-      roadPart3HistoryRows should have size 3
+      roadPart3HistoryRows should have size 2
 
       roadPart3newRoadway.head.roadPartNumber should be (3)
       roadPart3newRoadway.head.startAddrMValue should be (0)
       roadPart3newRoadway.head.endAddrMValue should be (120)
 
-      roadPart3HistoryRows.head.roadPartNumber should be (3)
+      roadPart3HistoryRows.head.roadPartNumber should be (2)
       roadPart3HistoryRows.head.startAddrMValue should be (0)
       roadPart3HistoryRows.head.endAddrMValue should be (120)
-
-      roadPart3HistoryRows.tail.head.roadPartNumber should be (2)
-      roadPart3HistoryRows.tail.head.startAddrMValue should be (0)
-      roadPart3HistoryRows.tail.head.endAddrMValue should be (120)
 
       roadPart3HistoryRows.last.roadPartNumber should be (1)
       roadPart3HistoryRows.last.startAddrMValue should be (370)


### PR DESCRIPTION
Fixed a bug where when a roadway is split in two then Viite would create an obsolete history row

Fixed tests