### PR TITLE
Viite-2860 regex and complementary

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
@@ -87,6 +87,12 @@ class RoadLinkService(val kgvClient: KgvRoadLink, val eventbus: DigiroadEventBus
     }
   }
 
+  def getRoadLinkMiddlePointByComplementaryLinkId(complementaryLinkId: Long): Option[Point] = {
+    kgvClient.complementaryData.fetchByLinkId(complementaryLinkId.toString).flatMap { RoadLink =>
+      Option(GeometryUtils.midPointGeometry(RoadLink.geometry))
+    }
+  }
+
   def getRoadLinkByLinkId(linkId: String): Option[RoadLink] = getRoadLinksByLinkIds(Set(linkId)).headOption
 
   def getRoadLinksByLinkIds(linkIds: Set[String]): Seq[RoadLink] = {

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
@@ -330,9 +330,14 @@ class RoadAddressService(
       }
       case "road" => params.size match {
         case 1 =>
-          // The params with type long can be MTKID or roadNumber
+          // The params with type long can be MTKID, complementary VVH_id or roadNumber
           val searchResultPoint = roadLinkService.getRoadLinkMiddlePointBySourceId(params.head)
-          val partialResultSeq = collectResult("mtkId", Seq(searchResultPoint))
+          val partialResultSeq = if (searchResultPoint.nonEmpty)
+            collectResult("mtkId", Seq(searchResultPoint))
+          else {
+            val complementaryResultPoint = roadLinkService.getRoadLinkMiddlePointByComplementaryLinkId(params.head)
+            collectResult("linkId", Seq(complementaryResultPoint))
+          }
           val searchResult = getFirstOrEmpty(getRoadAddressWithRoadNumberAddress(params.head).sortBy(address => (address.roadPartNumber, address.startAddrMValue)))
           collectResult("road", searchResult, partialResultSeq)
         case 2 => collectResult("road", getFirstOrEmpty(getRoadAddressWithRoadNumberParts(params.head, Set(params(1)), Set(Track.Combined, Track.LeftSide, Track.RightSide)).sortBy(address => (address.roadPartNumber, address.startAddrMValue))))

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
@@ -330,7 +330,7 @@ class RoadAddressService(
       }
       case "road" => params.size match {
         case 1 =>
-          // The params with type long can be MTKID, complementary VVH_id or roadNumber
+          // The params with type long can be MTKID, complementary link id or roadNumber
           val searchResultPoint = roadLinkService.getRoadLinkMiddlePointBySourceId(params.head)
           val partialResultSeq = if (searchResultPoint.nonEmpty)
             collectResult("mtkId", Seq(searchResultPoint))

--- a/viite-UI/src/utils/LocationInputParser.js
+++ b/viite-UI/src/utils/LocationInputParser.js
@@ -9,10 +9,10 @@
     var matchedCoordinates = input.match(coordinateRegex);
     if (matchedCoordinates) {
       return parseCoordinates(matchedCoordinates);
-    } else if (input.match(wildLetterRegex)) {
-      return {type: 'street', search: input};
     } else if (input.match(roadNumberRegex) || input.match(linkIdRegex)) {
       return {type: 'road', search: input};
+    } else if (input.match(wildLetterRegex)) {
+      return {type: 'street', search: input};
     } else {
       return {type: 'invalid'};
     }


### PR DESCRIPTION
 changed regex ordering to enable searching with id's that start with a letter
Added a method to allow searching for a link from complementary link data with the old vvh id