### PR TITLE
VIITE-2906 fix fixture reset test

### DIFF
--- a/digiroad2-oracle/sql/test_fixture_sequences.sql
+++ b/digiroad2-oracle/sql/test_fixture_sequences.sql
@@ -66,7 +66,7 @@ drop sequence ROADWAY_NUMBER_SEQ;
 create sequence ROADWAY_NUMBER_SEQ
   minvalue 1
   no maxvalue
-  start with 1000000
+  start with 1010000
   increment by 1
   cache 100
   cycle;

--- a/digiroad2-viite/src/test/resources/clear-db.sql
+++ b/digiroad2-viite/src/test/resources/clear-db.sql
@@ -7,6 +7,7 @@
   from pg_sequences
   where schemaname = 'public';
 */
+drop table if exists complementary_link_table cascade;
 drop table if exists complementary_filter cascade;
 drop table if exists export_lock cascade;
 drop table if exists municipality cascade;


### PR DESCRIPTION
drop complementary_link_table when clearing db

increase roadway_number_seq so tests won't fail after fixture reset test