### PR TITLE
VIITE-2911 select newRoadway startDate based on changes made

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/RoadwayFiller.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/RoadwayFiller.scala
@@ -175,6 +175,8 @@ object RoadwayFiller {
                             headProjectLink.administrativeClass == oldAdministrativeClass &&
                             headProjectLink.ely == currentRoadway.ely
 
+    val newRoadwayStartDate = if (noChanges) currentRoadway.startDate else projectStartDate
+
     val newRoadway: Roadway = Roadway(
                             NewIdValue,
                             roadwayNumber,
@@ -186,7 +188,7 @@ object RoadwayFiller {
                             headProjectLink.startAddrMValue,
                             lastProjectLink.endAddrMValue,
                             false,
-                            projectStartDate,
+                            newRoadwayStartDate,
                             None,
                             createdBy = headProjectLink.createdBy.get,
                             currentRoadway.roadName,


### PR DESCRIPTION
Tiketissä VIITE-2806 toteutettu turhien historiarivien poisjättäminen tapauksessa, jossa roadwayn tiedot eivät ole muuttuneet tavalla, joka vaatisi historian säilyttämisen. Tämän muuttumattoman historiarivin poisjättämistä ei oltu huomioitu uuden roadwayn aloituspäivämäärässä.