### PR TITLE
VIITE-2876 fixed checkRemovedEndOfRoadParts to also not give a valida…

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectValidator.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectValidator.scala
@@ -797,6 +797,7 @@ class ProjectValidator {
       val validRoadParts = roadAddressService.getValidRoadAddressParts(terminatedEndOfRoad.roadNumber, project.startDate)
 
       validRoadParts.filter(roadPart => !roadPartNumbers.contains(roadPart)) match {
+        //All road parts for the road number are reserved in the project
         case Seq() => Seq()
         case roadParts =>
           projectLinksWithRoadNumber.filter(pl => pl.status != Terminated && pl.roadPartNumber >= roadParts.max) match {

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectValidator.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectValidator.scala
@@ -790,20 +790,20 @@ class ProjectValidator {
     * @return
     */
   def checkRemovedEndOfRoadParts(project: Project, projectLinks: Seq[ProjectLink]): Seq[ValidationErrorDetails] = {
-    projectLinks.filter(pl => pl.status == Terminated && pl.discontinuity == Discontinuity.EndOfRoad).flatMap { rrp =>
+    projectLinks.filter(pl => pl.status == Terminated && pl.discontinuity == Discontinuity.EndOfRoad).flatMap { terminatedEndOfRoad =>
 
-      val projectLinksWithRoadNumber = projectLinks.filter(_.roadNumber == rrp.roadNumber)
+      val projectLinksWithRoadNumber = projectLinks.filter(_.roadNumber == terminatedEndOfRoad.roadNumber)
       val roadPartNumbers = projectLinksWithRoadNumber.flatMap(pl => Seq(pl.roadPartNumber,pl.originalRoadPartNumber)).distinct
-      val validRoadParts = roadAddressService.getValidRoadAddressParts(rrp.roadNumber, project.startDate)
+      val validRoadParts = roadAddressService.getValidRoadAddressParts(terminatedEndOfRoad.roadNumber, project.startDate)
 
       validRoadParts.filter(roadPart => !roadPartNumbers.contains(roadPart)) match {
         case Seq() => Seq()
         case roadParts =>
           projectLinksWithRoadNumber.filter(pl => pl.status != Terminated && pl.roadPartNumber >= roadParts.max) match {
             case Seq() =>
-              val lastRoadAddress = roadAddressService.getRoadAddressWithRoadAndPart(rrp.roadNumber, roadParts.max).maxBy(_.endAddrMValue)
+              val lastRoadAddress = roadAddressService.getRoadAddressWithRoadAndPart(terminatedEndOfRoad.roadNumber, roadParts.max).maxBy(_.endAddrMValue)
               if (lastRoadAddress.discontinuity != Discontinuity.EndOfRoad)
-                Seq(ValidationErrorDetails(project.id, alterMessage(ValidationErrorList.TerminationContinuity, currentRoadAndPart = Some(Seq((rrp.roadNumber, lastRoadAddress.roadPartNumber)))), Seq(lastRoadAddress.id),
+                Seq(ValidationErrorDetails(project.id, alterMessage(ValidationErrorList.TerminationContinuity, currentRoadAndPart = Some(Seq((terminatedEndOfRoad.roadNumber, lastRoadAddress.roadPartNumber)))), Seq(lastRoadAddress.id),
                   Seq(ProjectCoordinates(lastRoadAddress.geometry.head.x, lastRoadAddress.geometry.head.y, defaultZoomlevel)), Some("")))
               else
                 Seq()


### PR DESCRIPTION
…tion error

Dev-ympäristö: Projekti VIITE-2876 lakkautettu 1130/9 ja asetettu 1130/8 jatkuvuuskoodiksi tien loppu. 
Antaa validaatiovirheen, että tieosan 1130/7 jatkuvuuskoodiksi pitää muuttaa tien loppu.

Korjattu tarkastamalla, ettei varattujen linkkien joukossa ole lakkauttamatonta linkkiä, jonka tieosa suurempi kuin projektiin varaamattomilla tieosilla.