### PR TITLE
VIITE-3003 upgraded geotools to version 27.2

### DIFF
--- a/aws/buildspec.yaml
+++ b/aws/buildspec.yaml
@@ -16,14 +16,6 @@ phases:
     commands:
       - pip install --upgrade awscli
       - $(aws ecr get-login --no-include-email --region eu-west-1)
-      - mkdir digiroad2-geo/lib
-      - aws s3 cp "s3://fi-viite-dev/geotools-19/gt-graph-19.0.jar" ./digiroad2-geo/lib
-      - aws s3 cp "s3://fi-viite-dev/geotools-19/gt-main-19.0.jar" ./digiroad2-geo/lib
-      - aws s3 cp "s3://fi-viite-dev/geotools-19/gt-api-19.0.jar" ./digiroad2-geo/lib
-      - aws s3 cp "s3://fi-viite-dev/geotools-19/gt-referencing-19.0.jar" ./digiroad2-geo/lib
-      - aws s3 cp "s3://fi-viite-dev/geotools-19/gt-metadata-19.0.jar" ./digiroad2-geo/lib
-      - aws s3 cp "s3://fi-viite-dev/geotools-19/gt-opengis-19.0.jar" ./digiroad2-geo/lib
-      - aws s3 cp "s3://fi-viite-dev/geotools-19/jgridshift-1.0.jar" ./digiroad2-geo/lib
       - rm -rf /etc/localtime && ln -s /usr/share/zoneinfo/Europe/Helsinki /etc/localtime
   build:
     commands:

--- a/aws/qa-buildspec.yaml
+++ b/aws/qa-buildspec.yaml
@@ -16,14 +16,6 @@ phases:
     commands:
       - pip install --upgrade awscli
       - $(aws ecr get-login --no-include-email --region eu-west-1)
-      - mkdir digiroad2-geo/lib
-      - aws s3 cp "s3://fi-viite-dev/geotools-19/gt-graph-19.0.jar" ./digiroad2-geo/lib
-      - aws s3 cp "s3://fi-viite-dev/geotools-19/gt-main-19.0.jar" ./digiroad2-geo/lib
-      - aws s3 cp "s3://fi-viite-dev/geotools-19/gt-api-19.0.jar" ./digiroad2-geo/lib
-      - aws s3 cp "s3://fi-viite-dev/geotools-19/gt-referencing-19.0.jar" ./digiroad2-geo/lib
-      - aws s3 cp "s3://fi-viite-dev/geotools-19/gt-metadata-19.0.jar" ./digiroad2-geo/lib
-      - aws s3 cp "s3://fi-viite-dev/geotools-19/gt-opengis-19.0.jar" ./digiroad2-geo/lib
-      - aws s3 cp "s3://fi-viite-dev/geotools-19/jgridshift-1.0.jar" ./digiroad2-geo/lib
       - rm -rf /etc/localtime && ln -s /usr/share/zoneinfo/Europe/Helsinki /etc/localtime
   build:
     commands:

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/GraphPartitioner.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/GraphPartitioner.scala
@@ -1,5 +1,5 @@
 package fi.liikennevirasto.digiroad2.linearasset
-import com.vividsolutions.jts.geom.LineSegment
+import org.locationtech.jts.geom.LineSegment
 import fi.liikennevirasto.digiroad2.GeometryUtils
 import org.geotools.graph.build.line.BasicLineGraphGenerator
 import org.geotools.graph.structure.Graph

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/client/KGVClientSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/client/KGVClientSpec.scala
@@ -1,6 +1,6 @@
 package fi.liikennevirasto.digiroad2.client
 
-import com.vividsolutions.jts.geom.GeometryFactory
+import org.locationtech.jts.geom.GeometryFactory
 import fi.liikennevirasto.digiroad2.Point
 import fi.liikennevirasto.digiroad2.asset.BoundingRectangle
 import fi.liikennevirasto.digiroad2.client.kgv.KgvRoadLink

--- a/project/build.scala
+++ b/project/build.scala
@@ -26,6 +26,8 @@ object Digiroad2Build extends Build {
   val JettyVersion = "9.2.15.v20160210"
   val TestOutputOptions = Tests.Argument(TestFrameworks.ScalaTest, "-oNCXELOPQRMI") // List only problems, and their summaries. Set suitable logback level to get the effect.
   val AwsSdkVersion = "2.17.148"
+  val GeoToolsVersion = "27.2"
+  val GeoToolsApiVersion = "20.5" //latest version of GeoToolsApi
 
   // Get build id to check if executing in aws environment.
   val awsBuildId: String = scala.util.Properties.envOrElse("CODEBUILD_BUILD_ID", null)
@@ -48,14 +50,14 @@ object Digiroad2Build extends Build {
             "joda-time" % "joda-time" % JodaTimeVersion,
             "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
             "javax.media" % "jai_core" % "1.1.3" from "https://repo.osgeo.org/repository/release/javax/media/jai_core/1.1.3/jai_core-1.1.3.jar",
-            "org.geotools" % "gt-graph" % "19.0" from "http://livibuild04.vally.local/nexus/repository/maven-public/org/geotools/gt-graph/19.0/gt-graph-19.0.jar",
-            "org.geotools" % "gt-main" % "19.0" from "http://livibuild04.vally.local/nexus/repository/maven-public/org/geotools/gt-main/19.0/gt-main-19.0.jar",
-            "org.geotools" % "gt-api" % "19.0" from "http://livibuild04.vally.local/nexus/repository/maven-public/org/geotools/gt-api/19.0/gt-api-19.0.jar",
-            "org.geotools" % "gt-referencing" % "19.0" from "http://livibuild04.vally.local/nexus/repository/maven-public/org/geotools/gt-referencing/19.0/gt-referencing-19.0.jar",
-            "org.geotools" % "gt-metadata" % "19.0" from "http://livibuild04.vally.local/nexus/repository/maven-public/org/geotools/gt-metadata/19.0/gt-metadata-19.0.jar",
-            "org.geotools" % "gt-opengis" % "19.0" from "http://livibuild04.vally.local/nexus/repository/maven-public/org/geotools/gt-opengis/19.0/gt-opengis-19.0.jar",
+            "org.geotools" % "gt-graph" % GeoToolsVersion from s"https://repo.osgeo.org/repository/release/org/geotools/gt-graph/$GeoToolsVersion/gt-graph-$GeoToolsVersion.jar",
+            "org.geotools" % "gt-main" % GeoToolsVersion from s"https://repo.osgeo.org/repository/release/org/geotools/gt-main/$GeoToolsVersion/gt-main-$GeoToolsVersion.jar",
+            "org.geotools" % "gt-api" % GeoToolsApiVersion from s"https://repo.osgeo.org/repository/geotools-releases/org%2Fgeotools%2Fgt-api%2F$GeoToolsApiVersion%2Fgt-api-$GeoToolsApiVersion.jar",
+            "org.geotools" % "gt-referencing" % GeoToolsVersion from s"https://repo.osgeo.org/repository/release/org/geotools/gt-referencing/$GeoToolsVersion/gt-referencing-$GeoToolsVersion.jar",
+            "org.geotools" % "gt-metadata" % GeoToolsVersion from s"https://repo.osgeo.org/repository/release/org/geotools/gt-metadata/$GeoToolsVersion/gt-metadata-$GeoToolsVersion.jar",
+            "org.geotools" % "gt-opengis" % GeoToolsVersion from s"https://repo.osgeo.org/repository/release/org/geotools/gt-opengis/$GeoToolsVersion/gt-opengis-$GeoToolsVersion.jar",
             "jgridshift" % "jgridshift" % "1.0" from "https://repo.osgeo.org/repository/release/jgridshift/jgridshift/1.0/jgridshift-1.0.jar",
-            "com.vividsolutions" % "jts-core" % "1.14.0" from "http://livibuild04.vally.local/nexus/repository/maven-public/com/vividsolutions/jts-core/1.14.0/jts-core-1.14.0.jar",
+            "org.locationtech.jts" % "jts-core" % "1.18.2" from "https://repo1.maven.org/maven2/org/locationtech/jts/jts-core/1.18.2/jts-core-1.18.2.jar",
             "org.scalatest" % "scalatest_2.11" % ScalaTestVersion % "test"
           )
         )
@@ -78,7 +80,7 @@ object Digiroad2Build extends Build {
             "joda-time" % "joda-time" % JodaTimeVersion,
             "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
             "javax.media" % "jai_core" % "1.1.3" from "https://repo.osgeo.org/repository/release/javax/media/jai_core/1.1.3/jai_core-1.1.3.jar",
-            "com.vividsolutions" % "jts-core" % "1.14.0",
+            "org.locationtech.jts" % "jts-core" % "1.18.2" from "https://repo1.maven.org/maven2/org/locationtech/jts/jts-core/1.18.2/jts-core-1.18.2.jar",
             "org.scalatest" % "scalatest_2.11" % ScalaTestVersion % "test"
           )
         )

--- a/sbt.bat
+++ b/sbt.bat
@@ -123,7 +123,7 @@ goto end
 
 :run
 
-"%_JAVACMD%" %_JAVA_OPTS% %SBT_OPTS% -cp "%SBT_HOME%sbt-launch.jar" xsbt.boot.Boot %*
+"%_JAVACMD%" %_JAVA_OPTS% %SBT_OPTS% -cp "%SBT_HOME%/bin/sbt-launch.jar" xsbt.boot.Boot %*
 goto :eof
 
 :process

--- a/viite-UI/tmpl/index.html
+++ b/viite-UI/tmpl/index.html
@@ -99,7 +99,6 @@
 <script type="text/javascript" src="src/view/ProjectLinkStyler.js"></script>
 <script type="text/javascript" src="src/view/RoadLayer.js"></script>
 <script type="text/javascript" src="src/view/ProjectLinkLayer.js"></script>
-<script type="text/javascript" src="src/view/RoadLayerSelectionStyle.js"></script>
 <script type="text/javascript" src="src/view/MapView.js"></script>
 <script type="text/javascript" src="src/view/MapOverlay.js"></script>
 <script type="text/javascript" src="src/view/CoordinatesDisplay.js"></script>


### PR DESCRIPTION
upgraded jts-core to 1.18.2

fixed reference to /bin/sbt-launch.jar

removed reference to deleted RoadLayerSelectionStyle.js

NOTE:
Might have to clear geotools and jts-core from C:\Users\<USERNAME>\.ivy2\cache and building project with ./sbt.bat to download the upgraded version.