### PR TITLE
VIITE-3009 Updating: Postgis-jdbc & Postgresql, adding Postgis-geometry

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/ComplementaryLinkDAO.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/ComplementaryLinkDAO.scala
@@ -8,7 +8,7 @@ import fi.liikennevirasto.digiroad2.linearasset.RoadLink
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import org.joda.time.format.{DateTimeFormatter, ISODateTimeFormat}
 import org.joda.time.DateTime
-import org.postgis.PGgeometry
+import net.postgis.jdbc.geometry.GeometryBuilder
 import org.slf4j.LoggerFactory
 import slick.driver.JdbcDriver.backend.Database.dynamicSession
 import slick.jdbc.{GetResult, PositionedResult, StaticQuery => Q}
@@ -61,15 +61,16 @@ class ComplementaryLinkDAO {
       val modifiedAt = extractModifiedAt(Map(
         "starttime"              -> r.nextDateOption.map(d => formatter.parseDateTime(d.toString)),
         "versionstarttime"       -> r.nextDateOption.map(d => formatter.parseDateTime(d.toString)),
-        "sourcemodificationtime" -> r.nextDateOption.map(d => formatter.parseDateTime(d.toString)
-      ))).map(_.toString())
+        "sourcemodificationtime" -> r.nextDateOption.map(d => formatter.parseDateTime(d.toString))
+      )).map(_.toString())
 
-      val geom = PGgeometry.geomFromString(r.nextString())
+      val geom = GeometryBuilder.geomFromString(r.nextString())
       var geometry: Seq[Point] = Seq()
       for (i <- 1 to geom.numPoints()) {
         val point = geom.getPoint(i - 1)
         geometry = geometry :+ Point(point.x, point.y, point.z)
       }
+
       RoadLink(linkId, geometry, length, administrativeClass, TrafficDirection.UnknownDirection, modifiedAt, None, lifecycleStatus, LinkGeomSource.ComplementaryLinkInterface, municipalityCode, "")
     }
   }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/postgis/PostGISDatabase.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/postgis/PostGISDatabase.scala
@@ -1,7 +1,6 @@
 package fi.liikennevirasto.digiroad2.postgis
 
 import java.sql.Date
-
 import javax.sql.DataSource
 import com.jolbox.bonecp.{BoneCPConfig, BoneCPDataSource}
 import fi.liikennevirasto.digiroad2.asset.BoundingRectangle
@@ -9,7 +8,7 @@ import org.joda.time.LocalDate
 import slick.driver.JdbcDriver.backend.Database
 import fi.liikennevirasto.digiroad2.util.ViiteProperties
 import fi.liikennevirasto.digiroad2.{GeometryUtils, Point}
-import org.postgis.PGgeometry
+import net.postgis.jdbc.geometry.GeometryBuilder
 import org.postgresql.util.PGobject
 
 object PostGISDatabase {
@@ -137,7 +136,7 @@ object PostGISDatabase {
   def loadJGeometryToGeometry(geometry: Option[Object]): Seq[Point] = {
     if (geometry.nonEmpty) {
       val pgObject = geometry.get.asInstanceOf[PGobject]
-      val geom = PGgeometry.geomFromString(pgObject.getValue)
+      val geom = GeometryBuilder.geomFromString(pgObject.getValue)
       val n = geom.numPoints()
       var points: Seq[Point] = Seq()
       for (i <- 1 to n) {

--- a/project/build.scala
+++ b/project/build.scala
@@ -92,8 +92,9 @@ object Digiroad2Build extends Build {
         "com.newrelic.agent.java" % "newrelic-api" % NewRelicApiVersion,
         "org.mockito" % "mockito-core" % MockitoCoreVersion % "test",
         "com.googlecode.flyway" % "flyway-core" % "2.3.1",
-        "org.postgresql" % "postgresql" % "42.2.5",
-        "net.postgis" % "postgis-jdbc" % "2.3.0"
+        "org.postgresql" % "postgresql" % "42.2.27",
+        "net.postgis" % "postgis-geometry" % "2021.1.0",
+        "net.postgis" % "postgis-jdbc" % "2021.1.0" // dep postgresql, and from 2.5.0 and up: postgis-geometry
       ),
       unmanagedResourceDirectories in Compile += baseDirectory.value / ".." / "conf"
     )


### PR DESCRIPTION
VIITE-3009 library updates: Updating: Postgis-jdbc ->2021.1.0, and Postgresql -> 42.2.27. Adding Postgis-geometry 2021.1.0.

Postgis-jdbc 2.3.0 to the currently newest ->2021.1.0 (upd Aug 4, 2021), and Postgresql 42.2.5 to the currently newest 42.2 minor -> 42.2.27 (upd Nov 23, 2022). Postgis-geometry 2021.1.0 (upd Aug 05, 2021) added as Postgis-jdbc splitted to Postgis-jdbc, and Postgis-geometry at Postgis-jdbc 2.5.0.