### PR TITLE
VIITE-3046 RoadaddressChangesBrowser to include end date in the listing

### DIFF
--- a/viite-UI/src/utils/date-utils.js
+++ b/viite-UI/src/utils/date-utils.js
@@ -75,6 +75,11 @@
     return date.getFullYear() >= minYear && date.getFullYear() <= maxYear;
   };
 
+  /** Sets date to the next day */
+  dateUtils.addOneDayToDate = function (dateObject) {
+    dateObject.setDate(dateObject.getDate() + 1);
+  };
+
   /** Converts date object to string "yyyy-mm-dd" */
   dateUtils.parseDateToString = function (date) {
     const dayInNumber = date.getDate();

--- a/viite-UI/src/view/RoadAddressChangesBrowserWindow.js
+++ b/viite-UI/src/view/RoadAddressChangesBrowserWindow.js
@@ -172,9 +172,6 @@
                     if (roadAddrEndDateObject.getTime() < roadAddrStartDateObject.getTime()) {
                         roadAddrChangesEndDate.setCustomValidity("Loppupäivämäärä ei voi olla ennen alkupäivämäärää");
                     }
-                    if (roadAddrEndDateObject.getTime() === roadAddrStartDateObject.getTime()) {
-                        roadAddrChangesEndDate.setCustomValidity("Alku- ja loppupäivämäärä ei voi olla sama. Jos haluat vain yhden päivän tulokset, syötä peräkkäiset päivät.");
-                    }
                 }
                 return reportValidations();
             }
@@ -204,6 +201,10 @@
             roadAddrChangesEndDate.setCustomValidity("");
 
             if (willPassValidations())
+
+                //Sets the end date 1 day ahead, so that the inputted end date will be included in the projectlisting.
+                dateutil.addOneDayToDate(roadAddrEndDateObject);
+
                 fetchRoadAddressChanges(createParams());
         }
 


### PR DESCRIPTION
Browser end-date changed to add 1 day to the end-date input, so that listing shows projects from the date selected as the listing's end-date.