### PR TITLE
Refactor multitude of runWithRollback functions to a single function

### DIFF
--- a/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/PingApi.scala
+++ b/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/PingApi.scala
@@ -8,10 +8,8 @@ import org.slf4j.LoggerFactory
 class PingApi extends ScalatraServlet {
   private val logger = LoggerFactory.getLogger(getClass)
 
-  def withDynSession[T](f: => T): T = PostGISDatabase.withDynSession(f)
-
   get("/") {
-    withDynSession {
+    PostGISDatabase.withDynSession {
       try {
         val dbTime = PingDAO.getDbTime
         Ok(s"OK (DB Time: $dbTime)\n")

--- a/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
+++ b/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
@@ -1144,7 +1144,6 @@ class ViiteApi(val roadLinkService: RoadLinkService, val KGVClient: KgvRoadLink,
       tags "ViiteAPI - Project"
       summary "Given a valid projectId, this will fetch all the changes made on said project."
     )
-  def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
 
   get("/project/getchangetable/:projectId", operation(returnChangeTableById)) {
     val projectId = params("projectId").toLong
@@ -1179,7 +1178,7 @@ class ViiteApi(val roadLinkService: RoadLinkService, val KGVClient: KgvRoadLink,
     val projectId = params("projectId").toLong
     time(logger, s"GET request for /project/recalculateProject/$projectId") {
       try {
-        val invalidUnchangedLinkErrors = withDynTransaction {
+        val invalidUnchangedLinkErrors = PostGISDatabase.withDynTransaction {
           val project = projectService.fetchProjectById(projectId).get
           val invalidUnchangedLinkErrors = projectService.projectValidator.checkForInvalidUnchangedLinks(project, projectLinkDAO.fetchProjectLinks(projectId))
           if (invalidUnchangedLinkErrors.isEmpty) {

--- a/viite-backend/api/src/test/scala/fi/liikennevirasto/digiroad2/ViiteApiSpec.scala
+++ b/viite-backend/api/src/test/scala/fi/liikennevirasto/digiroad2/ViiteApiSpec.scala
@@ -4,9 +4,10 @@ import fi.liikennevirasto.digiroad2.client.kgv.{KgvRoadLink, KgvRoadLinkClient}
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.user.{Configuration, User}
 import fi.liikennevirasto.digiroad2.Digiroad2Context._
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 import fi.liikennevirasto.viite.{NodesAndJunctionsService, PreFillInfo, ProjectService, RoadAddressService, RoadNameService, RoadNameSource, RoadNetworkValidator, ViiteVkmClient}
 import fi.liikennevirasto.viite.dao.ProjectLinkDAO
-import fi.liikennevirasto.viite.util.{DigiroadSerializers, JsonSerializer, runWithRollback}
+import fi.liikennevirasto.viite.util.{DigiroadSerializers, JsonSerializer}
 import fi.vaylavirasto.viite.dao.ComplementaryLinkDAO
 import fi.vaylavirasto.viite.geometry.{BoundingRectangle, Point}
 import fi.vaylavirasto.viite.model.{AdministrativeClass, LifecycleStatus, LinkGeomSource, RoadLink, TrafficDirection}

--- a/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/postgis/DbUtils.scala
+++ b/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/postgis/DbUtils.scala
@@ -1,6 +1,6 @@
 package fi.vaylavirasto.viite.postgis
 
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+//import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import slick.driver.JdbcDriver.backend.Database.dynamicSession
 import slick.jdbc.StaticQuery.interpolation
 

--- a/viite-backend/database/src/test/scala/fi/vaylavirasto/viite/dao/MunicipalityDaoSpec.scala
+++ b/viite-backend/database/src/test/scala/fi/vaylavirasto/viite/dao/MunicipalityDaoSpec.scala
@@ -1,22 +1,13 @@
 package fi.vaylavirasto.viite.dao
 
 import org.scalatest.{FunSuite, Matchers}
-import slick.driver.JdbcDriver.backend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 
 
 /**
   * Created by pedrosag on 31-10-2016.
   */
 class MunicipalityDaoSpec extends FunSuite with Matchers{
-
-  def runWithRollback(f: => Unit): Unit = {
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      f
-      dynamicSession.rollback()
-    }
-  }
 
   test("Test getMunicipalityMapping When getting all municipalities Then should return some"){
     runWithRollback{

--- a/viite-backend/database/src/test/scala/fi/vaylavirasto/viite/dao/PostGISUserProviderSpec.scala
+++ b/viite-backend/database/src/test/scala/fi/vaylavirasto/viite/dao/PostGISUserProviderSpec.scala
@@ -1,21 +1,13 @@
 package fi.vaylavirasto.viite.dao
 
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 import fi.liikennevirasto.digiroad2.user.Configuration
 import fi.vaylavirasto.viite.postgis.DbUtils.runUpdateToDb
 import org.scalatest.{FunSuite, Matchers}
-import slick.jdbc.JdbcBackend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
 
 class PostGISUserProviderSpec extends FunSuite with Matchers {
 
-  def runWithRollback[T](f: => T): T = {
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      val t = f
-      dynamicSession.rollback()
-      t
-    }
-  }
 
   val TestUserName = "userprovidertest"
   val north = 1000

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/NodesAndJunctionsServiceSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/NodesAndJunctionsServiceSpec.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.viite
 
 import java.sql.Date
 import fi.liikennevirasto.digiroad2.DigiroadEventBus
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.viite.dao._
 import fi.liikennevirasto.viite.process.RoadwayAddressMapper
@@ -19,8 +19,7 @@ import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalatest.{BeforeAndAfter, FunSuite, Matchers}
 import org.scalatest.mockito.MockitoSugar
-import slick.driver.JdbcDriver.backend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
+import slick.driver.JdbcDriver.backend.Database.dynamicSession  // JdbcBackend#sessionDef
 import slick.jdbc.StaticQuery.interpolation
 
 import scala.util.{Left, Right}
@@ -94,15 +93,6 @@ class NodesAndJunctionsServiceSpec extends FunSuite with Matchers with BeforeAnd
                             override def withDynSession[T](f: => T): T = f
                             override def withDynTransaction[T](f: => T): T = f
                           }
-
-  def runWithRollback(f: => Unit): Unit = {
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      f
-      dynamicSession.rollback()
-    }
-  }
-
-  def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
 
   private val testRoadway1 = Roadway(NewIdValue, roadwayNumber1, roadNumber1, roadPartNumber1, AdministrativeClass.State, Track.Combined, Discontinuity.Continuous, 0, 100, reversed = false, DateTime.parse("2000-01-01"), None, "test", Some("TEST ROAD 1"), 1, TerminationCode.NoTermination)
 

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/ProjectLinkNameDAOSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/ProjectLinkNameDAOSpec.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.viite
 
 import fi.liikennevirasto.digiroad2.DigiroadEventBus
 import fi.liikennevirasto.digiroad2.client.kgv.{KgvRoadLink, KgvRoadLinkClient}
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.viite.dao._
 import fi.liikennevirasto.viite.process.RoadwayAddressMapper
@@ -12,8 +12,6 @@ import fi.vaylavirasto.viite.postgis.DbUtils.runUpdateToDb
 import org.joda.time.DateTime
 import org.scalatest.{BeforeAndAfter, FunSuite, Matchers}
 import org.scalatest.mock.MockitoSugar
-import slick.driver.JdbcDriver.backend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
 
 
 class ProjectLinkNameDAOSpec extends FunSuite with Matchers with BeforeAndAfter {
@@ -78,16 +76,6 @@ class ProjectLinkNameDAOSpec extends FunSuite with Matchers with BeforeAndAfter 
     override def withDynSession[T](f: => T): T = f
 
     override def withDynTransaction[T](f: => T): T = f
-  }
-
-  def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
-
-  def runWithRollback[T](f: => T): T = {
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      val t = f
-      dynamicSession.rollback()
-      t
-    }
   }
 
   test("Test setProjectRoadName When there is no road/projectlink name and given one new road name Then save should be successful") {

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/ProjectServiceLinkSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/ProjectServiceLinkSpec.scala
@@ -1,7 +1,7 @@
 package fi.liikennevirasto.viite
 
 import fi.liikennevirasto.digiroad2._
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.viite.dao._
 import fi.liikennevirasto.viite.dao.ProjectCalibrationPointDAO.UserDefinedCalibrationPoint
@@ -19,8 +19,6 @@ import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.{Answer, OngoingStubbing}
 import org.scalatest.{BeforeAndAfter, FunSuite, Matchers}
 import org.scalatest.mockito.MockitoSugar
-import slick.driver.JdbcDriver.backend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
 
 import scala.util.parsing.json.JSON
 
@@ -108,18 +106,6 @@ class ProjectServiceLinkSpec extends FunSuite with Matchers with BeforeAndAfter 
   after {
     reset(mockRoadLinkService)
   }
-
-  def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
-
-  def runWithRollback[T](f: => T): T = {
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      val t = f
-      dynamicSession.rollback()
-      t
-    }
-  }
-
-
 
   private def createProjectLinks(linkIds: Seq[String], projectId: Long, roadNumber: Long, roadPartNumber: Long, track: Int, discontinuity: Int, administrativeClass: Int, roadLinkSource: Int, roadEly: Long, user: String, roadName: String) = {
     projectService.createProjectLinks(linkIds, projectId, roadNumber, roadPartNumber, Track.apply(track), Discontinuity.apply(discontinuity), AdministrativeClass.apply(administrativeClass), LinkGeomSource.apply(roadLinkSource), roadEly, user, roadName)

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.viite
 
 import fi.liikennevirasto.digiroad2.DigiroadEventBus
 import fi.liikennevirasto.digiroad2.client.kgv._
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.viite.Dummies._
 import fi.liikennevirasto.viite.dao._
@@ -25,8 +25,7 @@ import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalatest.{BeforeAndAfter, FunSuite, Matchers}
 import org.scalatest.mock.MockitoSugar
-import slick.driver.JdbcDriver.backend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
+import slick.driver.JdbcDriver.backend.Database.dynamicSession   // JdbcBackend#sessionDef
 import slick.jdbc.StaticQuery.interpolation
 
 import java.sql.BatchUpdateException
@@ -124,16 +123,6 @@ class ProjectServiceSpec extends FunSuite with Matchers with BeforeAndAfter {
 
   after {
     reset(mockRoadLinkService)
-  }
-
-  def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
-
-  def runWithRollback[T](f: => T): T = {
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      val t = f
-      dynamicSession.rollback()
-      t
-    }
   }
 
   val linearLocations = Seq(

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/ProjectValidatorSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/ProjectValidatorSpec.scala
@@ -1,7 +1,8 @@
 package fi.liikennevirasto.viite
 
 import fi.liikennevirasto.digiroad2.DigiroadEventBus
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase // TODO refactor createJGeometry somewhere else
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.viite.dao._
 import fi.liikennevirasto.viite.dao.TerminationCode.NoTermination
@@ -19,20 +20,9 @@ import org.mockito.Mockito.when
 import org.mockito.stubbing.OngoingStubbing
 import org.scalatest.{FunSuite, Matchers}
 import org.scalatest.mockito.MockitoSugar
-import slick.driver.JdbcDriver.backend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
-import slick.jdbc.StaticQuery.interpolation
+
 
 class ProjectValidatorSpec extends FunSuite with Matchers {
-  def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
-
-  def runWithRollback[T](f: => T): T = {
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      val t = f
-      dynamicSession.rollback()
-      t
-    }
-  }
 
   val mockRoadLinkService: RoadLinkService = MockitoSugar.mock[RoadLinkService]
   val mockRoadwayAddressMapper: RoadwayAddressMapper = MockitoSugar.mock[RoadwayAddressMapper]

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilderSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilderSpec.scala
@@ -1,7 +1,7 @@
 package fi.liikennevirasto.viite
 
 import fi.liikennevirasto.digiroad2._
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.viite.dao._
 import fi.liikennevirasto.viite.dao.TerminationCode.NoTermination
@@ -12,19 +12,8 @@ import fi.vaylavirasto.viite.model.{AdministrativeClass, Discontinuity, Lifecycl
 import org.joda.time.DateTime
 import org.scalatest.{FunSuite, Matchers}
 import org.scalatest.mockito.MockitoSugar
-import slick.driver.JdbcDriver.backend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
 
 class RoadAddressLinkBuilderSpec extends FunSuite with Matchers {
-  def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
-
-  def runWithRollback[T](f: => T): T = {
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      val t = f
-      dynamicSession.rollback()
-      t
-    }
-  }
 
   private val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
   private val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/RoadAddressServiceSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/RoadAddressServiceSpec.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.viite
 
 import fi.liikennevirasto.digiroad2.DigiroadEventBus
 import fi.liikennevirasto.digiroad2.client.kgv._
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.viite.Dummies._
 import fi.liikennevirasto.viite.dao._
@@ -17,8 +17,6 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.scalatest.{FunSuite, Matchers}
 import org.scalatest.mockito.MockitoSugar
-import slick.driver.JdbcDriver.backend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -89,13 +87,6 @@ class RoadAddressServiceSpec extends FunSuite with Matchers{
     override def withDynSession[T](f: => T): T = f
 
     override def withDynTransaction[T](f: => T): T = f
-  }
-  def runWithRollback[T](f: => T): T = {
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      val t = f
-      dynamicSession.rollback()
-      t
-    }
   }
 
   private def dummyProject(id: Long, status: ProjectState, reservedParts: Seq[ProjectReservedPart] = List.empty[ProjectReservedPart], coordinates: Option[ProjectCoordinates] = None): Project ={

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/RoadNameServiceSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/RoadNameServiceSpec.scala
@@ -1,23 +1,13 @@
 package fi.liikennevirasto.viite
 
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 import fi.vaylavirasto.viite.dao.RoadNameDAO
 import fi.vaylavirasto.viite.postgis.DbUtils.runUpdateToDb
 import org.joda.time.DateTime
 import org.scalatest.{FunSuite, Matchers}
-import slick.driver.JdbcDriver.backend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
 
 class RoadNameServiceSpec extends FunSuite with Matchers {
   private val roadNameService = new RoadNameService
-
-  def runWithRollback[T](f: => T): T = {
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      val t = f
-      dynamicSession.rollback()
-      t
-    }
-  }
 
   test("Test roadNameService.getRoadNamesInTX() When searching for a newly create road name by it's road number Then return the entry for said road name.") {
     runWithRollback {

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/CalibrationPointDAOSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/CalibrationPointDAOSpec.scala
@@ -1,19 +1,10 @@
 package fi.liikennevirasto.viite.dao
 
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import fi.vaylavirasto.viite.model.CalibrationPointType
 import org.scalatest.{FunSuite, Matchers}
-import slick.driver.JdbcDriver.backend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 
 class CalibrationPointDAOSpec extends FunSuite with Matchers {
-
-  def runWithRollback(f: => Unit): Unit = {
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      f
-      dynamicSession.rollback()
-    }
-  }
 
   test("Test compare calibration point types When compared Then comparison works correctly") {
     val a = CalibrationPointType.UserDefinedCP

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/JunctionDAOSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/JunctionDAOSpec.scala
@@ -1,23 +1,14 @@
 package fi.liikennevirasto.viite.dao
 
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 import fi.liikennevirasto.viite.NewIdValue
 import fi.vaylavirasto.viite.dao.Sequences
 import fi.vaylavirasto.viite.geometry.Point
 import fi.vaylavirasto.viite.model.{AdministrativeClass, BeforeAfter, Discontinuity, NodePointType, NodeType, Track}
 import org.joda.time.DateTime
 import org.scalatest.{FunSuite, Matchers}
-import slick.driver.JdbcDriver.backend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
 
 class JunctionDAOSpec extends FunSuite with Matchers {
-
-  def runWithRollback(f: => Unit): Unit = {
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      f
-      dynamicSession.rollback()
-    }
-  }
 
   val dao = new JunctionDAO
   val nodeDAO = new NodeDAO

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/JunctionPointDAOSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/JunctionPointDAOSpec.scala
@@ -1,22 +1,13 @@
 package fi.liikennevirasto.viite.dao
 
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 import fi.liikennevirasto.viite.NewIdValue
 import fi.vaylavirasto.viite.dao.Sequences
 import fi.vaylavirasto.viite.model.{AdministrativeClass, BeforeAfter, Discontinuity, Track}
 import org.joda.time.DateTime
 import org.scalatest.{FunSuite, Matchers}
-import slick.driver.JdbcDriver.backend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
 
 class JunctionPointDAOSpec extends FunSuite with Matchers {
-
-  def runWithRollback(f: => Unit): Unit = {
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      f
-      dynamicSession.rollback()
-    }
-  }
 
   val dao = new JunctionPointDAO
   val junctionDAO = new JunctionDAO

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/LinearLocationDAOSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/LinearLocationDAOSpec.scala
@@ -1,16 +1,13 @@
 package fi.liikennevirasto.viite.dao
 
 import java.sql.BatchUpdateException
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 import fi.liikennevirasto.viite._
 import fi.liikennevirasto.viite.process.RoadAddressFiller.LinearLocationAdjustment
 import fi.vaylavirasto.viite.geometry.{BoundingRectangle, Point}
 import fi.vaylavirasto.viite.model.{AdministrativeClass, CalibrationPointLocation, CalibrationPointType, Discontinuity, LinkGeomSource, SideCode, Track}
 import org.joda.time.DateTime
 import org.scalatest.{FunSuite, Matchers}
-import slick.driver.JdbcDriver.backend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
-import slick.jdbc.StaticQuery.interpolation
 
 class LinearLocationDAOSpec extends FunSuite with Matchers {
 
@@ -19,13 +16,6 @@ class LinearLocationDAOSpec extends FunSuite with Matchers {
   val roadwayPointDAO = new RoadwayPointDAO
 
   private val testLinearLocation = LinearLocation(NewIdValue, 1, 1000L.toString, 0.0, 100.0, SideCode.TowardsDigitizing, 10000000000L, (CalibrationPointReference(Some(0L)), CalibrationPointReference.None), Seq(Point(0.0, 0.0), Point(0.0, 100.0)), LinkGeomSource.NormalLinkInterface, 200L)
-
-  def runWithRollback(f: => Unit): Unit = {
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      f
-      dynamicSession.rollback()
-    }
-  }
 
   test("Test create When creating linear location with new roadway id and no calibration points Then return new linear location") {
     runWithRollback {

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/NodeDAOSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/NodeDAOSpec.scala
@@ -1,6 +1,6 @@
 package fi.liikennevirasto.viite.dao
 
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 import fi.liikennevirasto.viite.NewIdValue
 import fi.vaylavirasto.viite.dao.Sequences
 import fi.vaylavirasto.viite.geometry.{BoundingRectangle, Point}
@@ -8,18 +8,10 @@ import fi.vaylavirasto.viite.model.{AdministrativeClass, BeforeAfter, Discontinu
 import fi.vaylavirasto.viite.postgis.DbUtils.runUpdateToDb
 import org.joda.time.DateTime
 import org.scalatest.{FunSuite, Matchers}
-import slick.driver.JdbcDriver.backend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
+import slick.driver.JdbcDriver.backend.Database.dynamicSession  // JdbcBackend#sessionDef
 import slick.jdbc.StaticQuery.interpolation
 
 class NodeDAOSpec extends FunSuite with Matchers {
-
-  def runWithRollback(f: => Unit): Unit = {
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      f
-      dynamicSession.rollback()
-    }
-  }
 
   private val nonExistingRoadNumber = -1
   private val existingRoadNumber = 10

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/NodePointDAOSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/NodePointDAOSpec.scala
@@ -1,24 +1,15 @@
 package fi.liikennevirasto.viite.dao
 
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 import fi.liikennevirasto.viite.NewIdValue
 import org.joda.time.DateTime
 import org.scalatest.{FunSuite, Matchers}
-import slick.driver.JdbcDriver.backend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
 import fi.liikennevirasto.viite.dao.TerminationCode.NoTermination
 import fi.vaylavirasto.viite.dao.Sequences
 import fi.vaylavirasto.viite.geometry.{BoundingRectangle, Point}
 import fi.vaylavirasto.viite.model.{AdministrativeClass, BeforeAfter, Discontinuity, LinkGeomSource, NodePointType, NodeType, SideCode, Track}
 
 class NodePointDAOSpec extends FunSuite with Matchers {
-
-  def runWithRollback(f: => Unit): Unit = {
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      f
-      dynamicSession.rollback()
-    }
-  }
 
   val dao = new NodePointDAO
   val nodeDAO = new NodeDAO

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/ProjectCalibrationPointDAOSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/ProjectCalibrationPointDAOSpec.scala
@@ -1,6 +1,6 @@
 package fi.liikennevirasto.viite.dao
 
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.viite.NewIdValue
 import fi.liikennevirasto.viite.dao.ProjectCalibrationPointDAO.UserDefinedCalibrationPoint
@@ -9,19 +9,13 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSuite, Matchers}
-import slick.driver.JdbcDriver.backend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
+import slick.driver.JdbcDriver.backend.Database.dynamicSession  // JdbcBackend#sessionDef
 import slick.jdbc.StaticQuery.interpolation
 
 class ProjectCalibrationPointDAOSpec extends FunSuite with Matchers {
 
   private val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-  def runWithRollback(f: => Unit): Unit = {
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      f
-      dynamicSession.rollback()
-    }
-  }
+
   val projectReservedPartDAO = new ProjectReservedPartDAO
 
   def addTestProjects(): Unit = {

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/ProjectDAOSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/ProjectDAOSpec.scala
@@ -1,6 +1,6 @@
 package fi.liikennevirasto.viite.dao
 
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 import fi.liikennevirasto.viite._
 import fi.vaylavirasto.viite.dao.Sequences
 import fi.vaylavirasto.viite.geometry.{GeometryUtils, Point}
@@ -8,22 +8,11 @@ import fi.vaylavirasto.viite.model.CalibrationPointType.NoCP
 import fi.vaylavirasto.viite.model.{AdministrativeClass, CalibrationPointType, Discontinuity, LinkGeomSource, RoadAddressChangeType, SideCode, Track}
 import org.joda.time.DateTime
 import org.scalatest.{FunSuite, Matchers}
-import slick.driver.JdbcDriver.backend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
 
 /**
   * Class to test DB trigger that does not allow reserving already reserved links to project
   */
 class ProjectDAOSpec extends FunSuite with Matchers {
-
-  def runWithRollback(f: => Unit): Unit = {
-    // Prevent deadlocks in DB because we create and delete links in tests and don't handle the project ids properly
-    // TODO: create projects with unique ids so we don't get into transaction deadlocks in tests
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      f
-      dynamicSession.rollback()
-    }
-  }
 
   val roadwayDAO = new RoadwayDAO
   val projectDAO = new ProjectDAO

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/ProjectLinkDAOSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/ProjectLinkDAOSpec.scala
@@ -1,6 +1,6 @@
 package fi.liikennevirasto.viite.dao
 
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 import fi.liikennevirasto.viite.Dummies.dummyLinearLocation
 import fi.liikennevirasto.viite.dao.TerminationCode.NoTermination
 import fi.liikennevirasto.viite.NewIdValue
@@ -10,24 +10,11 @@ import fi.vaylavirasto.viite.model.CalibrationPointType.{NoCP, RoadAddressCP}
 import fi.vaylavirasto.viite.model.{AdministrativeClass, Discontinuity, LinkGeomSource, RoadAddressChangeType, SideCode, Track}
 import org.joda.time.DateTime
 import org.scalatest.{FunSuite, Matchers}
-import slick.driver.JdbcDriver.backend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
 
 /**
   * Class to test DB trigger that does not allow reserving already reserved links to project
   */
 class ProjectLinkDAOSpec extends FunSuite with Matchers {
-
-  def runWithRollback(f: => Unit): Unit = {
-    // Prevent deadlocks in DB because we create and delete links in tests and don't handle the project ids properly
-    // TODO: create projects with unique ids so we don't get into transaction deadlocks in tests
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      f
-      dynamicSession.rollback()
-    }
-  }
-
-  def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
 
   val projectDAO = new ProjectDAO
   val projectLinkDAO = new ProjectLinkDAO

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/ProjectReservedPartDAOSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/ProjectReservedPartDAOSpec.scala
@@ -1,6 +1,6 @@
 package fi.liikennevirasto.viite.dao
 
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 import fi.liikennevirasto.viite.Dummies.dummyLinearLocation
 import fi.liikennevirasto.viite.NewIdValue
 import fi.vaylavirasto.viite.dao.Sequences
@@ -11,22 +11,11 @@ import fi.vaylavirasto.viite.postgis.DbUtils.runUpdateToDb
 import org.joda.time.DateTime
 import org.postgresql.util.PSQLException
 import org.scalatest.{FunSuite, Matchers}
-import slick.driver.JdbcDriver.backend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
 
 /**
   * Class to test DB trigger that does not allow reserving already reserved parts to project
   */
 class ProjectReservedPartDAOSpec extends FunSuite with Matchers {
-
-  def runWithRollback(f: => Unit): Unit = {
-    // Prevent deadlocks in DB because we create and delete links in tests and don't handle the project ids properly
-    // TODO: create projects with unique ids so we don't get into transaction deadlocks in tests
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      f
-      dynamicSession.rollback()
-    }
-  }
 
   val roadwayDAO = new RoadwayDAO
   val linearLocationDAO = new LinearLocationDAO

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/RoadNameDAOSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/RoadNameDAOSpec.scala
@@ -1,21 +1,12 @@
 package fi.liikennevirasto.viite.dao
 
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 import fi.vaylavirasto.viite.dao.{RoadName, RoadNameDAO, RoadNameForRoadAddressBrowser, Sequences}
 import fi.vaylavirasto.viite.model.{AdministrativeClass, Discontinuity, Track}
 import org.scalatest.{FunSuite, Matchers}
 import org.joda.time.DateTime
-import slick.driver.JdbcDriver.backend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
 
 class RoadNameDAOSpec extends FunSuite with Matchers {
-
-  def runWithRollback(f: => Unit): Unit = {
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      f
-      dynamicSession.rollback()
-    }
-  }
 
   val roadwayDAO = new RoadwayDAO
 

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/RoadNetworkDAOSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/RoadNetworkDAOSpec.scala
@@ -1,24 +1,15 @@
 package fi.liikennevirasto.viite.dao
 
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 import fi.liikennevirasto.viite._
 import fi.vaylavirasto.viite.dao.Sequences
 import fi.vaylavirasto.viite.geometry.Point
 import fi.vaylavirasto.viite.model.{AdministrativeClass, Discontinuity, LinkGeomSource, SideCode, Track}
 import org.joda.time.DateTime
 import org.scalatest.{FunSuite, Matchers}
-import slick.driver.JdbcDriver.backend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
 
 
 class RoadNetworkDAOSpec extends FunSuite with Matchers {
-
-  def runWithRollback(f: => Unit): Unit = {
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      f
-      dynamicSession.rollback()
-    }
-  }
 
   val dao = new RoadNetworkDAO
   val roadwayDAO = new RoadwayDAO

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/RoadwayChangesDAOSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/RoadwayChangesDAOSpec.scala
@@ -1,6 +1,6 @@
 package fi.liikennevirasto.viite.dao
 
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 import fi.liikennevirasto.viite.NewIdValue
 import fi.liikennevirasto.viite.dao.TerminationCode.NoTermination
 import fi.liikennevirasto.viite.util.{projectLinkDAO, projectReservedPartDAO}
@@ -10,20 +10,12 @@ import fi.vaylavirasto.viite.model.{AdministrativeClass, Discontinuity, LinkGeom
 import fi.vaylavirasto.viite.postgis.DbUtils.runUpdateToDb
 import org.joda.time.DateTime
 import org.scalatest.{FunSuite, Matchers}
-import slick.driver.JdbcDriver.backend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
+import slick.driver.JdbcDriver.backend.Database.dynamicSession  // JdbcBackend#sessionDef
 import slick.jdbc.StaticQuery.interpolation
 
 import java.sql.Timestamp
 
 class RoadwayChangesDAOSpec extends FunSuite with Matchers {
-
-  def runWithRollback(f: => Unit): Unit = {
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      f
-      dynamicSession.rollback()
-    }
-  }
 
   val projectDAO = new ProjectDAO
   private val roadNumber1 = 990

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/RoadwayDAOSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/RoadwayDAOSpec.scala
@@ -1,25 +1,15 @@
 package fi.liikennevirasto.viite.dao
 
 import java.sql.SQLException
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 import fi.liikennevirasto.viite._
 import fi.vaylavirasto.viite.dao.Sequences
 import fi.vaylavirasto.viite.geometry.Point
 import fi.vaylavirasto.viite.model.{AdministrativeClass, Discontinuity, LinkGeomSource, SideCode, Track}
 import org.joda.time.DateTime
 import org.scalatest.{FunSuite, Matchers}
-import slick.driver.JdbcDriver.backend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
-
 
 class RoadwayDAOSpec extends FunSuite with Matchers {
-
-  def runWithRollback(f: => Unit): Unit = {
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      f
-      dynamicSession.rollback()
-    }
-  }
 
   val dao = new RoadwayDAO
   val linearLocationDAO = new LinearLocationDAO

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/integration/Viite_13_218_spec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/integration/Viite_13_218_spec.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.viite
 
 import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.client.kgv.KgvRoadLink
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.util.ViiteProperties
 import fi.liikennevirasto.viite.dao._
@@ -19,8 +19,7 @@ import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalatest.{BeforeAndAfter, FunSuite, Matchers}
 import org.scalatest.mockito.MockitoSugar
-import slick.driver.JdbcDriver.backend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
+import slick.driver.JdbcDriver.backend.Database.dynamicSession // for set<type>
 
 import scala.collection.immutable.HashMap
 import scala.collection.mutable.ListBuffer
@@ -95,25 +94,6 @@ class Viite_13_218_spec extends FunSuite with Matchers with BeforeAndAfter {
 
   after {
     reset(mockRoadLinkService)
-  }
-
-//  def withDynTransaction[T](f: => T): T = OracleDatabase.withDynTransaction(f)
-//
-//  def runWithRollback[T](f: => T): T = {
-//    Database.forDataSource(OracleDatabase.ds).withDynTransaction {
-//      val t = f
-//      dynamicSession.rollback()
-//  t
-//}
-//  }
-   def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
-
-  def runWithRollback[T](f: => T): T = {
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      val t = f
-      dynamicSession.rollback()
-      t
-    }
   }
 
   private def addressToRoadLink(ral: RoadAddress): RoadLink = {

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/process/DefaultSectionCalculatorStrategySpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/process/DefaultSectionCalculatorStrategySpec.scala
@@ -1,6 +1,6 @@
 package fi.liikennevirasto.viite.process
 
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 import fi.liikennevirasto.viite.dao._
 import fi.liikennevirasto.viite.dao.ProjectCalibrationPointDAO.UserDefinedCalibrationPoint
 import fi.liikennevirasto.viite.process.strategy.DefaultSectionCalculatorStrategy
@@ -13,16 +13,8 @@ import fi.vaylavirasto.viite.model.LinkGeomSource.{ComplementaryLinkInterface, F
 import fi.vaylavirasto.viite.model.{AdministrativeClass, Discontinuity, LinkGeomSource, RoadAddressChangeType, SideCode, Track}
 import org.joda.time.DateTime
 import org.scalatest.{FunSuite, Matchers}
-import slick.driver.JdbcDriver.backend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
 
 class DefaultSectionCalculatorStrategySpec extends FunSuite with Matchers {
-  def runWithRollback(f: => Unit): Unit = {
-   Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      f
-      dynamicSession.rollback()
-    }
-  }
   val defaultSectionCalculatorStrategy = new DefaultSectionCalculatorStrategy
   val roadwayDAO = new RoadwayDAO
   val linearLocationDAO = new LinearLocationDAO

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/process/ProjectDeltaCalculatorSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/process/ProjectDeltaCalculatorSpec.scala
@@ -1,6 +1,6 @@
 package fi.liikennevirasto.viite.process
 
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 import fi.liikennevirasto.viite.NewIdValue
 import fi.liikennevirasto.viite.dao._
 import fi.liikennevirasto.viite.dao.TerminationCode.NoTermination
@@ -15,23 +15,11 @@ import fi.vaylavirasto.viite.model.{AdministrativeClass, Discontinuity, LinkGeom
 import org.joda.time.DateTime
 import org.scalatest.{FunSuite, Matchers}
 import org.scalatest.enablers.Definition.definitionOfOption
-import slick.driver.JdbcDriver.backend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
 
 import scala.collection.immutable
 
 class ProjectDeltaCalculatorSpec extends FunSuite with Matchers {
   val roadwayDAO = new RoadwayDAO
-
-  def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
-
-  def runWithRollback[T](f: => T): T = {
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      val t = f
-      dynamicSession.rollback()
-      t
-    }
-  }
 
   private def createRoadAddress(start: Long, distance: Long, roadwayNumber: Long = 0L) = {
     //TODO the road address now have the linear location id and has been set to 1L

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/process/ProjectSectionCalculatorSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/process/ProjectSectionCalculatorSpec.scala
@@ -1,7 +1,7 @@
 package fi.liikennevirasto.viite.process
 
 import fi.liikennevirasto.digiroad2.DigiroadEventBus
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.util.MissingTrackException
 import fi.liikennevirasto.viite._
@@ -17,9 +17,6 @@ import fi.vaylavirasto.viite.postgis.DbUtils.runUpdateToDb
 import org.joda.time.DateTime
 import org.scalatest.{FunSuite, Matchers}
 import org.scalatest.mockito.MockitoSugar
-import slick.driver.JdbcDriver.backend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
-import slick.jdbc.StaticQuery.interpolation
 
 class ProjectSectionCalculatorSpec extends FunSuite with Matchers {
   val mockRoadLinkService: RoadLinkService = MockitoSugar.mock[RoadLinkService]
@@ -78,14 +75,6 @@ class ProjectSectionCalculatorSpec extends FunSuite with Matchers {
                             override def withDynSession[T](f: => T): T = f
                             override def withDynTransaction[T](f: => T): T = f
                           }
-
-  def runWithRollback[T](f: => T): T = {
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      val t = f
-      dynamicSession.rollback()
-      t
-    }
-  }
 
   val projectId = 1
   private val rap = Project(projectId, ProjectState.apply(1), "TestProject", "TestUser", DateTime.parse("2700-01-01"),

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/process/RoadwayFillerSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/process/RoadwayFillerSpec.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.viite.process
 
 import fi.liikennevirasto.digiroad2.DigiroadEventBus
 import fi.liikennevirasto.digiroad2.client.kgv.{KgvRoadLink, KgvRoadLinkClient}
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.viite._
 import fi.liikennevirasto.viite.Dummies._
@@ -13,19 +13,8 @@ import fi.vaylavirasto.viite.model.{AdministrativeClass, Discontinuity, RoadAddr
 import org.joda.time.DateTime
 import org.scalatest.{BeforeAndAfter, FunSuite, Matchers}
 import org.scalatest.mock.MockitoSugar
-import slick.driver.JdbcDriver.backend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
 
 class RoadwayFillerSpec extends FunSuite with Matchers with BeforeAndAfter {
-  def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
-
-  def runWithRollback[T](f: => T): T = {
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      val t = f
-      dynamicSession.rollback()
-      t
-    }
-  }
 
   val mockProjectService: ProjectService = MockitoSugar.mock[ProjectService]
   val mockRoadLinkService: RoadLinkService = MockitoSugar.mock[RoadLinkService]
@@ -1205,7 +1194,7 @@ class RoadwayFillerSpec extends FunSuite with Matchers with BeforeAndAfter {
   }
 
   test("Test RoadwayFiller.applyRoadwayChanges() When dealing with a termination of a roadway with history Then check correctly assigned roadway id's.") {
-    withDynTransaction {
+    runWithRollback {
       val roadways = Map(
         (0L, dummyRoadway(roadwayNumber = 1L, roadNumber = 1L, roadPartNumber = 1L, startAddrM = 0L, endAddrM = 200L, DateTime.parse("1950-01-01"), None))
       )

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/process/TrackSectionOrderSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/process/TrackSectionOrderSpec.scala
@@ -1,6 +1,6 @@
 package fi.liikennevirasto.viite.process
 
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 import fi.liikennevirasto.viite.Dummies
 import fi.liikennevirasto.viite.Dummies._
 import fi.liikennevirasto.viite.dao.TerminationCode.NoTermination
@@ -10,17 +10,8 @@ import fi.vaylavirasto.viite.geometry.Point
 import fi.vaylavirasto.viite.model.{AdministrativeClass, Discontinuity, LinkGeomSource, RoadAddressChangeType, SideCode, Track}
 import org.joda.time.DateTime
 import org.scalatest.{FunSuite, Matchers}
-import slick.driver.JdbcDriver.backend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
 
 class TrackSectionOrderSpec extends FunSuite with Matchers {
-
-  private def runWithRollback(f: => Unit): Unit = {
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      f
-      dynamicSession.rollback()
-    }
-  }
 
   private def toDummyProjectLink(id: Long, geom: Seq[Point], track: Track = Track.Combined) = {
     dummyProjectLink(1L, 1L, track, Discontinuity.Continuous, 0, 10, Some(DateTime.now), linkId = id.toString, status = RoadAddressChangeType.NotHandled, geometry = geom)

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/util/DataImporterSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/util/DataImporterSpec.scala
@@ -1,6 +1,7 @@
 //package fi.liikennevirasto.viite.util
 //
 //import fi.liikennevirasto.digiroad2.client.vvh._
+//import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 //import fi.liikennevirasto.viite.dao._
 //import org.mockito.Mockito.when
 //import org.scalatest.mockito.MockitoSugar
@@ -23,13 +24,6 @@
 //  def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
 //
 //  def withDynSession[T](f: => T): T = PostGISDatabase.withDynSession(f)
-//
-//  def runWithRollback(f: => Unit): Unit = {
-//    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-//      f
-//      dynamicSession.rollback()
-//    }
-//  }
 //
 //  val mockVVHClient = MockitoSugar.mock[KgvRoadLink]
 //  val mockVVHRoadLinkClient = MockitoSugar.mock[KgvRoadLinkClient]

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/util/TwoTrackRoadUtilsSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/util/TwoTrackRoadUtilsSpec.scala
@@ -1,6 +1,6 @@
 package fi.liikennevirasto.viite.util
 
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.runWithRollback
 import fi.liikennevirasto.viite._
 import fi.liikennevirasto.viite.dao._
 import fi.liikennevirasto.viite.dao.ProjectCalibrationPointDAO.UserDefinedCalibrationPoint
@@ -10,24 +10,12 @@ import fi.vaylavirasto.viite.model.CalibrationPointType.{JunctionPointCP, NoCP, 
 import fi.vaylavirasto.viite.model.{AdministrativeClass, Discontinuity, LinkGeomSource, RoadAddressChangeType, SideCode, Track}
 import org.joda.time.DateTime
 import org.scalatest.{FunSuite, Matchers}
-import slick.driver.JdbcDriver.backend.Database
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
 
 class TwoTrackRoadUtilsSpec extends FunSuite with Matchers {
 
   val projectDAO = new ProjectDAO
   val projectLinkDAO = new ProjectLinkDAO
   val projectReservedPartDAO = new ProjectReservedPartDAO
-
-  def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
-
-  def runWithRollback[T](f: => T): T = {
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      val t = f
-      dynamicSession.rollback()
-      t
-    }
-  }
 
   private def setUpProjectWithLinks(
                                      testTrack1: TestTrack,

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/util/package.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/util/package.scala
@@ -202,12 +202,4 @@ package object util {
     ProjectLink(rl.id, rl.roadNumber, rl.roadPartNumber, Track.apply(rl.trackCode.toInt), Discontinuity.apply(rl.discontinuity), rl.startAddressM, rl.endAddressM, rl.startAddressM, rl.endAddressM, None, None, rl.modifiedBy, rl.linkId, rl.startMValue, rl.endMValue, rl.sideCode, (rl.startCalibrationPointType, rl.endCalibrationPointType), (rl.startCalibrationPointType, rl.endCalibrationPointType), rl.geometry, project.id, RoadAddressChangeType.NotHandled, AdministrativeClass.State, rl.roadLinkSource, GeometryUtils.geometryLength(rl.geometry), if (rl.status == RoadAddressChangeType.New) 0 else rl.id, if (rl.status == RoadAddressChangeType.New) 0 else rl.linearLocationId, rl.elyCode, reversed = false, None, rl.roadLinkTimeStamp)
   }
 
-  def runWithRollback[T](f: => T): T = {
-    Database.forDataSource(PostGISDatabase.ds).withDynTransaction {
-      val t = f
-      dynamicSession.rollback()
-      t
-    }
-  }
-
 }


### PR DESCRIPTION
Hmm, ihan viime metreillä, poistellessani vielä turhiksi jääneitä importeja, havaitsin, että meillä on myös _TestTransactions.scala_ -tiedosto.
Tiedä sitten, olisiko se järkevämpi paikka. Käyttöä en tosin löytänyt, vaikka tiedosto olikin olemassa.