### PR TITLE
VIITE-3067 CalibrationPointDAO create function fails silently. …

### DIFF
--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
@@ -908,7 +908,9 @@ class RoadAddressService(
         val calibrationPoint = CalibrationPointDAO.fetchByRoadwayPointId(oldRoadwayPointId).filter(_.startOrEnd == CalibrationPointLocation.StartOfLink)
         logger.info(s"Update calibration point (${calibrationPoint.map(_.id)}) for after roadway point id: $oldRoadwayPointId to $newRoadwayPointId, startOrEnd: $startOrEnd")
         CalibrationPointDAO.expireById(calibrationPoint.map(_.id))
-        CalibrationPointDAO.create(calibrationPoint.map(_.copy(id = NewIdValue, roadwayPointId = newRoadwayPointId, startOrEnd = startOrEnd, typeCode = CalibrationPointType.RoadAddressCP, createdBy = username)))
+        calibrationPoint.foreach(cp => CalibrationPointDAO.
+          create(newRoadwayPointId, cp.linkId, startOrEnd, CalibrationPointType.RoadAddressCP, username)
+        )
       }
     }
 

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/CalibrationPointDAO.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/CalibrationPointDAO.scala
@@ -4,7 +4,6 @@ import org.joda.time.DateTime
 import slick.driver.JdbcDriver.backend.Database.dynamicSession
 import slick.jdbc.StaticQuery.interpolation
 import slick.jdbc.{GetResult, PositionedResult, StaticQuery => Q}
-import fi.liikennevirasto.viite.NewIdValue
 import fi.vaylavirasto.viite.dao.{BaseDAO, Sequences}
 import fi.vaylavirasto.viite.model.{CalibrationPoint, CalibrationPointLocation, CalibrationPointType}
 
@@ -28,35 +27,16 @@ object CalibrationPointDAO extends BaseDAO {
     }
   }
 
-  // TODO Check this method! It failed silently in updating junction point address, but the other create method works.
-  def create(calibrationPoints: Iterable[CalibrationPoint]): Seq[Long] = {
-    val ps = dynamicSession.prepareStatement(
-      """INSERT INTO CALIBRATION_POINT (ID, ROADWAY_POINT_ID, LINK_ID, START_END, TYPE, CREATED_BY)
-      VALUES (?, ?, ?, ?, ?, ?)""".stripMargin)
-
-    // set ids for the calibration points without one
-    val (ready, idLess) = calibrationPoints.partition(_.id != NewIdValue)
-    val newIds = Sequences.fetchCalibrationPointIds(idLess.size)
-    val createCalibrationPoints = ready ++ idLess.zip(newIds).map(x =>
-      x._1.copy(id = x._2)
-    )
-
-    createCalibrationPoints.foreach {
-      calibrationPoint =>
-        ps.setLong(1, calibrationPoint.id)
-        ps.setLong(2, calibrationPoint.roadwayPointId)
-        ps.setString(3, calibrationPoint.linkId)
-        ps.setInt(4, calibrationPoint.startOrEnd.value)
-        ps.setInt(5, calibrationPoint.typeCode.value)
-        ps.setString(6, calibrationPoint.createdBy)
-    }
-
-    ps.executeBatch()
-    ps.close()
-    createCalibrationPoints.map(_.id).toSeq
+  def create(cp: CalibrationPoint): Long = {
+    create(cp.roadwayPointId, cp.linkId, cp.startOrEnd, cp.typeCode, cp.createdBy)
+    cp.id
   }
 
-  def create(roadwayPointId: Long, linkId: String, startOrEnd: CalibrationPointLocation, calType: CalibrationPointType, createdBy: String): Unit = {
+  def create(roadwayPointId: Long,
+             linkId: String,
+             startOrEnd: CalibrationPointLocation,
+             calType: CalibrationPointType,
+             createdBy: String): Unit = {
     runUpdateToDb(s"""
       Insert Into CALIBRATION_POINT (ID, ROADWAY_POINT_ID, LINK_ID, START_END, TYPE, CREATED_BY) VALUES
       (${Sequences.nextCalibrationPointId}, $roadwayPointId, '$linkId', ${startOrEnd.value}, ${calType.value}, '$createdBy')
@@ -119,17 +99,6 @@ object CalibrationPointDAO extends BaseDAO {
      """.as[Long].list.toSet
   }
 
-  def fetchByRoadwayPointInExpiredJunctionPoint(roadwayPointId: Long, addr: Long): Set[Long] = {
-    sql"""
-         SELECT CP.ID
-         FROM CALIBRATION_POINT CP
-         JOIN ROADWAY_POINT RP ON RP.ID = CP.ROADWAY_POINT_ID
-         JOIN JUNCTION_POINT JP ON JP.ROADWAY_POINT_ID = RP.ID
-         JOIN JUNCTION J ON J.ID = JP.JUNCTION_ID
-         WHERE cp.roadway_point_id = $roadwayPointId AND rp.addr_m = $addr AND CP.VALID_TO IS NULL AND JP.VALID_TO IS NOT NULL
-     """.as[Long].list.toSet
-  }
-
   def fetchByLinkId(linkIds: Iterable[String]): Seq[CalibrationPoint] = {
     if (linkIds.isEmpty) {
       Seq()
@@ -147,7 +116,7 @@ object CalibrationPointDAO extends BaseDAO {
   }
 
   def fetch(calibrationPointsLinkIds: Seq[String], startOrEnd: Long): Seq[CalibrationPoint] = {
-    val whereClause = calibrationPointsLinkIds.map(p => s" (link_id = ''' + $p + ''' and start_end = $startOrEnd)").mkString(" where ", " or ", "")
+    val whereClause = calibrationPointsLinkIds.map(p => s" (link_id = '$p' and start_end = $startOrEnd)").mkString(" where ", " or ", "")
     val query = s"""
      SELECT CP.ID, ROADWAY_POINT_ID, LINK_ID, ROADWAY_NUMBER, RP.ADDR_M, START_END, TYPE, VALID_FROM, VALID_TO, CP.CREATED_BY, CP.CREATED_TIME
      FROM CALIBRATION_POINT CP

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/CalibrationPointDAOSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/CalibrationPointDAOSpec.scala
@@ -1,6 +1,7 @@
 package fi.liikennevirasto.viite.dao
 
-import fi.vaylavirasto.viite.model.CalibrationPointType
+import fi.liikennevirasto.viite.NewIdValue
+import fi.vaylavirasto.viite.model.{CalibrationPoint, CalibrationPointLocation, CalibrationPointType}
 import fi.vaylavirasto.viite.postgis.PostGISDatabase.runWithRollback
 import org.scalatest.{FunSuite, Matchers}
 
@@ -27,6 +28,168 @@ class CalibrationPointDAOSpec extends FunSuite with Matchers {
     a == a should be(true)
     b == b should be(true)
     c == c should be(true)
+  }
+
+  test("Test fetch calibration point fetches by linkId") {
+    runWithRollback { // fetches should not write to DB, but just in case...
+
+      // fetch(linkId, startEnd)
+      // -- (not found: There is no such link 123)
+      val cp: Option[CalibrationPoint] = CalibrationPointDAO.fetch("123", CalibrationPointLocation.StartOfLink.value)
+      cp shouldBe None
+      // -- (is available)
+      val cpBylinkId: Option[CalibrationPoint] = CalibrationPointDAO.fetch("4388117", CalibrationPointLocation.StartOfLink.value)
+      cpBylinkId.get should not be None
+      cpBylinkId.get.roadwayPointId should be (1)
+
+      // fetch(Seq(linkId), startEnd)
+      // -- (not found: There are no such links 123, 124)
+      val cps: Seq[CalibrationPoint] = CalibrationPointDAO.fetch(Seq("123","124"), CalibrationPointLocation.StartOfLink.value)
+      cps.size should be (0)
+      //  -- (are available)
+      val cpBylinkIds: Seq[CalibrationPoint] = CalibrationPointDAO.fetch(Seq("4388117","4388118"), CalibrationPointLocation.StartOfLink.value.toLong)
+      cpBylinkIds.size should be (2)
+      cpBylinkIds.head.roadwayPointId should be (1) // first points ...
+      cpBylinkIds.last.roadwayPointId should be (2) // ... in the set
+
+      // fetchByLinkId(linkIds)
+      val cpList: Seq[CalibrationPoint] = CalibrationPointDAO.fetchByLinkId(Seq("1991144"))
+      cpList.size should be (2)
+
+    }
+  }
+
+  test("Test fetch calibration point fetches by roadwayPoints") {
+    runWithRollback { // fetches should not write to DB, but just in case...
+
+      // fetchByRoadwayPointId
+      // // -- existing roadway point
+      val cpByRp: Seq[CalibrationPoint] = CalibrationPointDAO.fetchByRoadwayPointId(118)
+      cpByRp.size should be (1)
+      cpByRp.head.linkId should be ("1991144")
+      // -- non-existing roadway point
+      val cpByRpNone: Seq[CalibrationPoint] = CalibrationPointDAO.fetchByRoadwayPointId(5432)
+      cpByRpNone.size should be (0)
+
+      // fetchByRoadwayPointIds
+      // (fetch with available rwpoints)
+      val cpByRps: Seq[CalibrationPoint] = CalibrationPointDAO.fetchByRoadwayPointIds(Seq(118,119))
+      cpByRps.size should be (2)
+      cpByRps.head.linkId should be ("1991144")
+      cpByRps.last.linkId should be ("1991144")
+      // (fetch with non-existing rwpoints)
+      val cpByRpsFail: Seq[CalibrationPoint] = CalibrationPointDAO.fetchByRoadwayPointIds(Seq(11111))
+      cpByRpsFail.size should be (0)
+      // (fetch with partly non-existing rwpoints)
+      val cpByRpsOkAndFail: Seq[CalibrationPoint] = CalibrationPointDAO.fetchByRoadwayPointIds(Seq(118,11111))
+      cpByRpsOkAndFail.size should be (1)
+      cpByRpsOkAndFail.head.linkId should be ("1991144")
+
+    }
+  }
+
+  test("Test fetch calibration point fetches by calibration point id") {
+    runWithRollback { // fetches should not write to DB, but just in case...
+
+      // TODO is this a good way to handle things... ...should we throw an explicit exception from the fetch function?
+      assertThrows[Exception] {
+        // fetch(id)
+        // -- (not found: There is no such id 987654321)
+        val cpByIdNotFound: CalibrationPoint = CalibrationPointDAO.fetch(987654321)
+        cpByIdNotFound.linkId should be ("4388117")
+      }
+      // -- (is found)
+      val cpForId: Seq[CalibrationPoint] = CalibrationPointDAO.fetchByLinkId(Seq("1991144")) // get a calibr. point to get a valid id to fetch
+      val cpById: CalibrationPoint = CalibrationPointDAO.fetch(cpForId.head.id)
+      cpById.linkId should be ("1991144")
+
+    }
+  }
+
+  test("Test fetch calibration point fetches by roadway number") {
+    runWithRollback { // fetches should not write to DB, but just in case...
+
+      //fetchIdByRoadwayNumberSection(roadwayNumber, startAddr, endAddr)
+      val CpIdsBoth: Set[Long]  = CalibrationPointDAO.fetchIdByRoadwayNumberSection(39317,    0,4000)
+      CpIdsBoth.size shouldBe (2)
+      val CpIdsStart: Set[Long] = CalibrationPointDAO.fetchIdByRoadwayNumberSection(39317,    0,1000)
+      CpIdsStart.size shouldBe (1)
+      val CpIdsEnd: Set[Long]   = CalibrationPointDAO.fetchIdByRoadwayNumberSection(39317, 1000,4000)
+      CpIdsEnd.size shouldBe (1)
+
+    }
+  }
+
+  test("Test calibration point expiration") {
+    runWithRollback { // tests should not make permanent changes to the DB.
+
+      // first, get an existing calibration point to expire
+      val CpToExpireOption: Option[CalibrationPoint] = CalibrationPointDAO.fetch("4388117", CalibrationPointLocation.StartOfLink.value)
+      val CpToExpire = CpToExpireOption.get
+      CpToExpire should not be None
+
+      // expire it
+      CalibrationPointDAO.expireById(Seq(CpToExpire.id))
+
+      // check it is expired indeed
+      val CpExpired: Option[CalibrationPoint] = CalibrationPointDAO.fetch("4388117", CalibrationPointLocation.StartOfLink.value)
+      CpExpired shouldBe None
+
+    }
+  }
+
+  def getCalPointToCreate: CalibrationPoint = {
+    CalibrationPoint(
+      NewIdValue,
+      11,
+      "1718137", //"1718142",
+      98765,
+      0,
+      CalibrationPointLocation.StartOfLink,
+      CalibrationPointType.UserDefinedCP,
+      None,
+      None,
+      createdBy="thisIsATestRun"
+    )
+  }
+
+  test("Test calibration point create with CalibrationPoint object") {
+
+    val cpToCreate: CalibrationPoint = getCalPointToCreate
+
+    runWithRollback { // tests should not make permanent changes to the DB.
+      // first, check there is no such cp already
+      val CpToCreateOption1: Option[CalibrationPoint] = CalibrationPointDAO.fetch(cpToCreate.linkId, cpToCreate.startOrEnd.value)
+      CpToCreateOption1 shouldBe None
+
+      // create it
+      CalibrationPointDAO.create(cpToCreate)
+
+      // check it is available after creation
+      val CpToCreateOption2: Option[CalibrationPoint] = CalibrationPointDAO.fetch(cpToCreate.linkId, cpToCreate.startOrEnd.value)
+      CpToCreateOption2 should not be None
+
+    }
+  }
+
+  test("Test calibration point create with values") {
+
+    val cp: CalibrationPoint = getCalPointToCreate
+
+    runWithRollback { // tests should not make permanent changes to the DB.
+
+      // first, check there is no such cp already
+      val CpToCreateOption1: Option[CalibrationPoint] = CalibrationPointDAO.fetch(cp.linkId, cp.startOrEnd.value)
+      CpToCreateOption1 shouldBe None
+
+      // create it
+      CalibrationPointDAO.create(cp.roadwayPointId, cp.linkId, cp.startOrEnd, cp.typeCode, cp.createdBy)
+
+      // check it is available after creation
+      val CpToCreateOption2: Option[CalibrationPoint] = CalibrationPointDAO.fetch(cp.linkId, cp.startOrEnd.value)
+      CpToCreateOption2 should not be None
+
+    }
   }
 
 }


### PR DESCRIPTION
…Removing, and replacing with another one. Adding tests for CalibrationPointDAO. Removing unused fetchRoadwayPointInExpiredJunctionPoint function. Repairing one of the fetch functions.