### PR TITLE
VIITE-3083 integration/road_address rounding/truncating geometry …

### DIFF
--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
@@ -261,7 +261,10 @@ class RoadAddressService(
 
     roadAddresses.flatMap { ra =>
       val roadLink = roadLinks.find(rl => rl.linkId == ra.linkId)
-      roadLink.map(rl => roadAddressLinkBuilder.build(rl, ra))
+      roadLink.map(rl => {
+        val ral: RoadAddressLink = roadAddressLinkBuilder.build(rl, ra)
+        ral.copy(geometry = (ral.geometry.dropRight(1):+rl.geometry.last.with3decimals) ) // Nasty hack to retain already correctly rounded 3 decimals from linear location
+      })
     }
   }
 


### PR DESCRIPTION
…endpoints' 3rd decimals incorrectly (comparing to the linear locations) in some cases, where the 4th decimal is ~5.