### PR TITLE
Viite 3084 date validation

### DIFF
--- a/viite-UI/src/utils/date-utils.js
+++ b/viite-UI/src/utils/date-utils.js
@@ -18,6 +18,12 @@
     return s ? moment(s, dateUtils.FINNISH_DATE_FORMAT) : null;
   };
 
+  dateUtils.isFinnishDateString = function (dateString) {
+    // Regular expression to match date format with day 1-31 and month 1-12
+    const regex = /^(0?[1-9]|[12]\d|3[01])\.(0?[1-9]|1[0-2])\.(\d{4})$/;
+    return regex.test(dateString);
+  };
+
   dateUtils.addFinnishDatePicker = function (element, additionalOptions) {
     return addPicker(jQuery(element),additionalOptions);
   };

--- a/viite-UI/src/view/RoadAddressBrowserWindow.js
+++ b/viite-UI/src/view/RoadAddressBrowserWindow.js
@@ -402,6 +402,12 @@
                 }
             }
 
+            // Clear date error message when typing is started again
+            document.getElementById('roadAddrSituationDate').addEventListener('input', function() {
+                validateDate(this.value);
+                this.setCustomValidity("");
+            });
+
             function validateElyAndRoadNumber (elyElement, roadNumberElement) {
                 if (elyElement.value === "" && roadNumberElement.value === "")
                     elyElement.setCustomValidity("Ely tai Tie on pakollinen tieto");

--- a/viite-UI/src/view/RoadAddressBrowserWindow.js
+++ b/viite-UI/src/view/RoadAddressBrowserWindow.js
@@ -390,13 +390,16 @@
                     maxRoadPartNumber.reportValidity();
             }
 
-            function validateDate(date) {
-                if (dateutil.isValidDate(date)) {
-                    if(!dateutil.isDateInYearRange(date, ViiteConstants.MIN_YEAR_INPUT, ViiteConstants.MAX_YEAR_INPUT))
+            function validateDate(dateString) {
+                if (dateutil.isFinnishDateString(dateString)) {
+                    if (dateutil.isDateInYearRange(roadAddrSituationDateObject, ViiteConstants.MIN_YEAR_INPUT, ViiteConstants.MAX_YEAR_INPUT)) {
+                        roadAddrSituationDate.setCustomValidity("");
+                    } else {
                         roadAddrSituationDate.setCustomValidity("Vuosiluvun tulee olla väliltä " + ViiteConstants.MIN_YEAR_INPUT + " - " + ViiteConstants.MAX_YEAR_INPUT);
-                }
-                else
+                    }
+                } else {
                     roadAddrSituationDate.setCustomValidity("Päivämäärän tulee olla muodossa pp.kk.yyyy");
+                }
             }
 
             function validateElyAndRoadNumber (elyElement, roadNumberElement) {
@@ -405,7 +408,7 @@
             }
 
             function willPassValidations() {
-                validateDate(roadAddrSituationDateObject);
+                validateDate(roadAddrSituationDate.value);
                 validateElyAndRoadNumber(ely, roadNumber);
                 return reportValidations();
             }


### PR DESCRIPTION
Added isFinnishDateString function to [date-utils.js](https://github.com/finnishtransportagency/viite/compare/VIITE-3084_date_validation?expand=1#diff-d34e60de5601adc53af074a8fc4faccc86b25d8c49f995c904a6ded7273d8097) to check for correct date format of dd.mm.yyyy with 31 days and 12 months. 

It's now used in validateDate function in [RoadAddressBrowserWindow.js](https://github.com/finnishtransportagency/viite/compare/VIITE-3084_date_validation?expand=1#diff-f40912904efc8cc9ef7b8f3dd1d271c404b7dea77d36e44a69818f8001e0b9cc) to check for correct format of the input string.  

Modified willPassValidations to pass input value as a string instead of date object to validateDate.

Added event listener to clear the date error message when user starts typing the date again.