### PR TITLE
Viite 3097 road address changes browser modification

### DIFF
--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/RoadwayChangesDAO.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/RoadwayChangesDAO.scala
@@ -520,6 +520,10 @@ SELECT
         LEFT JOIN road_name rn ON rn.road_number = COALESCE(rc.new_road_number, rc.old_road_number)
           AND rn.valid_to IS NULL
           AND rn.start_date <= p.start_date
+           -- End date should be null if the change is not a termination (5).
+           -- If the road is terminated, the end date is the same as the end date of the road  (if the whole road was terminated in this project) or null if the start date of the road name start date is earlier than the start date of the project
+          AND ((rc.change_type != 5 and rn.end_date IS null) OR (rc.change_type = 5 and (rn.end_date = (p.start_date - INTERVAL '1 DAY') or (rn.end_date is null and rn.start_date < p.start_date))))
+
         ORDER BY p.start_date, rc.new_road_number, rc.new_road_part_number, rc.new_start_addr_m, rc.new_track
       """.stripMargin
 

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/RoadwayChangesDAOSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/RoadwayChangesDAOSpec.scala
@@ -588,8 +588,8 @@ class RoadwayChangesDAOSpec extends FunSuite with Matchers {
       val adminClass = 1
       val discontinuity = 1L
       val trackCombined = 0L
-      val startDate1 = "2022-01-01"
-      val startDate2 = "2022-07-01"
+      val queryStartDate1 = "2022-01-01"
+      val queryStartDate2 = "2022-07-01"
       val projectStartDate = DateTime.parse("2022-06-01")
       val projectEndDate = DateTime.parse("2022-06-30")
 
@@ -632,10 +632,10 @@ class RoadwayChangesDAOSpec extends FunSuite with Matchers {
 
       // Fetch change infos for the specified roadNumber and roadPartNumber
       val dateTargetProjectAccepted = "ProjectAcceptedDate"
-      val result = dao.fetchChangeInfosForRoadAddressChangesBrowser(Some(startDate1), None, Some(dateTargetProjectAccepted), None, Some(roadNumber), Some(firstRoadPartNumber), Some(firstRoadPartNumber))
+      val result = dao.fetchChangeInfosForRoadAddressChangesBrowser(Some(queryStartDate1), None, Some(dateTargetProjectAccepted), None, Some(roadNumber), Some(firstRoadPartNumber), Some(firstRoadPartNumber))
       result.size should be >= 4 // Expecting 4 change infos
 
-      val result2 = dao.fetchChangeInfosForRoadAddressChangesBrowser(Some(startDate2), None, Some(dateTargetProjectAccepted), None, Some(roadNumber), Some(firstRoadPartNumber), Some(firstRoadPartNumber))
+      val result2 = dao.fetchChangeInfosForRoadAddressChangesBrowser(Some(queryStartDate2), None, Some(dateTargetProjectAccepted), None, Some(roadNumber), Some(firstRoadPartNumber), Some(firstRoadPartNumber))
       result2.size should be >= 2 // Expecting 2 change infos after startDate2
 
       // Check that both firstRoadPartNumber and secondRoadPartNumber are included in the results


### PR DESCRIPTION
VIITE-3097 Road address changes browser now returns whole project data for every matching criteria. 

Updated fetchChangeInfosForRoadAddressChangesBrowser to get all road address changes that are linked to projects that fit the search criteria. Replaced multiple if clauses to use Seq and map() to make the dynamic SQL query construction more straightforward.  

In the constructed query RelevantProjects filters projects based on searched criteria and AllRelatedRoadwayChanges fetches all road address changes  related to RelevantProjects.

Added a new unit test to check that the updated fetchChangeInfosForRoadAddressChangesBrowser correctly returns all related road address changes linked to projects. The test checks that, when multiple projects affect the same road part which is searched, the method should return all road way changes linked to the projects, even outside the filtered criteria (road part number in this case) and that the fetch returns correctly with the given date window.  