### PR TITLE
Viite 3085 date validation for road address changes browser window

### DIFF
--- a/viite-UI/src/utils/date-utils.js
+++ b/viite-UI/src/utils/date-utils.js
@@ -20,7 +20,7 @@
 
   dateUtils.isFinnishDateString = function (dateString) {
     // Regular expression to match date format with day 1-31 and month 1-12
-    const regex = /^(0?[1-9]|[12]\d|3[01])\.(0?[1-9]|1[0-2])\.(\d{4})$/;
+    const regex = /^(?<day>0?[1-9]|[12]\d|3[01])\.(?<month>0?[1-9]|1[0-2])\.(\d{4})$/;
     return regex.test(dateString);
   };
 

--- a/viite-UI/src/utils/date-utils.js
+++ b/viite-UI/src/utils/date-utils.js
@@ -20,7 +20,7 @@
 
   dateUtils.isFinnishDateString = function (dateString) {
     // Regular expression to match date format with day 1-31 and month 1-12
-    const regex = /^(?<day>0?[1-9]|[12]\d|3[01])\.(?<month>0?[1-9]|1[0-2])\.(\d{4})$/;
+    const regex = /^(?<day>0?[1-9]|[12]\d|3[01])\.(?<month>0?[1-9]|1[0-2])\.(?<year>\d{4})$/;
     return regex.test(dateString);
   };
 

--- a/viite-UI/src/view/RoadAddressBrowserWindow.js
+++ b/viite-UI/src/view/RoadAddressBrowserWindow.js
@@ -449,7 +449,7 @@
                 case "Nodes":
                 case "Junctions":
                 case "RoadNames":
-                    validateDate(roadAddrSituationDateObject);
+                    validateDate(roadAddrSituationDate.value);
                     if (reportValidations())
                         fetchByTargetValue(createParams());
                     break;

--- a/viite-UI/src/view/RoadAddressChangesBrowserWindow.js
+++ b/viite-UI/src/view/RoadAddressChangesBrowserWindow.js
@@ -157,18 +157,20 @@
             }
 
             function validateDate(dateString, dateElement) {
-                if (dateutil.isFinnishDateString(dateString)) {
+                // Check format ignoring whitespace
+                if (dateutil.isFinnishDateString(dateString.trim())) {
                     const dateObject = moment(dateString, "DD-MM-YYYY").toDate();
                     if (dateutil.isDateInYearRange(dateObject, ViiteConstants.MIN_YEAR_INPUT, ViiteConstants.MAX_YEAR_INPUT)) {
                         dateElement.setCustomValidity("");
                     } else {
                         dateElement.setCustomValidity("Vuosiluvun tulee olla väliltä " + ViiteConstants.MIN_YEAR_INPUT + " - " + ViiteConstants.MAX_YEAR_INPUT);
-                        dateElement.reportValidity();
+                        return false;
                     }
                 } else {
                     dateElement.setCustomValidity("Päivämäärän tulee olla muodossa pp.kk.yyyy");
-                    dateElement.reportValidity();
+                    return false;
                 }
+                return true;
             }
 
             // Clear date error message when typing is started again
@@ -183,20 +185,16 @@
             });
 
             function willPassValidations() {
-                if (roadAddrChangesStartDate.value.trim()) {
-                    // If start date is provided, validate it
+                // If start date is provided, validate it
+                if (roadAddrChangesStartDate.value.trim().length > 0) {
                     validateDate(roadAddrChangesStartDate.value, roadAddrChangesStartDate);
                 } else {
                     // If start date is not provided, set custom validity
                     roadAddrChangesStartDate.setCustomValidity("Alkupäivämäärä on pakollinen tieto");
-                    roadAddrChangesStartDate.reportValidity();
-                    return false;
                 }
-
-                validateDate(roadAddrChangesStartDate.value, roadAddrChangesStartDate);
-                if (roadAddrChangesEndDate.value) {
-                    validateDate(roadAddrChangesEndDate.value, roadAddrChangesEndDate);
-                    if (roadAddrEndDateObject.getTime() < roadAddrStartDateObject.getTime()) {
+                // Validate end date
+                if (roadAddrChangesEndDate.value && validateDate(roadAddrChangesEndDate.value, roadAddrChangesEndDate)) {
+                        if (roadAddrEndDateObject.getTime() < roadAddrStartDateObject.getTime()) {
                         roadAddrChangesEndDate.setCustomValidity("Loppupäivämäärä ei voi olla ennen alkupäivämäärää");
                     }
                 }

--- a/viite-UI/src/view/RoadAddressChangesBrowserWindow.js
+++ b/viite-UI/src/view/RoadAddressChangesBrowserWindow.js
@@ -194,7 +194,7 @@
                 }
                 // Validate end date
                 if (roadAddrChangesEndDate.value && validateDate(roadAddrChangesEndDate.value, roadAddrChangesEndDate)) {
-                        if (roadAddrEndDateObject.getTime() < roadAddrStartDateObject.getTime()) {
+                    if (roadAddrEndDateObject.getTime() < roadAddrStartDateObject.getTime()) {
                         roadAddrChangesEndDate.setCustomValidity("Loppupäivämäärä ei voi olla ennen alkupäivämäärää");
                     }
                 }

--- a/viite-UI/src/view/RoadAddressChangesBrowserWindow.js
+++ b/viite-UI/src/view/RoadAddressChangesBrowserWindow.js
@@ -162,6 +162,7 @@
                     const dateObject = moment(dateString, "DD-MM-YYYY").toDate();
                     if (dateutil.isDateInYearRange(dateObject, ViiteConstants.MIN_YEAR_INPUT, ViiteConstants.MAX_YEAR_INPUT)) {
                         dateElement.setCustomValidity("");
+                        return true;
                     } else {
                         dateElement.setCustomValidity("Vuosiluvun tulee olla väliltä " + ViiteConstants.MIN_YEAR_INPUT + " - " + ViiteConstants.MAX_YEAR_INPUT);
                         return false;
@@ -170,7 +171,6 @@
                     dateElement.setCustomValidity("Päivämäärän tulee olla muodossa pp.kk.yyyy");
                     return false;
                 }
-                return true;
             }
 
             // Clear date error message when typing is started again

--- a/viite-UI/src/view/RoadAddressChangesBrowserWindow.js
+++ b/viite-UI/src/view/RoadAddressChangesBrowserWindow.js
@@ -156,24 +156,55 @@
                     maxRoadPartNumber.reportValidity();
             }
 
-            function validateDate(date) {
-                if (dateutil.isValidDate(date)) {
-                    if(!dateutil.isDateInYearRange(date, ViiteConstants.MIN_YEAR_INPUT, ViiteConstants.MAX_YEAR_INPUT))
-                        roadAddrChangesStartDate.setCustomValidity("Vuosiluvun tulee olla väliltä " + ViiteConstants.MIN_YEAR_INPUT + " - " + ViiteConstants.MAX_YEAR_INPUT);
+            function validateDate(dateString, dateElement) {
+                if (dateutil.isFinnishDateString(dateString)) {
+                    const dateObject = moment(dateString, "DD-MM-YYYY").toDate();
+                    if (dateutil.isDateInYearRange(dateObject, ViiteConstants.MIN_YEAR_INPUT, ViiteConstants.MAX_YEAR_INPUT)) {
+                        dateElement.setCustomValidity("");
+                    } else {
+                        dateElement.setCustomValidity("Vuosiluvun tulee olla väliltä " + ViiteConstants.MIN_YEAR_INPUT + " - " + ViiteConstants.MAX_YEAR_INPUT);
+                        dateElement.reportValidity();
+                    }
+                } else {
+                    dateElement.setCustomValidity("Päivämäärän tulee olla muodossa pp.kk.yyyy");
+                    dateElement.reportValidity();
                 }
-                else
-                    roadAddrChangesStartDate.setCustomValidity("Päivämäärän tulee olla muodossa pp.kk.yyyy");
             }
 
+            // Clear date error message when typing is started again
+            roadAddrChangesStartDate.addEventListener('input', function() {
+                validateDate(this.value, this);
+                this.setCustomValidity("");
+            });
+
+            roadAddrChangesEndDate.addEventListener('input', function() {
+                validateDate(this.value, this);
+                this.setCustomValidity("");
+            });
+
             function willPassValidations() {
-                validateDate(roadAddrStartDateObject);
+                if (roadAddrChangesStartDate.value.trim()) {
+                    // If start date is provided, validate it
+                    validateDate(roadAddrChangesStartDate.value, roadAddrChangesStartDate);
+                } else {
+                    // If start date is not provided, set custom validity
+                    roadAddrChangesStartDate.setCustomValidity("Alkupäivämäärä on pakollinen tieto");
+                    roadAddrChangesStartDate.reportValidity();
+                    return false;
+                }
+
+                validateDate(roadAddrChangesStartDate.value, roadAddrChangesStartDate);
                 if (roadAddrChangesEndDate.value) {
-                    validateDate(roadAddrEndDateObject);
+                    validateDate(roadAddrChangesEndDate.value, roadAddrChangesEndDate);
                     if (roadAddrEndDateObject.getTime() < roadAddrStartDateObject.getTime()) {
                         roadAddrChangesEndDate.setCustomValidity("Loppupäivämäärä ei voi olla ennen alkupäivämäärää");
                     }
                 }
                 return reportValidations();
+            }
+
+            if (!willPassValidations()) {
+                return; // Stop execution if validation fails
             }
 
             function createParams() {


### PR DESCRIPTION
The isFinnishDateString now uses named capture groups in the regex as ESLint warnings suggests.

The switch (targetValue.value) in RoadAddressBrowserWindow.js was still incorrectly using date object as a parameter instead of string value, which is now used with validateDate. (Forgot this in https://github.com/finnishtransportagency/viite/pull/1559 PR).

The validateDate now uses isFinnishDateString to check for the correct format of both startDate and endDate. If startDate is not provided the search is denied with "Alkupäivämäärä on pakollinen tieto" validation warning. Added eventListeners for date inputs to empty the validation warning when typing is continued.


