### PR TITLE
VIITE-3118 nodes/valid Change exception handing to returning an InternalServerError instead of halting. …

### DIFF
--- a/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/IntegrationApi.scala
+++ b/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/IntegrationApi.scala
@@ -429,7 +429,8 @@ println("Threading print test: Now in avoidRestrictions")
           validNodesWithJunctionsToApi(fetchedNodesWithJunctions)
         } catch {
           case t: Throwable =>
-            handleCommonIntegrationAPIExceptions(t, getValidNodes.operationId)
+            //handleCommonIntegrationAPIExceptions(t, getValidNodes.operationId)  // Use if _not_ using avoidRestrictions
+            InternalServerError(t.getMessage)                                     // Use if _using_ avoidRestrictions
         }
       }
     }


### PR DESCRIPTION
…This way the Future returns a value that can be passed further.