### PR TITLE
Viite-3124 validate calibration point integrity

### DIFF
--- a/viite-UI/src/view/RoadNetworkErrorsList.js
+++ b/viite-UI/src/view/RoadNetworkErrorsList.js
@@ -27,6 +27,8 @@
                         showMissingCalibrationPoints(result.missingCalibrationPointsFromStart.concat(result.missingCalibrationPointsFromEnd));
                     if (result.missingCalibrationPointsFromJunctions.length > 0)
                         showMissingCalibrationPointsForJunctions(result.missingCalibrationPointsFromJunctions);
+                    if (result.linksWithExtraCalibrationPoints.length > 0)
+                        showLinksWithExtraCalibrationPoints(result.linksWithExtraCalibrationPoints);
                     if (result.missingRoadwayPointsFromStart.length > 0 || result.missingRoadwayPointsFromEnd.length > 0)
                         showMissingRoadwayPoints(result.missingRoadwayPointsFromStart.concat(result.missingRoadwayPointsFromEnd));
                     if (result.invalidRoadwayLengths.length > 0)
@@ -102,6 +104,33 @@
                                     <td>${cp.junctionPointId}</td>
                                 </tr>`);
                 table.append(string);
+            });
+            contentWrapper.append(table);
+        };
+
+        const showLinksWithExtraCalibrationPoints = function (linksWithExtraCalibrationPoints) {
+            const contentWrapper = $('#roadNetworkErrorWindowContent');
+            contentWrapper.append('<h3>Linkit joilla on ylimääräisiä kalibrointipisteitä</h3>');
+            const table = $('<table class="viite-table"> ' +
+                '<thead> ' +
+                '<th>Linkin Id</th>' +
+                '<th>Tie</th>' +
+                '<th>Osa</th>' +
+                '<th>Kpl/Alku</th>' +
+                '<th>Kpl/Loppu</th>' +
+                '<th>Kalibrointipisteiden Id:t</th>'+
+                '</thead>' +
+                '<tbody></tbody></table>');
+            linksWithExtraCalibrationPoints.forEach((link) => {
+                const tableRow = $(`<tr>
+                            <td>${link.linkId}</td>
+                            <td>${link.roadNumber}</td>
+                            <td>${link.roadPartNumber}</td>
+                            <td>${link.startCount}</td>
+                            <td>${link.endCount}</td>
+                            <td>${link.calibrationPoints}</td>
+                        </tr>`);
+                table.append(tableRow);
             });
             contentWrapper.append(table);
         };

--- a/viite-UI/src/view/RoadNetworkErrorsList.js
+++ b/viite-UI/src/view/RoadNetworkErrorsList.js
@@ -27,6 +27,8 @@
                         showMissingCalibrationPoints(result.missingCalibrationPointsFromStart.concat(result.missingCalibrationPointsFromEnd));
                     if (result.missingCalibrationPointsFromJunctions.length > 0)
                         showMissingCalibrationPointsForJunctions(result.missingCalibrationPointsFromJunctions);
+                    if (result.linksWithExtraCalibrationPointsOnSameRoadway.length > 0)
+                        showLinksWithExtraCalibrationPointsOnSameRoadway(result.linksWithExtraCalibrationPointsOnSameRoadway);
                     if (result.linksWithExtraCalibrationPoints.length > 0)
                         showLinksWithExtraCalibrationPoints(result.linksWithExtraCalibrationPoints);
                     if (result.missingRoadwayPointsFromStart.length > 0 || result.missingRoadwayPointsFromEnd.length > 0)
@@ -104,6 +106,33 @@
                                     <td>${cp.junctionPointId}</td>
                                 </tr>`);
                 table.append(string);
+            });
+            contentWrapper.append(table);
+        };
+
+        const showLinksWithExtraCalibrationPointsOnSameRoadway = function (linksWithExtraCalibrationPointsOnSameRoadway) {
+            const contentWrapper = $('#roadNetworkErrorWindowContent');
+            contentWrapper.append('<h3>Linkit joilla on ylimääräisiä kalibrointipisteitä samalla roadwayllä (estää kartan päivittymisen)</h3>');
+            const table = $('<table class="viite-table"> ' +
+                '<thead> ' +
+                '<th>Linkin Id</th>' +
+                '<th>Tie</th>' +
+                '<th>Osa</th>' +
+                '<th>Kpl/Alku</th>' +
+                '<th>Kpl/Loppu</th>' +
+                '<th>Kalibrointipisteiden Id:t</th>'+
+                '</thead>' +
+                '<tbody></tbody></table>');
+            linksWithExtraCalibrationPointsOnSameRoadway.forEach((link) => {
+                const tableRow = $(`<tr>
+                            <td>${link.linkId}</td>
+                            <td>${link.roadNumber}</td>
+                            <td>${link.roadPartNumber}</td>
+                            <td>${link.startCount}</td>
+                            <td>${link.endCount}</td>
+                            <td>${link.calibrationPoints}</td>
+                        </tr>`);
+                table.append(tableRow);
             });
             contentWrapper.append(table);
         };

--- a/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
+++ b/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
@@ -349,6 +349,7 @@ class ViiteApi(val roadLinkService: RoadLinkService, val KGVClient: KgvRoadLink,
         val missingCalibrationPointsFromTheEnd = roadNetworkValidator.getMissingCalibrationPointsFromTheEnd
         val missingCalibrationPointsFromJunctions = roadNetworkValidator.getMissingCalibrationPointsFromJunctions
         val linksWithExtraCalibrationPoints = roadNetworkValidator.getLinksWithExtraCalibrationPoints
+        val linksWithExtraCalibrationPointsOnSameRoadway = roadNetworkValidator.getLinksWithExtraCalibrationPointsOnSameRoadway
         val missingRoadwayPointsFromTheStart = roadNetworkValidator.getMissingRoadwayPointsFromTheStart
         val missingRoadwayPointsFromTheEnd = roadNetworkValidator.getMissingRoadwayPointsFromTheEnd
         val invalidRoadwayLengths = roadNetworkValidator.getInvalidRoadwayLengths
@@ -359,7 +360,8 @@ class ViiteApi(val roadLinkService: RoadLinkService, val KGVClient: KgvRoadLink,
           "missingCalibrationPointsFromStart" -> missingCalibrationPointsFromTheStart.map(cp => missingCalibrationPointToApi(cp)),
           "missingCalibrationPointsFromEnd" -> missingCalibrationPointsFromTheEnd.map(cp => missingCalibrationPointToApi(cp)),
           "missingCalibrationPointsFromJunctions" -> missingCalibrationPointsFromJunctions.map(cp => missingCalibrationPointFromJunctionToApi(cp)),
-          "linksWithExtraCalibrationPoints" -> linksWithExtraCalibrationPoints.map(cp => linksWithExtraCalibrationPointsToApi(cp)),
+          "linksWithExtraCalibrationPoints" -> linksWithExtraCalibrationPoints.map(l => linksWithExtraCalibrationPointsToApi(l)),
+          "linksWithExtraCalibrationPointsOnSameRoadway" -> linksWithExtraCalibrationPointsOnSameRoadway.map(l => linksWithExtraCalibrationPointsOnSameRoadwayToApi(l)),
           "missingRoadwayPointsFromStart" -> missingRoadwayPointsFromTheStart.map(rwp => missingRoadwayPointToApi(rwp)),
           "missingRoadwayPointsFromEnd" -> missingRoadwayPointsFromTheEnd.map(rwp => missingRoadwayPointToApi(rwp)),
           "invalidRoadwayLengths" -> invalidRoadwayLengths.map(rw => invalidRoadwayLengthToApi(rw)),
@@ -401,6 +403,17 @@ class ViiteApi(val roadLinkService: RoadLinkService, val KGVClient: KgvRoadLink,
   }
 
   def linksWithExtraCalibrationPointsToApi(link: LinksWithExtraCalibrationPoints): Map[String, Any] = {
+    Map(
+      "linkId" -> link.linkId,
+      "roadNumber" -> link.roadPart.roadNumber,
+      "roadPartNumber" -> link.roadPart.partNumber,
+      "startCount" -> link.startCount,
+      "endCount" -> link.endCount,
+      "calibrationPoints" -> link.calibrationPointIds
+    )
+  }
+
+  def linksWithExtraCalibrationPointsOnSameRoadwayToApi(link: LinksWithExtraCalibrationPoints): Map[String, Any] = {
     Map(
       "linkId" -> link.linkId,
       "roadNumber" -> link.roadPart.roadNumber,

--- a/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
+++ b/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
@@ -340,7 +340,7 @@ class ViiteApi(val roadLinkService: RoadLinkService, val KGVClient: KgvRoadLink,
   private val getRoadNetworkErrors: SwaggerSupportSyntax.OperationBuilder = (
     apiOperation[Map[String, Any]]("roadnetworkerrors")
       tags "ViiteAPI - RoadNetworkErrors"
-      summary "Runs road network integrity checks, returning all the found errors, e.g. missing points (roadway p., calibration p.), or roadways' integrity errors"
+      summary "Runs road network integrity checks, returning all the found errors, e.g. missing or extra points (roadway p., calibration p.), or roadways' integrity errors"
     )
   get("/roadnetworkerrors", operation(getRoadNetworkErrors)) {
     time(logger, s"GET request for /roadnetworkerrors") {
@@ -348,6 +348,7 @@ class ViiteApi(val roadLinkService: RoadLinkService, val KGVClient: KgvRoadLink,
         val missingCalibrationPointsFromTheStart = roadNetworkValidator.getMissingCalibrationPointsFromTheStart
         val missingCalibrationPointsFromTheEnd = roadNetworkValidator.getMissingCalibrationPointsFromTheEnd
         val missingCalibrationPointsFromJunctions = roadNetworkValidator.getMissingCalibrationPointsFromJunctions
+        val linksWithExtraCalibrationPoints = roadNetworkValidator.getLinksWithExtraCalibrationPoints
         val missingRoadwayPointsFromTheStart = roadNetworkValidator.getMissingRoadwayPointsFromTheStart
         val missingRoadwayPointsFromTheEnd = roadNetworkValidator.getMissingRoadwayPointsFromTheEnd
         val invalidRoadwayLengths = roadNetworkValidator.getInvalidRoadwayLengths
@@ -358,6 +359,7 @@ class ViiteApi(val roadLinkService: RoadLinkService, val KGVClient: KgvRoadLink,
           "missingCalibrationPointsFromStart" -> missingCalibrationPointsFromTheStart.map(cp => missingCalibrationPointToApi(cp)),
           "missingCalibrationPointsFromEnd" -> missingCalibrationPointsFromTheEnd.map(cp => missingCalibrationPointToApi(cp)),
           "missingCalibrationPointsFromJunctions" -> missingCalibrationPointsFromJunctions.map(cp => missingCalibrationPointFromJunctionToApi(cp)),
+          "linksWithExtraCalibrationPoints" -> linksWithExtraCalibrationPoints.map(cp => linksWithExtraCalibrationPointsToApi(cp)),
           "missingRoadwayPointsFromStart" -> missingRoadwayPointsFromTheStart.map(rwp => missingRoadwayPointToApi(rwp)),
           "missingRoadwayPointsFromEnd" -> missingRoadwayPointsFromTheEnd.map(rwp => missingRoadwayPointToApi(rwp)),
           "invalidRoadwayLengths" -> invalidRoadwayLengths.map(rw => invalidRoadwayLengthToApi(rw)),
@@ -395,6 +397,17 @@ class ViiteApi(val roadLinkService: RoadLinkService, val KGVClient: KgvRoadLink,
       "junctionNumber"-> cp.junctionNumber,
       "nodeNumber" -> cp.nodeNumber,
       "beforeAfter" -> cp.beforeAfter
+    )
+  }
+
+  def linksWithExtraCalibrationPointsToApi(link: LinksWithExtraCalibrationPoints): Map[String, Any] = {
+    Map(
+      "linkId" -> link.linkId,
+      "roadNumber" -> link.roadPart.roadNumber,
+      "roadPartNumber" -> link.roadPart.partNumber,
+      "startCount" -> link.startCount,
+      "endCount" -> link.endCount,
+      "calibrationPoints" -> link.calibrationPointIds
     )
   }
 

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/RoadNetworkValidator.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/RoadNetworkValidator.scala
@@ -1,6 +1,6 @@
 package fi.liikennevirasto.viite
 
-import fi.liikennevirasto.viite.dao.{InvalidRoadwayLength, MissingCalibrationPoint, MissingCalibrationPointFromJunction, MissingRoadwayPoint, OverlappingRoadwayOnLinearLocation, RoadNetworkDAO, Roadway}
+import fi.liikennevirasto.viite.dao.{LinksWithExtraCalibrationPoints, InvalidRoadwayLength, MissingCalibrationPoint, MissingCalibrationPointFromJunction, MissingRoadwayPoint, OverlappingRoadwayOnLinearLocation, RoadNetworkDAO, Roadway}
 import fi.vaylavirasto.viite.model.RoadPart
 import fi.vaylavirasto.viite.postgis.PostGISDatabase.withDynSession
 import org.slf4j.LoggerFactory
@@ -24,6 +24,12 @@ class RoadNetworkValidator {
   def getMissingCalibrationPointsFromJunctions: Seq[MissingCalibrationPointFromJunction] = {
     withDynSession {
       roadNetworkDAO.fetchMissingCalibrationPointsFromJunctions()
+    }
+  }
+
+  def getLinksWithExtraCalibrationPoints: Seq[LinksWithExtraCalibrationPoints] = {
+    withDynSession {
+      roadNetworkDAO.fetchLinksWithExtraCalibrationPoints()
     }
   }
 

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/RoadNetworkValidator.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/RoadNetworkValidator.scala
@@ -33,6 +33,12 @@ class RoadNetworkValidator {
     }
   }
 
+  def getLinksWithExtraCalibrationPointsOnSameRoadway: Seq[LinksWithExtraCalibrationPoints] = {
+    withDynSession {
+      roadNetworkDAO.fetchLinksWithExtraCalibrationPointsWithSameRoadwayNumber()
+    }
+  }
+
   def getMissingRoadwayPointsFromTheStart: Seq[MissingRoadwayPoint] = {
     withDynSession {
       roadNetworkDAO.fetchMissingRoadwayPointsFromStart()
@@ -78,7 +84,7 @@ class RoadNetworkValidator {
     val missingCalibrationPointsFromStart = roadNetworkDAO.fetchMissingCalibrationPointsFromStart(roadPart)
     val missingCalibrationPointFromTheEnd = roadNetworkDAO.fetchMissingCalibrationPointsFromEnd(roadPart)
     val missingCalibrationPointFromJunction = roadNetworkDAO.fetchMissingCalibrationPointsFromJunctions(roadPart)
-    val extraCalibrationPoints = roadNetworkDAO.fetchExtraCalibrationPointsByRoadPart(roadPart)
+    val extraCalibrationPoints = roadNetworkDAO.fetchLinksWithExtraCalibrationPointsByRoadPart(roadPart)
     if (missingCalibrationPointsFromStart.nonEmpty) {
       logger.warn(s"Found missing calibration points for road part start: $roadPart:\r ${missingCalibrationPointsFromStart.mkString("\r ")}")
       throw new RoadNetworkValidationException(s"$MissingCalibrationPointFromTheStart (tieosa $roadPart)")

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/RoadNetworkValidator.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/RoadNetworkValidator.scala
@@ -78,6 +78,7 @@ class RoadNetworkValidator {
     val missingCalibrationPointsFromStart = roadNetworkDAO.fetchMissingCalibrationPointsFromStart(roadPart)
     val missingCalibrationPointFromTheEnd = roadNetworkDAO.fetchMissingCalibrationPointsFromEnd(roadPart)
     val missingCalibrationPointFromJunction = roadNetworkDAO.fetchMissingCalibrationPointsFromJunctions(roadPart)
+    val extraCalibrationPoints = roadNetworkDAO.fetchExtraCalibrationPointsByRoadPart(roadPart)
     if (missingCalibrationPointsFromStart.nonEmpty) {
       logger.warn(s"Found missing calibration points for road part start: $roadPart:\r ${missingCalibrationPointsFromStart.mkString("\r ")}")
       throw new RoadNetworkValidationException(s"$MissingCalibrationPointFromTheStart (tieosa $roadPart)")
@@ -89,6 +90,10 @@ class RoadNetworkValidator {
     else if (missingCalibrationPointFromJunction.nonEmpty) {
       logger.warn(s"Found missing calibration points from junctions for road part: $roadPart:\r ${missingCalibrationPointFromJunction.mkString("\r ")}")
       throw new RoadNetworkValidationException(s"$MissingCalibrationPointFromJunctions (tieosa $roadPart)")
+    }
+    else if (extraCalibrationPoints.nonEmpty) {
+      logger.warn(s"Found extra calibration points for road part: $roadPart:\r ${extraCalibrationPoints.map(_.toString).mkString("\r ")}")
+      throw new RoadNetworkValidationException(s"$LinkHasExtraCalibrationPoints (tieosa $roadPart)")
     }
     else {
       logger.info(s"Calibration points are valid for road part: $roadPart ")

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/RoadNetworkDAO.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/RoadNetworkDAO.scala
@@ -421,7 +421,7 @@ class RoadNetworkDAO extends BaseDAO {
   }
 
   /**
-   * Construct query to links with extra calibration points (more than one calibration point on start/end of the same link)
+   * Construct query to find links with extra calibration points (more than one calibration point on start/end of the same link)
    * @param roadPartFilter fetch extra calibration points for specific road part
    * @param sameRoadwayNumber fetch extra calibration points with the same roadway number
    * @return LinksWithExtraCalibrationPoints query

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/package.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/package.scala
@@ -146,6 +146,7 @@ package object viite {
   val MissingCalibrationPointFromJunctions = s"$IntegrityValidationError: Kalibrointipiste puuttuu liittymästä"
   val MissingRoadwayPointFromTheStart      = s"$IntegrityValidationError: Roadway point puuttuu kohteen alusta"
   val MissingRoadwayPointFromTheEnd        = s"$IntegrityValidationError: Roadway point puuttuu kohteen lopusta"
+  val LinkHasExtraCalibrationPoints        = s"$IntegrityValidationError: Linkillä on ylimääräisiä kalibrointipisteitä"
   val OverlappingRoadwaysOnLinearLocation  = s"$IntegrityValidationError: Liian monta roadwayta lineaarilokaatiolla"
   val InvalidRoadwayLengthTroughHistory    = s"$IntegrityValidationError: Roadwaylla pituuseroja historiassa"
   val OverlappingRoadwayInHistory          = s"$IntegrityValidationError: Tiellä esiintyy päällekkäisiä roadwayta historiassa"

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/RoadNetworkDAOSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/RoadNetworkDAOSpec.scala
@@ -106,6 +106,8 @@ class RoadNetworkDAOSpec extends FunSuite with Matchers {
 
       val geometry1 = Seq(Point(0.0, 0.0), Point(0.0,50.0))
       val geometry2 = Seq(Point(0.0, 50.0), Point(0.0, 100.0))
+      val geometry3 = Seq(Point(0.0, 100.0), Point(0.0, 150.0))
+      val geometry4 = Seq(Point(0.0, 150.0), Point(0.0, 200.0))
 
       val roadwayNumber1 = Sequences.nextRoadwayNumber
       val roadwayNumber2 = Sequences.nextRoadwayNumber
@@ -116,8 +118,8 @@ class RoadNetworkDAOSpec extends FunSuite with Matchers {
       // Create Roadways with different roadway numbers
       roadwayDAO.create(Seq(
         Roadway(Sequences.nextRoadwayId, roadwayNumber1, roadPart, AdministrativeClass.State, Track.Combined,Discontinuity.Continuous, 0, 100, false, DateTime.now().minusDays(1), None, "test", Some("Test road"), 9,TerminationCode.NoTermination, DateTime.now().minusDays(1),None),
-        Roadway(Sequences.nextRoadwayId, roadwayNumber2, roadPart, AdministrativeClass.State, Track.Combined,Discontinuity.EndOfRoad, 0, 100, false, DateTime.now().minusDays(1), None, "test", Some("Test road"), 9,TerminationCode.NoTermination, DateTime.now().minusDays(1),None),
-        Roadway(Sequences.nextRoadwayId, roadwayNumber3, roadPart, AdministrativeClass.State, Track.Combined,Discontinuity.EndOfRoad, 100, 200, false, DateTime.now().minusDays(1), None, "test", Some("Test road"), 9,TerminationCode.NoTermination, DateTime.now().minusDays(1),None)
+        Roadway(Sequences.nextRoadwayId, roadwayNumber2, roadPart, AdministrativeClass.State, Track.Combined,Discontinuity.Continuous, 100, 150, false, DateTime.now().minusDays(1), None, "test", Some("Test road"), 9,TerminationCode.NoTermination, DateTime.now().minusDays(1),None),
+        Roadway(Sequences.nextRoadwayId, roadwayNumber3, roadPart, AdministrativeClass.State, Track.Combined,Discontinuity.EndOfRoad, 150, 200, false, DateTime.now().minusDays(1), None, "test", Some("Test road"), 9,TerminationCode.NoTermination, DateTime.now().minusDays(1),None)
       ))
 
       // Create LinearLocations
@@ -141,13 +143,13 @@ class RoadNetworkDAOSpec extends FunSuite with Matchers {
           linkId2, 100.0, 150.0,
           SideCode.TowardsDigitizing, 10000000000L,
           (CalibrationPointReference(None, None), CalibrationPointReference(Some(150), Some(CalibrationPointType.RoadAddressCP))),
-          geometry1,LinkGeomSource.NormalLinkInterface,
+          geometry3,LinkGeomSource.NormalLinkInterface,
           roadwayNumber2,Some(DateTime.now().minusDays(1)), None),
         LinearLocation(Sequences.nextLinearLocationId, 4.0,
           linkId2, 150.0, 200.0,
           SideCode.TowardsDigitizing, 10000000000L,
           (CalibrationPointReference(None, None), CalibrationPointReference(Some(200), Some(CalibrationPointType.RoadAddressCP))),
-          geometry2, LinkGeomSource.NormalLinkInterface,
+          geometry4, LinkGeomSource.NormalLinkInterface,
           roadwayNumber3, Some(DateTime.now().minusDays(1)), None)
       ))
 


### PR DESCRIPTION
Added three methods to fetch links with extra calibration points from the database: 
1.  fetchLinksWithExtraCalibrationPoints
2.  fetchLinksWithExtraCalibrationPointsWithSameRoadwayNumber
- These are used with roadNetworkErrorWindowContent to show all the found links in the UI for the user
3.  fetchLinksWithExtraCalibrationPointsByRoadPart
- This is used with roadNetworkValidator to validateRoadNetwork before preserving project to DB
- It rises RoadNetworkValidationException: LinkHasExtraCalibrationPoints if links with extra calibration points are found

Added test to test that all three queries work as them should to find extra calibration points 