### PR TITLE
Viite-3134 fix to fetch and list extra calibration points correctly

### DIFF
--- a/viite-UI/src/view/RoadNetworkErrorsList.js
+++ b/viite-UI/src/view/RoadNetworkErrorsList.js
@@ -118,18 +118,19 @@
                 '<th>Linkin Id</th>' +
                 '<th>Tie</th>' +
                 '<th>Osa</th>' +
-                '<th>Kpl/Alku</th>' +
-                '<th>Kpl/Loppu</th>' +
+                '<th>Linkin Alku/Loppu</th>' +
+                '<th>Määrä</th>' +
                 '<th>Kalibrointipisteiden Id:t</th>'+
                 '</thead>' +
                 '<tbody></tbody></table>');
             linksWithExtraCalibrationPointsOnSameRoadway.forEach((link) => {
+                const startEndText = link.startEnd === 0 ? 'Alku' : (link.startEnd === 1 ? 'Loppu' : link.startEnd);
                 const tableRow = $(`<tr>
                             <td>${link.linkId}</td>
                             <td>${link.roadNumber}</td>
                             <td>${link.roadPartNumber}</td>
-                            <td>${link.startCount}</td>
-                            <td>${link.endCount}</td>
+                            <td>${startEndText}</td>
+                            <td>${link.calibrationPointCount + ' kpl'}</td>
                             <td>${link.calibrationPoints}</td>
                         </tr>`);
                 table.append(tableRow);
@@ -145,18 +146,19 @@
                 '<th>Linkin Id</th>' +
                 '<th>Tie</th>' +
                 '<th>Osa</th>' +
-                '<th>Kpl/Alku</th>' +
-                '<th>Kpl/Loppu</th>' +
+                '<th>Linkin Alku/Loppu</th>' +
+                '<th>Määrä</th>' +
                 '<th>Kalibrointipisteiden Id:t</th>'+
                 '</thead>' +
                 '<tbody></tbody></table>');
             linksWithExtraCalibrationPoints.forEach((link) => {
+                const startEndText = link.startEnd === 0 ? 'Alku' : (link.startEnd === 1 ? 'Loppu' : link.startEnd);
                 const tableRow = $(`<tr>
                             <td>${link.linkId}</td>
                             <td>${link.roadNumber}</td>
                             <td>${link.roadPartNumber}</td>
-                            <td>${link.startCount}</td>
-                            <td>${link.endCount}</td>
+                            <td>${startEndText}</td>
+                            <td>${link.calibrationPointCount + ' kpl'}</td>
                             <td>${link.calibrationPoints}</td>
                         </tr>`);
                 table.append(tableRow);

--- a/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
+++ b/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
@@ -407,8 +407,8 @@ class ViiteApi(val roadLinkService: RoadLinkService, val KGVClient: KgvRoadLink,
       "linkId" -> link.linkId,
       "roadNumber" -> link.roadPart.roadNumber,
       "roadPartNumber" -> link.roadPart.partNumber,
-      "startCount" -> link.startCount,
-      "endCount" -> link.endCount,
+      "startEnd" -> link.startEnd,
+      "calibrationPointCount" -> link.calibrationPointCount,
       "calibrationPoints" -> link.calibrationPointIds
     )
   }
@@ -418,8 +418,8 @@ class ViiteApi(val roadLinkService: RoadLinkService, val KGVClient: KgvRoadLink,
       "linkId" -> link.linkId,
       "roadNumber" -> link.roadPart.roadNumber,
       "roadPartNumber" -> link.roadPart.partNumber,
-      "startCount" -> link.startCount,
-      "endCount" -> link.endCount,
+      "startEnd" -> link.startEnd,
+      "calibrationPointCount" -> link.calibrationPointCount,
       "calibrationPoints" -> link.calibrationPointIds
     )
   }

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/RoadNetworkValidator.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/RoadNetworkValidator.scala
@@ -84,7 +84,7 @@ class RoadNetworkValidator {
     val missingCalibrationPointsFromStart = roadNetworkDAO.fetchMissingCalibrationPointsFromStart(roadPart)
     val missingCalibrationPointFromTheEnd = roadNetworkDAO.fetchMissingCalibrationPointsFromEnd(roadPart)
     val missingCalibrationPointFromJunction = roadNetworkDAO.fetchMissingCalibrationPointsFromJunctions(roadPart)
-    val extraCalibrationPoints = roadNetworkDAO.fetchLinksWithExtraCalibrationPointsByRoadPart(roadPart)
+    val extraCalibrationPoints = roadNetworkDAO.fetchLinksWithExtraCalibrationPoints(Some(roadPart))
     if (missingCalibrationPointsFromStart.nonEmpty) {
       logger.warn(s"Found missing calibration points for road part start: $roadPart:\r ${missingCalibrationPointsFromStart.mkString("\r ")}")
       throw new RoadNetworkValidationException(s"$MissingCalibrationPointFromTheStart (tieosa $roadPart)")

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/RoadNetworkDAO.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/RoadNetworkDAO.scala
@@ -432,11 +432,6 @@ class RoadNetworkDAO extends BaseDAO {
         AND r.valid_to IS NULL
         AND r.end_date IS NULL"""
 
-  private val selectAndCountCalibrationPoints =
-    """SELECT scp.link_id, r.road_number, r.road_part_number, scp.start_end,
-              count(DISTINCT cp.id) AS calibration_point_count,
-              array_agg(DISTINCT cp.id) AS calibration_point_ids"""
-
   private val joinGroupAndOrderCalibrationPointData =
     """JOIN
         roadway r ON rp.roadway_number = r.roadway_number

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/RoadNetworkDAOSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/RoadNetworkDAOSpec.scala
@@ -193,7 +193,7 @@ class RoadNetworkDAOSpec extends FunSuite with Matchers {
       val allLinksWithExtraCalPoints = dao.fetchLinksWithExtraCalibrationPoints()
       allLinksWithExtraCalPoints.map(_.linkId) should contain allOf (linkId1, linkId2)
 
-      val linksWithExtraCalibrationPointsByRoadPart = dao.fetchLinksWithExtraCalibrationPointsByRoadPart(roadPart)
+      val linksWithExtraCalibrationPointsByRoadPart = dao.fetchLinksWithExtraCalibrationPoints(Some(roadPart))
       linksWithExtraCalibrationPointsByRoadPart.map(_.linkId) should contain allOf (linkId1, linkId2)
 
     }


### PR DESCRIPTION
Fetching links with extra calibration points on same roadway number now counts the found calibration points correctly. 

Corrected and changed the presentation of data on Road Networks Errors List for better readability.