### PR TITLE
Viite-3137 & Viite-3139 handling of roadway points

### DIFF
--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/NodesAndJunctionsService.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/NodesAndJunctionsService.scala
@@ -928,7 +928,6 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
       val sortedRoadways = roadwayDAO.fetchAllByRoadwayNumbers(roadwayNumbersSection.toSet).sortBy(_.startAddrMValue)
 
       val (startAddrMValue, endAddrMValue) = (sortedRoadways.headOption.map(_.startAddrMValue), sortedRoadways.lastOption.map(_.endAddrMValue))
-      val junctionPointsFromObsoleteRoadwayPoints = getJunctionPointsFromObsoleteRoadwayPoints(roadwayPoints)
 
       val obsoleteNodePoints = sortedRoadways.flatMap { rw =>
         val nodePoints = nodePointDAO.fetchByRoadwayPointIds(roadwayPoints.filter(_.roadwayNumber == rw.roadwayNumber).map(_.id))
@@ -976,7 +975,7 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
         }
         affectedJunctionsPoints
       }
-      val allObsoleteJunctionPoints = junctionPointsFromObsoleteRoadwayPoints ++ obsoleteJunctionPoints
+      val allObsoleteJunctionPoints = obsoleteJunctionPoints ++ getJunctionPointsFromObsoleteRoadwayPoints(roadwayPoints)
       logger.info(s"Obsolete node points : ${obsoleteNodePoints.map(_.id).toSet}")
       logger.info(s"Obsolete junction points : ${allObsoleteJunctionPoints.map(_.id).toSet}")
       (obsoleteNodePoints, allObsoleteJunctionPoints)
@@ -1064,8 +1063,6 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
         getObsoleteNodePointsAndJunctionPointsByModifiedRoadwayNumbers(modifiedRoadwayNumbers, terminatedJunctionPoints)
       }
     }.values.flatten.toSeq
-
-    logger.info(s"Obsolete points from modified roadways : ${obsoletePointsFromModifiedRoadways.map { case (nodePoints, junctionPoints) => (nodePoints.map(_.id), junctionPoints.map(_.id)) }}")
 
     val obsoleteNodePoints = terminatedNodePoints ++ obsoletePointsFromModifiedRoadways.flatMap(_._1)
     val obsoleteJunctionPoints = terminatedJunctionPoints ++ obsoletePointsFromModifiedRoadways.flatMap(_._2)

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/NodesAndJunctionsService.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/NodesAndJunctionsService.scala
@@ -910,9 +910,8 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
 
     def getJunctionPointsFromObsoleteRoadwayPoints(roadwayPoints: Seq[RoadwayPoint]): Seq[JunctionPoint] = {
       // Find roadway points that are not on start or end of any project link
-      val obsoleteRoadwayPoints = roadwayPoints.filter { rwp =>
-        val exists = projectLinks.exists(pl => pl.roadwayNumber == rwp.roadwayNumber && (rwp.addrMValue == pl.addrMRange.start || rwp.addrMValue == pl.addrMRange.end))
-        !exists
+      val obsoleteRoadwayPoints = roadwayPoints.filterNot { rwp =>
+        projectLinks.exists(pl => pl.roadwayNumber == rwp.roadwayNumber && (rwp.addrMValue == pl.addrMRange.start || rwp.addrMValue == pl.addrMRange.end))
       }
       // Fetch junction points related to obsolete roadway points
       val obsoleteJunctionPointsFromRoadwayPoints = obsoleteRoadwayPoints.flatMap { rwp =>

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
@@ -955,6 +955,12 @@ class RoadAddressService(
           else {
             logger.info(s"Skipping roadway points' roadwayNumber (${rwp.roadwayNumber} -> ${newRwp.roadwayNumber}) and addrM (${rwp.addrMValue} -> ${newRwp.addrMValue}) update " +
               s"because a similar roadway point already exists in the database with these values (id: ${existingRoadwayPoint.get.id}, roadwayNumber: ${existingRoadwayPoint.get.roadwayNumber}, addrMValue: ${existingRoadwayPoint.get.addrMValue})")
+            // Expire the junction point related to the existing roadway point
+            val junctionPoints = junctionPointDAO.fetchByRoadwayPointId(rwp.id)
+            junctionPoints.foreach { jp =>
+              logger.info(s"Expiring junction point ${jp.id} related to skipped roadway_point ${rwp.id}")
+              junctionPointDAO.expireById(Seq(jp.id))
+            }
             Seq()
           }
         } else {

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
@@ -830,27 +830,27 @@ class RoadAddressService(
 
     // Expire calibration points not applied by project road changes logic
     startCPsToBeExpired.foreach {
-      ll =>
-        val cal = CalibrationPointDAO.fetch(ll.linkId, CalibrationPointLocation.StartOfLink.value)
+      cp =>
+        val cal = CalibrationPointDAO.fetch(cp.linkId, CalibrationPointLocation.StartOfLink.value)
         if (cal.isDefined) {
           CalibrationPointDAO.expireById(Set(cal.get.id))
           logger.info(s"Expiring calibration point id:" + cal.get.id)
           // Check if the expired calibrationpoint needs to be replaced with a JunctionCP
-          CalibrationPointsUtils.createCalibrationPointIfNeeded(ll.roadwayPointId, ll.linkId, CalibrationPointLocation.StartOfLink, CalibrationPointType.JunctionPointCP, username)
+          CalibrationPointsUtils.createCalibrationPointIfNeeded(cp.roadwayPointId, cp.linkId, CalibrationPointLocation.StartOfLink, CalibrationPointType.JunctionPointCP, username)
         } else {
-          logger.error(s"Failed to expire start calibration point for link id: ${ll.linkId}")
+          logger.error(s"Failed to expire start calibration point for link id: ${cp.linkId}")
         }
     }
     endCPsToBeExpired.foreach {
-      ll =>
-        val cal = CalibrationPointDAO.fetch(ll.linkId, CalibrationPointLocation.EndOfLink.value)
+      cp =>
+        val cal = CalibrationPointDAO.fetch(cp.linkId, CalibrationPointLocation.EndOfLink.value)
         if (cal.isDefined) {
           CalibrationPointDAO.expireById(Set(cal.get.id))
           logger.info(s"Expiring calibration point id:" + cal.get.id)
           // Check if the expired calibrationpoint needs to be replaced with a JunctionCP
-          CalibrationPointsUtils.createCalibrationPointIfNeeded(ll.roadwayPointId, ll.linkId, CalibrationPointLocation.EndOfLink, CalibrationPointType.JunctionPointCP, username)
+          CalibrationPointsUtils.createCalibrationPointIfNeeded(cp.roadwayPointId, cp.linkId, CalibrationPointLocation.EndOfLink, CalibrationPointType.JunctionPointCP, username)
         } else {
-          logger.error(s"Failed to expire end calibration point for link id: ${ll.linkId}")
+          logger.error(s"Failed to expire end calibration point for link id: ${cp.linkId}")
         }
     }
 
@@ -955,12 +955,6 @@ class RoadAddressService(
           else {
             logger.info(s"Skipping roadway points' roadwayNumber (${rwp.roadwayNumber} -> ${newRwp.roadwayNumber}) and addrM (${rwp.addrMValue} -> ${newRwp.addrMValue}) update " +
               s"because a similar roadway point already exists in the database with these values (id: ${existingRoadwayPoint.get.id}, roadwayNumber: ${existingRoadwayPoint.get.roadwayNumber}, addrMValue: ${existingRoadwayPoint.get.addrMValue})")
-            // Expire the junction point related to the existing roadway point
-            val junctionPoints = junctionPointDAO.fetchByRoadwayPointId(rwp.id)
-            junctionPoints.foreach { jp =>
-              logger.info(s"Expiring junction point ${jp.id} related to skipped roadway_point ${rwp.id}")
-              junctionPointDAO.expireById(Seq(jp.id))
-            }
             Seq()
           }
         } else {

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/RoadNetworkValidator.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/RoadNetworkValidator.scala
@@ -94,8 +94,10 @@ class RoadNetworkValidator {
       throw new RoadNetworkValidationException(s"$MissingCalibrationPointFromTheEnd (tieosa $roadPart)")
     }
     else if (missingCalibrationPointFromJunction.nonEmpty) {
-      logger.warn(s"Found missing calibration points from junctions for road part: $roadPart:\r ${missingCalibrationPointFromJunction.mkString("\r ")}")
-      throw new RoadNetworkValidationException(s"$MissingCalibrationPointFromJunctions (tieosa $roadPart)")
+      missingCalibrationPointFromJunction.foreach { missingPoint =>
+        logger.warn(s"Missing Calibration Point From Junction: RoadPart: ${missingPoint.missingCalibrationPoint.roadPart}, Track: ${missingPoint.missingCalibrationPoint.track}, AddrM: ${missingPoint.missingCalibrationPoint.addrM}, CreatedTime: ${missingPoint.missingCalibrationPoint.createdTime}, CreatedBy: ${missingPoint.missingCalibrationPoint.createdBy}, JunctionPointId: ${missingPoint.junctionPointId}, JunctionNumber: ${missingPoint.junctionNumber}, NodeNumber: ${missingPoint.nodeNumber}, BeforeAfter: ${missingPoint.beforeAfter}")
+      }
+      throw new RoadNetworkValidationException(s"$MissingCalibrationPointFromJunctions (tieosa $roadPart) \r ${missingCalibrationPointFromJunction.mkString("\r ")}")
     }
     else if (extraCalibrationPoints.nonEmpty) {
       logger.warn(s"Found extra calibration points for road part: $roadPart:\r ${extraCalibrationPoints.map(_.toString).mkString("\r ")}")


### PR DESCRIPTION
- Fixed issue where single roadway points were handled multiple times.
- Junction points that belong to skipped roadway points caused issues and are now expired as part of NodesAndJunctionsService.
- Better logging for risen missingCalibrationPointFromJunction RoadNetw
orkValidationException