### PR TITLE
VIITE-3141 upgrading (mostly minor) libraries:

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -11,25 +11,27 @@ object Digiroad2Build extends Build {
   val Version = "0.1.0-SNAPSHOT"
 
   val ScalaVersion = "2.11.7"
-  val ScalatraVersion = "2.6.5"
-  val ScalaTestVersion = "3.2.0-SNAP7"
+  val ScalatraVersion = "2.6.5" // "2.7.0" requires code changes. // "2.7.1" last scala 2.11 version
+  val ScalaTestVersion = "3.2.0-SNAP7" // "3.2.0-SNAP10" (next scala 2.11 version) requires code changes. "object org.scalatest.prop.Configuration$ not found."
 
   val JodaConvertVersion = "2.2.3" // no dependencies
-  val JodaTimeVersion = "2.12.5" // dep on joda-convert // TODO "Note that from Java SE 8 onwards, users are asked to migrate to java.time (JSR-310) - a core part of the JDK which replaces this project." (from https://mvnrepository.com/artifact/joda-time/joda-time)
-  val SlickVersion = "3.0.0"
+  val JodaTimeVersion = "2.12.7" // dep on joda-convert // TODO "Note that from Java SE 8 onwards, users are asked to migrate to java.time (JSR-310) - a core part of the JDK which replaces this project." (from https://mvnrepository.com/artifact/joda-time/joda-time)
+  val SlickVersion = "3.0.3" // 3.1.x and further requires significant changes in the database code, or library change maybe. // 3.4.x and further requires scala 2.12
   val JodaSlickMapperVersion = "2.2.0" // provides slick 3.1.1, joda-time 2.7, and joda-convert 1.7
 
   val AkkaVersion = "2.5.32" // 2.6.x and up requires Scala 2.12 or greater
-  val HttpClientVersion = "4.5.14"
-  val NewRelicApiVersion = "3.1.1"
-  val CommonsIOVersion = "2.6"
-  val JsonJacksonVersion = "3.7.0-M7" // with "3.7.0-M8" test does not compile
-  val MockitoCoreVersion = "4.11.0" // 5.0.0 and up requires Java update to Java 11: "java.lang.UnsupportedClassVersionError: org/mockito/Mockito has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0"
-  val LogbackClassicVersion = "1.3.6" // Java EE version. 1.4.x requires Jakarta instead of JavaEE
+  val HttpClientVersion  = "4.5.14"
+  val NewRelicApiVersion = "8.12.0"
+  val CommonsIOVersion   = "2.16.1"
+  val JsonJacksonVersion = "3.7.0-M11" // 3.7.0-M12 and up: could not find implicit value for evidence parameter of type org.json4s.AsJsonInput[org.json4s.StreamInput] //  4.0.6 last Scala 2.11 version
+  val MockitoCoreVersion    = "4.11.0" // last version working with java8 runtime // 5.0.0 and up requires Java update to Java 11: "java.lang.UnsupportedClassVersionError: org/mockito/Mockito has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0"
+  val LogbackClassicVersion = "1.3.14" // Java EE version. 1.4.x requires Jakarta instead of JavaEE
   val JettyVersion = "9.2.15.v20160210"
   val TestOutputOptions = Tests.Argument(TestFrameworks.ScalaTest, "-oNCXELOPQRMI") // List only problems, and their summaries. Set suitable logback level to get the effect.
-  val AwsSdkVersion = "2.17.148"
-  val GeoToolsVersion = "28.3"
+  val AwsSdkVersion       = "2.26.7" // "2.17.148"
+  val GeoToolsVersion     = "28.5" // "29.x" fails api/viite/roadaddress with Internal Server Error // available "31.1"
+  val GeoToolsIFVersion   = GeoToolsVersion // Differs from GeoToolsVersion after "29.2"
+  val JavaxServletVersion = "4.0.1"
 
   val jodaConvert    = "org.joda"             %  "joda-convert"  % JodaConvertVersion
   val jodaTime       = "joda-time"            %  "joda-time"     % JodaTimeVersion
@@ -79,14 +81,14 @@ object Digiroad2Build extends Build {
         jodaConvert,
         jodaTime,
         akkaActor,
-        "javax.media" % "jai_core" % "1.1.3" from "https://repo.osgeo.org/repository/release/javax/media/jai_core/1.1.3/jai_core-1.1.3.jar",
-        "org.geotools" % "gt-graph" % GeoToolsVersion from s"https://repo.osgeo.org/repository/release/org/geotools/gt-graph/$GeoToolsVersion/gt-graph-$GeoToolsVersion.jar",
-        "org.geotools" % "gt-main" % GeoToolsVersion from s"https://repo.osgeo.org/repository/release/org/geotools/gt-main/$GeoToolsVersion/gt-main-$GeoToolsVersion.jar",
+//        "javax.media" % "jai_core" % "1.1.3" from "https://repo.osgeo.org/repository/release/javax/media/jai_core/1.1.3/jai_core-1.1.3.jar",
+        "org.geotools" % "gt-graph"       % GeoToolsVersion from s"https://repo.osgeo.org/repository/release/org/geotools/gt-graph/$GeoToolsVersion/gt-graph-$GeoToolsVersion.jar",
+        "org.geotools" % "gt-main"        % GeoToolsVersion from s"https://repo.osgeo.org/repository/release/org/geotools/gt-main/$GeoToolsVersion/gt-main-$GeoToolsVersion.jar",
         "org.geotools" % "gt-referencing" % GeoToolsVersion from s"https://repo.osgeo.org/repository/release/org/geotools/gt-referencing/$GeoToolsVersion/gt-referencing-$GeoToolsVersion.jar",
-        "org.geotools" % "gt-metadata" % GeoToolsVersion from s"https://repo.osgeo.org/repository/release/org/geotools/gt-metadata/$GeoToolsVersion/gt-metadata-$GeoToolsVersion.jar",
-        "org.geotools" % "gt-opengis" % GeoToolsVersion from s"https://repo.osgeo.org/repository/release/org/geotools/gt-opengis/$GeoToolsVersion/gt-opengis-$GeoToolsVersion.jar",
+        "org.geotools" % "gt-metadata"    % GeoToolsVersion from s"https://repo.osgeo.org/repository/release/org/geotools/gt-metadata/$GeoToolsVersion/gt-metadata-$GeoToolsVersion.jar",
+        "org.geotools" % "gt-opengis"   % GeoToolsIFVersion from s"https://repo.osgeo.org/repository/release/org/geotools/gt-opengis/$GeoToolsIFVersion/gt-opengis-$GeoToolsIFVersion.jar",
         "jgridshift" % "jgridshift" % "1.0" from "https://repo.osgeo.org/repository/release/jgridshift/jgridshift/1.0/jgridshift-1.0.jar",
-        "org.locationtech.jts" % "jts-core" % "1.18.2" from "https://repo1.maven.org/maven2/org/locationtech/jts/jts-core/1.18.2/jts-core-1.18.2.jar",
+        "org.locationtech.jts" % "jts-core" % "1.19.0", // from "https://repo1.maven.org/maven2/org/locationtech/jts/jts-core/1.19.0/jts-core-1.19.0.jar",
         "org.scalatest" % "scalatest_2.11" % ScalaTestVersion % "test"
       )
     )
@@ -103,30 +105,30 @@ object Digiroad2Build extends Build {
       scalaVersion := ScalaVersion,
       //      resolvers ++= Seq(Classpaths.typesafeReleases,
       //        "maven-public" at "http://livibuild04.vally.local/nexus/repository/maven-public/",
-      //        "ivy-public" at "http://livibuild04.vally.local/nexus/repository/ivy-public/"),
+      //        "ivy-public"   at "http://livibuild04.vally.local/nexus/repository/ivy-public/"),
       resolvers += Classpaths.typesafeReleases,
       scalacOptions ++= Seq("-unchecked", "-feature"),
       testOptions in Test ++= (
         if (System.getProperty("digiroad2.nodatabase", "false") == "true") Seq(Tests.Argument("-l"), Tests.Argument("db")) else Seq()),
       testOptions in Test += TestOutputOptions,
       libraryDependencies ++= Seq(
-        "org.apache.commons" % "commons-lang3" % "3.2",
-        "commons-codec" % "commons-codec" % "1.15",
-        "com.jolbox" % "bonecp" % "0.8.0.RELEASE",
+        "org.apache.commons" % "commons-lang3" % "3.14.0",
+        "commons-codec"      % "commons-codec" % "1.17.0",
+        "com.jolbox"         % "bonecp"        % "0.8.0.RELEASE",
         "org.scalatest" % "scalatest_2.11" % ScalaTestVersion % "test",
-        "com.typesafe.slick" %% "slick" % SlickVersion,
+        "com.typesafe.slick" %% "slick"        % SlickVersion,
         jsonJackson,
         jodaConvert,
         jodaTime,
         "com.github.tototoshi" %% "slick-joda-mapper" % JodaSlickMapperVersion,
-        "com.github.tototoshi" %% "scala-csv" % "1.3.5",
+        "com.github.tototoshi" %% "scala-csv"         % "1.3.10",
         httpClient,
         "com.newrelic.agent.java" % "newrelic-api" % NewRelicApiVersion,
         mockitoCore % "test",
-        "com.googlecode.flyway" % "flyway-core" % "2.3.1",
-        "org.postgresql" % "postgresql" % "42.2.28",
-        "net.postgis" % "postgis-geometry" % "2021.1.0",
-        "net.postgis" % "postgis-jdbc" % "2021.1.0" // dep postgresql, and from 2.5.0 and up: postgis-geometry
+        "org.flywaydb"   % "flyway-core"   % "3.2.1", // 4.0 requires init code changes. Versions "10.0.0"+ available
+        "org.postgresql" % "postgresql"    % "42.7.3",
+        "net.postgis" % "postgis-geometry" % "2023.1.0",
+        "net.postgis" % "postgis-jdbc"     % "2023.1.0" // dep postgresql, and from 2.5.0 and up: postgis-geometry
       ),
       unmanagedResourceDirectories in Compile += baseDirectory.value / ".." / "conf"
     )
@@ -162,7 +164,7 @@ object Digiroad2Build extends Build {
         httpClient,
         "org.scalatra" %% "scalatra-swagger"  % ScalatraVersion,
         "com.github.nscala-time" %% "nscala-time" % "2.32.0",
-        "software.amazon.awssdk" % "s3" % AwsSdkVersion,
+        "software.amazon.awssdk" % "s3"  % AwsSdkVersion,
         "software.amazon.awssdk" % "sso" % AwsSdkVersion
       ),
       unmanagedResourceDirectories in Compile += baseDirectory.value / ".." / "conf"
@@ -199,7 +201,7 @@ object Digiroad2Build extends Build {
         "org.eclipse.jetty" % "jetty-servlets" % JettyVersion % "compile",
         "org.eclipse.jetty" % "jetty-proxy" % JettyVersion % "compile",
         "org.eclipse.jetty" % "jetty-jmx" % JettyVersion % "compile",
-        "org.eclipse.jetty.orbit" % "javax.servlet" % "3.0.0.v201112011016" % "provided;test" artifacts Artifact("javax.servlet", "jar", "jar")
+        "javax.servlet"     % "javax.servlet-api" % JavaxServletVersion % "provided"
       ),
       unmanagedResourceDirectories in Compile += baseDirectory.value / ".." / "conf"
     )
@@ -224,7 +226,7 @@ object Digiroad2Build extends Build {
         "org.scalatra" %% "scalatra" % ScalatraVersion,
         "org.scalatra" %% "scalatra-json" % ScalatraVersion,
         jsonJackson, jsonNative,
-        "org.scala-lang.modules"   %% "scala-parser-combinators" % "1.1.0",
+        "org.scala-lang.modules"   %% "scala-parser-combinators" % "1.1.2",
         "org.scalatest" % "scalatest_2.11" % ScalaTestVersion % "test",
         "org.scalatra" %% "scalatra-scalatest" % ScalatraVersion % "test",
         "org.scalatra" %% "scalatra-auth" % ScalatraVersion,
@@ -234,7 +236,7 @@ object Digiroad2Build extends Build {
         "commons-io" % "commons-io" % CommonsIOVersion,
         "com.newrelic.agent.java" % "newrelic-api" % NewRelicApiVersion,
         httpClient,
-        "org.scalatra" %% "scalatra-swagger"  % ScalatraVersion
+        "org.scalatra" %% "scalatra-swagger" % ScalatraVersion
       ),
       unmanagedResourceDirectories in Compile += baseDirectory.value / ".." / "conf"
     )
@@ -275,7 +277,7 @@ object Digiroad2Build extends Build {
         "org.eclipse.jetty" % "jetty-webapp" % JettyVersion % "container;compile",
         "org.eclipse.jetty" % "jetty-servlets" % JettyVersion % "container;compile",
         "org.eclipse.jetty" % "jetty-proxy" % JettyVersion % "container;compile",
-        "org.eclipse.jetty.orbit" % "javax.servlet" % "3.0.0.v201112011016" % "container;provided;test" artifacts (Artifact("javax.servlet", "jar", "jar"))
+        "javax.servlet"     % "javax.servlet-api" % JavaxServletVersion % "provided"
       )
     )
   ) dependsOn(baseJar, geoJar, DBJar, viiteJar, apiCommonJar, ApiJar) aggregate
@@ -285,8 +287,9 @@ object Digiroad2Build extends Build {
     .enablePlugins(GatlingPlugin)
     .settings(scalaVersion := ScalaVersion)
     .settings(libraryDependencies ++= Seq(
-      "io.gatling.highcharts" % "gatling-charts-highcharts" % "3.9.3" % "test",
-      "io.gatling" % "gatling-test-framework" % "3.9.3" % "test"))
+      "io.gatling.highcharts" % "gatling-charts-highcharts" % "3.11.3" % "test",
+      "io.gatling"            % "gatling-test-framework"    % "3.11.3" % "test"
+    ))
 
   val assemblySettings: Seq[Def.Setting[_]] = sbtassembly.Plugin.assemblySettings ++ Seq(
     mainClass in assembly := Some("fi.liikennevirasto.digiroad2.ProductionServer"),

--- a/viite-backend/database/src/main/scala/fi/liikennevirasto/digiroad2/util/DatabaseMigration.scala
+++ b/viite-backend/database/src/main/scala/fi/liikennevirasto/digiroad2/util/DatabaseMigration.scala
@@ -1,6 +1,6 @@
 package fi.liikennevirasto.digiroad2.util
 
-import com.googlecode.flyway.core.Flyway
+import org.flywaydb.core.Flyway
 import fi.vaylavirasto.viite.postgis.PostGISDatabase._
 
 object DatabaseMigration {

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/util/DataFixture.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/util/DataFixture.scala
@@ -1,7 +1,7 @@
 package fi.liikennevirasto.viite.util
 
 import java.util.Properties
-import com.googlecode.flyway.core.Flyway
+import org.flywaydb.core.Flyway
 import com.jolbox.bonecp.{BoneCPConfig, BoneCPDataSource}
 import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.client.kgv.KgvRoadLink


### PR DESCRIPTION
logback-classic  from 1.3.6          to 1.3.14   (Dec 01, 2023, currently newest of 1.3.x series. 1.4.x requires jakarta)
commons-codec    from 1.15           to 1.17.0   (Apr 27, 2024, currently newest)
commons-io       from 2.6            to 2.16.1   (Apr 08, 2024, currently newest)
scala-csv        from 1.3.5          to 1.3.10   (Dec 16, 2021, currently newest, still getting updates?)
flyway-core      from 2.3.1 (@com.googlecode.flyway) to 3.2.1 (@org.flywaydb, Mar 20, 2015, newer versions 4.x and up require code rewrite)
newrelic-api     from 3.1.1          to 8.12.0   (May 24, 2024, currently newest)
slick            from 3.0.0          to 3.0.3    (Sep 11, 2015, further versions 3.1.x and up require whole lib change, or massive DB code rewrite)
jts-core         from 1.18.2         to 1.19.0   (Jun 21, 2022, currently newest)
gatling          from 3.9.3          to 3.11.3   (May 22, 2024, currently newest)
jai_core         up-to-date, REMOVING 1.1.3      (Oct 24, 2017, current and ONLY version)
joda-time        from 2.12.5         to 2.12.7   (Feb 04, 2024, currently newest)
postgis-jdbc     from 2021.1.0       to 2023.1.0 (Dec 08, 2023, currently newest)
postgis-geometry from 2021.1.0       to 2023.1.0 (Dec 08, 2023, currently newest)
commons-lang3    from 3.2            to 3.14.0   (Nov 22, 2023, currently newest)
javax-servlet    from 3.0.0.v201112011016(@org.eclipse.jetty.orbit) to javax-servlet-api 4.0.1(@javax.servlet, Apr 20, 2018, further versions 4.0.2 and up require jakarta instead of java.)
geotools         from 28.3           to 28.5     (Sep 06, 2023, further versions 29.x      and up require code rewrite (Java Runtime))
json4s-jackson   from 3.7.0-M7      to 3.7.0-M11 (Mar 14, 2021, further versions 3.7.0-M12 and up require code rewrite. 4.0.6 (Sep 29, 2022) last version with Scala 2.11 support)
json4s-native    - " -
postgresql       from 42.2.28        to 42.7.3   (Mar 14, 2024, currently newest)
scala-parser-combinators from 1.0.0  to 1.1.2    (Jun 08, 2019, further versions 1.2.0xxx require code rewrite. 2.2.0 (Jan 27, 2023) last version with Scala 2.11 support.)
awssdk (s3,sso)  from 2.17.148       to 2.26.7   (Jun 20, 2024, currently newest)