### PR TITLE
VIITE-3146 Update Flyway to last 5.x version (5.2.4), and change refe…

### DIFF
--- a/Deployment.md
+++ b/Deployment.md
@@ -36,7 +36,7 @@ Tietokannan rakenne päivitetään automaattisesti buildauksien yhteydessä (ks.
 
 Automaattipäivitys on toteutettu [Flyway](http://flywaydb.org/)-tietokantamigraatiotyökalulla.
 Tietokantamigraatiomääritykset on versioitu `db.migration`-paketissa `database`-projektissa.
-Flyway päivittää tiedon käytössä olevasta migraatioversiosta tietokantaan itseensä; versiotieto löytyy taulusta `schema_version`.
+Flyway päivittää tiedon käytössä olevasta migraatioversiosta tietokantaan itseensä; versiotieto löytyy taulusta `flyway_schema_history`.
 
 Katso lisätietoja [Digiroad-2](README.md) artikkelista.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ by copying the xml-files from the `local-dev/idea-run-configurations` folder to 
 `.idea/runConfigurations` folder (under the project folder). Restart Idea to see the new run configurations.
 
 - Flyway_init.xml
-  - Initialize the database for Flyway by creating the `schema_version` table
+  - Initialize the database for Flyway by creating the `flyway_schema_history` table
 - Fixture_reset_test.xml
   - Empty the database, run the Flyway migrations, populate the database with the test data (required by the unit tests) 
 - Flyway_migrate.xml

--- a/project/build.scala
+++ b/project/build.scala
@@ -117,7 +117,7 @@ object Digiroad2Build extends Build {
         httpClient,
         "com.newrelic.agent.java" % "newrelic-api" % NewRelicApiVersion,
         mockitoCore % "test",
-        "org.flywaydb"   % "flyway-core"   % "4.2.0", // Versions "10.0.0"+ available
+        "org.flywaydb"   % "flyway-core"   % "5.2.4", // Versions "10.0.0"+ available
         "org.postgresql" % "postgresql"    % "42.7.3",
         "net.postgis" % "postgis-geometry" % "2023.1.0",
         "net.postgis" % "postgis-jdbc"     % "2023.1.0" // dep postgresql, and from 2.5.0 and up: postgis-geometry

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/util/DataFixture.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/util/DataFixture.scala
@@ -209,9 +209,9 @@ object DataFixture {
     // This old version of Flyway tries to drop the postgis extension too, so we clean the database manually instead
     SqlScriptRunner.runScriptInClasspath("/clear-db.sql")
     try {
-      SqlScriptRunner.executeStatement("delete from schema_version where installed_rank > 1")
+      SqlScriptRunner.executeStatement("delete from flyway_schema_history where installed_rank > 1")
     } catch {
-      case e: Exception => println(s"Failed to reset schema_version table: ${e.getMessage}")
+      case e: Exception => println(s"Failed to reset flyway_schema_history table: ${e.getMessage}")
     }
 
   }


### PR DESCRIPTION
…rences to the migration table previously used to the one used by the newer versions of Flyway. (#1644)

(This change requires manual flyway table name change into the db before the update. Tried by migration, but got into trouble. So be it.)