### PR TITLE
VIITE-3173 Mockito update

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -26,6 +26,7 @@ object Digiroad2Build extends Build {
   val CommonsIOVersion      = "2.16.1"
   val JsonJacksonVersion    = "3.7.0-M11" // 3.7.0-M12 and up: could not find implicit value for evidence parameter of type org.json4s.AsJsonInput[org.json4s.StreamInput] //  4.0.6 last Scala 2.11 version
   val MockitoCoreVersion    = "4.11.0" // last version working with java8 runtime // 5.0.0 and up requires Java update to Java 11: "java.lang.UnsupportedClassVersionError: org/mockito/Mockito has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0"
+  val Mockito_4_X           = "3.2.18.0" // Next versions are based on MockitoCore 5_x; they require newer Java Runtime
   val LogbackClassicVersion = "1.3.14" // Java EE version. 1.4.x requires Jakarta instead of JavaEE
   val JettyVersion = "9.2.15.v20160210"
   val TestOutputOptions = Tests.Argument(TestFrameworks.ScalaTest, "-oNCXELOPQRMI") // List only problems, and their summaries. Set suitable logback level to get the effect.
@@ -45,6 +46,7 @@ object Digiroad2Build extends Build {
   val jsonJackson    = "org.json4s"         %% "json4s-jackson"  % JsonJacksonVersion
   val jsonNative     = "org.json4s"         %% "json4s-native"   % JsonJacksonVersion
   val mockitoCore    = "org.mockito"        %  "mockito-core"    % MockitoCoreVersion
+  val mockito4X      = "org.scalatestplus"  %% "mockito-4-11"     % Mockito_4_X
   val logbackClassic = "ch.qos.logback"     % "logback-classic"  % LogbackClassicVersion
 
   val geoToolsDependencies: Seq[ModuleID] = Seq(
@@ -71,6 +73,7 @@ object Digiroad2Build extends Build {
     file(s"viite-backend/$BaseProjectName"),
     settings = Defaults.coreDefaultSettings ++ projectSettings ++ Seq(
       name := BaseProjectName,
+      scalacOptions ++= Seq("-Ylog-classpath"),
       libraryDependencies ++= Seq(
         jodaTime, jodaConvert,
         "org.scalatest" % "scalatest_2.11" % ScalaTestVersion % "test"
@@ -117,6 +120,7 @@ object Digiroad2Build extends Build {
         httpClient,
         "com.newrelic.agent.java" % "newrelic-api" % NewRelicApiVersion,
         mockitoCore % "test",
+        mockito4X   % "test",
         "org.flywaydb"   % "flyway-core"   % "9.22.3", // Upgrading to 10.x requires Java Runtime upgrade. 10.0.0 says: "Flyway has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 52.0"
         "org.postgresql" % "postgresql"    % "42.7.3",
         "net.postgis" % "postgis-geometry" % "2023.1.0",
@@ -143,6 +147,7 @@ object Digiroad2Build extends Build {
         "org.scalatra" %% "scalatra-scalatest" % ScalatraVersion % "test",
         "org.scalatra" %% "scalatra-auth" % ScalatraVersion % "test",
         mockitoCore    % "test",
+        mockito4X      % "test",
         akkaTestkit    % "test",
         logbackClassic % "runtime",
         "commons-io" % "commons-io" % CommonsIOVersion,
@@ -176,6 +181,7 @@ object Digiroad2Build extends Build {
         "org.scalatra" %% "scalatra-auth" % ScalatraVersion,
         "org.scalatra" %% "scalatra-swagger" % ScalatraVersion,
         mockitoCore % "test",
+        mockito4X      % "test",
         jodaConvert,
         jodaTime,
         "org.eclipse.jetty" % "jetty-webapp" % JettyVersion % "compile",
@@ -205,6 +211,7 @@ object Digiroad2Build extends Build {
         "org.scalatra" %% "scalatra-scalatest" % ScalatraVersion % "test",
         "org.scalatra" %% "scalatra-auth" % ScalatraVersion,
         mockitoCore    % "test",
+        mockito4X      % "test",
         akkaTestkit    % "test",
         logbackClassic % "runtime",
         "commons-io" % "commons-io" % CommonsIOVersion,
@@ -238,6 +245,7 @@ object Digiroad2Build extends Build {
         "org.scalatra" %% "scalatra-auth" % ScalatraVersion,
         "org.scalatra" %% "scalatra-swagger"  % ScalatraVersion,
         mockitoCore % "test",
+        mockito4X      % "test",
         akkaTestkit % "test",
         logbackClassic % "runtime",
         "commons-io" % "commons-io" % CommonsIOVersion,

--- a/project/build.scala
+++ b/project/build.scala
@@ -46,7 +46,7 @@ object Digiroad2Build extends Build {
   val jsonJackson    = "org.json4s"         %% "json4s-jackson"  % JsonJacksonVersion
   val jsonNative     = "org.json4s"         %% "json4s-native"   % JsonJacksonVersion
   val mockitoCore    = "org.mockito"        %  "mockito-core"    % MockitoCoreVersion
-  val mockito4X      = "org.scalatestplus"  %% "mockito-4-11"     % Mockito_4_X
+  val mockito4X      = "org.scalatestplus"  %% "mockito-4-11"    % Mockito_4_X
   val logbackClassic = "ch.qos.logback"     % "logback-classic"  % LogbackClassicVersion
 
   val geoToolsDependencies: Seq[ModuleID] = Seq(
@@ -73,7 +73,6 @@ object Digiroad2Build extends Build {
     file(s"viite-backend/$BaseProjectName"),
     settings = Defaults.coreDefaultSettings ++ projectSettings ++ Seq(
       name := BaseProjectName,
-      scalacOptions ++= Seq("-Ylog-classpath"),
       libraryDependencies ++= Seq(
         jodaTime, jodaConvert,
         "org.scalatest" % "scalatest_2.11" % ScalaTestVersion % "test"

--- a/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/ApiUtils.scala
+++ b/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/ApiUtils.scala
@@ -78,7 +78,7 @@ object ApiUtils {
 
   /** Work id formed of request id (i.e. "integration") and query params */
   def getWorkId(requestId: String, params: Params, contentType: String): String = {
-    val sortedParams = params.toSeq.filterNot(param => param._1 == "retry" || param._1 == "queryId").sortBy(_._1)
+    val sortedParams = params.toMap.toSeq.filterNot(param => param._1 == "retry" || param._1 == "queryId").sortBy(_._1)
     val identifiers = Seq(requestId) ++ sortedParams.map(_._2.replaceAll(",", "-"))
     s"${identifiers.mkString("_")}.$contentType"
   }

--- a/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/ChangeApi.scala
+++ b/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/ChangeApi.scala
@@ -54,7 +54,7 @@ class ChangeApi(roadAddressService: RoadAddressService, nodesAndJunctionsService
         BadRequestWithLoggerWarn(s"'since' cannot be later than 'until'. ${request.getQueryString}", s"(${request.getRequestURI})")
       }
       else {
-        time(logger, s"GET request for /road_numbers", params = Some(params)) {
+        time(logger, s"GET request for /road_numbers", params = Some(params.toMap)) {
           roadNumberToGeoJson(since, roadAddressService.getChanged(since, until))
         }
       }

--- a/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/IntegrationApi.scala
+++ b/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/IntegrationApi.scala
@@ -172,7 +172,7 @@ println("Threading print test: Now in avoidRestrictions")
   get("/summary", operation(getRoadNetworkSummary)) {
     contentType = formats("json")
 
-    time(logger, s"Summary:  GET request for /summary", params=Some(params)) {
+    time(logger, s"Summary:  GET request for /summary", params=Some(params.toMap)) {
 
       try {
         val dateOption = dateParameterOptionGetValidOrThrow("date")
@@ -288,7 +288,7 @@ println("Threading print test: Now in avoidRestrictions")
       if(untilOption.isDefined) {
         datesInCorrectOrderOrThrow(since, untilOption.get)
       }
-      time(logger, s"GET request for /roadnames/changes", params = Some(params)) {
+      time(logger, s"GET request for /roadnames/changes", params = Some(params.toMap)) {
         fetchUpdatedRoadNames(since, untilOption)
       }
     } catch {
@@ -309,7 +309,7 @@ println("Threading print test: Now in avoidRestrictions")
   get("/roadway/changes", operation(getRoadwayChanges)) {
     contentType = formats("json")
 
-    time(logger, s"GET request for /roadway/changes", params=Some(params)) {
+    time(logger, s"GET request for /roadway/changes", params=Some(params.toMap)) {
       try {
         val since: DateTime = dateParameterGetValidOrThrow("since")
         val roadways : Seq[Roadway] = fetchUpdatedRoadways(since)
@@ -336,7 +336,7 @@ println("Threading print test: Now in avoidRestrictions")
         ))
       } catch {
         case t: Throwable =>
-          handleCommonIntegrationAPIExceptions(t,getRoadwayChanges.operationId)
+          handleCommonIntegrationAPIExceptions(t, getRoadwayChanges.operationId)
       }
     }
   }
@@ -367,7 +367,7 @@ println("Threading print test: Now in avoidRestrictions")
         datesInCorrectOrderOrThrow(since, untilOption.get)
       }
 
-      time(logger, s"GET request for /roadway_changes/changes", params=Some(params)) {
+      time(logger, s"GET request for /roadway_changes/changes", params=Some(params.toMap)) {
         roadwayChangesToApi(roadAddressService.fetchUpdatedRoadwayChanges(since, untilOption))
       }
     } catch {
@@ -507,7 +507,7 @@ println(s"fetchAllValidNodesWithJunctions GOT RESULT, of size ${result.size}") /
   get("/linear_location/changes", operation(getLinearLocationChanges)) {
     contentType = formats("json")
 
-    time(logger, s"GET request for /linear_location/changes", params=Some(params)) {
+    time(logger, s"GET request for /linear_location/changes", params=Some(params.toMap)) {
         try {
           val since = dateParameterGetValidOrThrow("since")
           val linearLocations: Seq[LinearLocation] = fetchUpdatedLinearLocations(since)
@@ -560,7 +560,7 @@ println(s"fetchAllValidNodesWithJunctions GOT RESULT, of size ${result.size}") /
   get(transformers = "/nodes_junctions/changes", operation(nodesToGeoJson)) {
     contentType = formats("json")
 
-    time(logger, s"GET request for /nodes_junctions/changes", params=Some(params)) {
+    time(logger, s"GET request for /nodes_junctions/changes", params=Some(params.toMap)) {
       try {
         val since: DateTime = dateParameterGetValidOrThrow("since")
         val untilOption: Option[DateTime] = dateParameterOptionGetValidOrThrow("until")

--- a/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/SearchApi.scala
+++ b/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/SearchApi.scala
@@ -58,7 +58,7 @@ class SearchApi(roadAddressService: RoadAddressService,
     )
   get("/road_address/?", operation(getRoadAddress)) {
     val requestString = s"GET request for ${request.getRequestURI}?${request.getQueryString} (${getRoadAddress.operationId})"
-    time(logger, requestString, params=Some(params)) {
+    time(logger, requestString, params=Some(params.toMap)) {
 
       val linkId = params.getOrElse("linkId", halt(BadRequest("Missing mandatory query parameter 'linkId'"))) //TODO MAKE OTHER REQUIRED PARAMS LIKE THIS!
 

--- a/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
+++ b/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
@@ -289,7 +289,7 @@ class ViiteApi(val roadLinkService: RoadLinkService, val KGVClient: KgvRoadLink,
     val roadName = params.get("roadName")
     val startDate = params.get("startDate")
     val endDate = params.get("endDate")
-    time(logger, s"GET request for /roadnames", params=Some(params)) {
+    time(logger, s"GET request for /roadnames", params=Some(params.toMap)) {
       roadNameService.getRoadNames(roadNumber, roadName, optionStringToDateTime(startDate), optionStringToDateTime(endDate)) match {
         case Right(roadNameList) => Map("success" -> true, "roadNameInfo" -> roadNameList.map(roadNameToApi))
         case Left(errorMessage) => Map("success" -> false, "reason" -> errorMessage)
@@ -515,7 +515,7 @@ class ViiteApi(val roadLinkService: RoadLinkService, val KGVClient: KgvRoadLink,
       summary "Returns data for road address browser based on the search criteria"
     )
   get("/roadaddressbrowser", operation(getDataForRoadAddressBrowser)) {
-    time(logger, s"GET request for /roadaddressbrowser", params=Some(params)) {
+    time(logger, s"GET request for /roadaddressbrowser", params=Some(params.toMap)) {
       def validateInputs(situationDate: Option[String], target: Option[String], ely: Option[Long], roadNumber: Option[Long], minRoadPartNumber: Option[Long], maxRoadPartNumber: Option[Long]): Boolean = {
         def parseDate(dateString: Option[String]): Option[DateTime] = {
           try {
@@ -923,7 +923,7 @@ class ViiteApi(val roadLinkService: RoadLinkService, val KGVClient: KgvRoadLink,
       val endPart = params("endPart").toLong
       val projDate = DateTime.parse(params("projDate"))
       val projectId = params("projectId").toLong
-      time(logger, s"GET request for /roadlinks/roadaddress/project/validatereservedlink/", params=Some(params)) {
+      time(logger, s"GET request for /roadlinks/roadaddress/project/validatereservedlink/", params=Some(params.toMap)) {
         projectService.checkRoadPartExistsAndReservable(roadNumber, startPart, endPart, projDate, projectId) match {
           case Left(err) => Map("success" -> err)
           case Right((reservedparts, formedparts)) => Map("success" -> "ok", "reservedInfo" -> reservedparts.map(projectReservedPartToApi),
@@ -1303,7 +1303,7 @@ class ViiteApi(val roadLinkService: RoadLinkService, val KGVClient: KgvRoadLink,
     val roadNumber = params.get("roadNumber").map(_.toLong)
     val minRoadPartNumber = params.get("minRoadPartNumber").map(_.toLong)
     val maxRoadPartNumber = params.get("maxRoadPartNumber").map(_.toLong)
-    time(logger, s"GET request for /nodes", params=Some(params)) {
+    time(logger, s"GET request for /nodes", params=Some(params.toMap)) {
       if (roadNumber.isDefined) {
         nodesAndJunctionsService.getNodesByRoadAttributes(roadNumber.get, minRoadPartNumber, maxRoadPartNumber) match {
           case Right(nodes) => Map("success" -> true, "nodes" -> nodes.map(nodeSearchToApi))

--- a/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/ViiteSwagger.scala
+++ b/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/ViiteSwagger.scala
@@ -8,9 +8,9 @@ class ResourcesApp(implicit val swagger: Swagger) extends ScalatraServlet with N
 object ViiteApiInfo extends ApiInfo(title = "VIITE API",
   description = "Docs for VIITE API",
   termsOfServiceUrl = "",
-  contact = "",
-  license = "",
-  licenseUrl =""
+  contact = null,
+  license = null,
+  licenseUrl = ""
 )
 
 class ViiteSwagger extends Swagger(Swagger.SpecVersion, "1.0.0", ViiteApiInfo)

--- a/viite-backend/api/src/test/scala/fi/liikennevirasto/digiroad2/IntegrationApiSpec.scala
+++ b/viite-backend/api/src/test/scala/fi/liikennevirasto/digiroad2/IntegrationApiSpec.scala
@@ -11,7 +11,7 @@ import org.json4s.{DefaultFormats, Formats}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.scalatest.{BeforeAndAfter, FunSuite}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatra.test.scalatest.ScalatraSuite
 
 class IntegrationApiSpec extends FunSuite with ScalatraSuite with BeforeAndAfter {

--- a/viite-backend/api/src/test/scala/fi/liikennevirasto/digiroad2/SearchApiSpec.scala
+++ b/viite-backend/api/src/test/scala/fi/liikennevirasto/digiroad2/SearchApiSpec.scala
@@ -3,7 +3,7 @@ package fi.liikennevirasto.digiroad2
 import fi.liikennevirasto.viite.RoadAddressService
 import org.mockito.Mockito.when
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatra.test.scalatest.ScalatraSuite
 
 class SearchApiSpec extends FunSuite with ScalatraSuite {

--- a/viite-backend/api/src/test/scala/fi/liikennevirasto/digiroad2/ViiteApiSpec.scala
+++ b/viite-backend/api/src/test/scala/fi/liikennevirasto/digiroad2/ViiteApiSpec.scala
@@ -18,7 +18,7 @@ import org.json4s.jackson.Serialization.read
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatest.{BeforeAndAfter, FunSuite}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatra.test.scalatest.ScalatraSuite
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/viite-backend/database/src/main/scala/fi/liikennevirasto/digiroad2/client/kgv/KgvOperation.scala
+++ b/viite-backend/database/src/main/scala/fi/liikennevirasto/digiroad2/client/kgv/KgvOperation.scala
@@ -103,7 +103,7 @@ trait KgvOperation extends LinkOperationsAbstract{
       /** Extract KGV data from the given http response. Assumes the response is ok, and content readable.
         * @return The KGV data as FeatureCollection - or None, if cannot be parsed to such. */
       def getParsedBody(response: ClassicHttpResponse): Option[FeatureCollection] = {
-          val feature = parse(StreamInput(response.getEntity.getContent)).values.asInstanceOf[Map[String, Any]]
+          val feature = parse(response.getEntity.getContent).values.asInstanceOf[Map[String, Any]]
           feature("type").toString match {
             case "Feature" =>
               Some(FeatureCollection(features = List(convertToFeature(feature))))

--- a/viite-backend/database/src/test/scala/fi/liikennevirasto/digiroad2/service/RoadLinkServiceSpec.scala
+++ b/viite-backend/database/src/test/scala/fi/liikennevirasto/digiroad2/service/RoadLinkServiceSpec.scala
@@ -10,7 +10,7 @@ import fi.vaylavirasto.viite.postgis.PostGISDatabase
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.scalatest.{BeforeAndAfter, FunSuite, Matchers}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{Await, Future}

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/APIServiceForNodesAndJunctionsSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/APIServiceForNodesAndJunctionsSpec.scala
@@ -6,7 +6,7 @@ import fi.vaylavirasto.viite.model.{LinkGeomSource, NodeType, RoadPart, SideCode
 import fi.vaylavirasto.viite.postgis.PostGISDatabase.runWithRollback
 import org.joda.time.DateTime
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfter, FunSuite, Matchers}
 
 class APIServiceForNodesAndJunctionsSpec extends FunSuite with Matchers with BeforeAndAfter {

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/NodesAndJunctionsServiceSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/NodesAndJunctionsServiceSpec.scala
@@ -18,7 +18,7 @@ import org.mockito.Mockito.when
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalatest.{BeforeAndAfter, FunSuite, Matchers}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import slick.driver.JdbcDriver.backend.Database.dynamicSession
 import slick.jdbc.StaticQuery.interpolation
 

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/ProjectLinkNameDAOSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/ProjectLinkNameDAOSpec.scala
@@ -11,7 +11,7 @@ import fi.vaylavirasto.viite.postgis.DbUtils.runUpdateToDb
 import fi.vaylavirasto.viite.postgis.PostGISDatabase.runWithRollback
 import org.joda.time.DateTime
 import org.scalatest.{BeforeAndAfter, FunSuite, Matchers}
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 
 class ProjectLinkNameDAOSpec extends FunSuite with Matchers with BeforeAndAfter {

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/ProjectServiceLinkSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/ProjectServiceLinkSpec.scala
@@ -18,7 +18,7 @@ import org.mockito.Mockito.{reset, when}
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.{Answer, OngoingStubbing}
 import org.scalatest.{BeforeAndAfter, FunSuite, Matchers}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.util.parsing.json.JSON
 

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
@@ -24,7 +24,7 @@ import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalatest.{BeforeAndAfter, FunSuite, Matchers}
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import slick.driver.JdbcDriver.backend.Database.dynamicSession   // JdbcBackend#sessionDef
 import slick.jdbc.StaticQuery.interpolation
 

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/ProjectValidatorSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/ProjectValidatorSpec.scala
@@ -19,7 +19,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.mockito.stubbing.OngoingStubbing
 import org.scalatest.{FunSuite, Matchers}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 
 class ProjectValidatorSpec extends FunSuite with Matchers {

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilderSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilderSpec.scala
@@ -11,7 +11,7 @@ import fi.vaylavirasto.viite.model.{AddrMRange, AdministrativeClass, Discontinui
 import fi.vaylavirasto.viite.postgis.PostGISDatabase.runWithRollback
 import org.joda.time.DateTime
 import org.scalatest.{FunSuite, Matchers}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class RoadAddressLinkBuilderSpec extends FunSuite with Matchers {
 

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/RoadAddressServiceSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/RoadAddressServiceSpec.scala
@@ -16,7 +16,7 @@ import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.scalatest.{FunSuite, Matchers}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/ProjectCalibrationPointDAOSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/ProjectCalibrationPointDAOSpec.scala
@@ -8,7 +8,7 @@ import fi.vaylavirasto.viite.postgis.DbUtils.runUpdateToDb
 import fi.vaylavirasto.viite.postgis.PostGISDatabase.runWithRollback
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{FunSuite, Matchers}
 import slick.driver.JdbcDriver.backend.Database.dynamicSession  // JdbcBackend#sessionDef
 import slick.jdbc.StaticQuery.interpolation

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/ProjectLinkDAOSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/ProjectLinkDAOSpec.scala
@@ -11,8 +11,8 @@ import fi.vaylavirasto.viite.postgis.PostGISDatabase.runWithRollback
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers.contains
 import org.mockito.Mockito.verify
-import org.scalatest.mockito.MockitoSugar.mock
 import org.scalatest.{FunSuite, Matchers}
+import org.scalatestplus.mockito.MockitoSugar.mock
 import org.slf4j.Logger
 
 /**

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/integration/Viite_13_218_spec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/integration/Viite_13_218_spec.scala
@@ -18,7 +18,7 @@ import org.mockito.Mockito.{reset, when}
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalatest.{BeforeAndAfter, FunSuite, Matchers}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import slick.driver.JdbcDriver.backend.Database.dynamicSession
 
 import scala.collection.immutable.HashMap

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/process/ProjectSectionCalculatorSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/process/ProjectSectionCalculatorSpec.scala
@@ -16,7 +16,7 @@ import fi.vaylavirasto.viite.postgis.DbUtils.runUpdateToDb
 import fi.vaylavirasto.viite.postgis.PostGISDatabase.runWithRollback
 import org.joda.time.DateTime
 import org.scalatest.{FunSuite, Matchers}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class ProjectSectionCalculatorSpec extends FunSuite with Matchers {
   val mockRoadLinkService: RoadLinkService = MockitoSugar.mock[RoadLinkService]

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/process/RoadwayFillerSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/process/RoadwayFillerSpec.scala
@@ -12,7 +12,7 @@ import fi.vaylavirasto.viite.model.{AddrMRange, AdministrativeClass, Discontinui
 import fi.vaylavirasto.viite.postgis.PostGISDatabase.runWithRollback
 import org.joda.time.DateTime
 import org.scalatest.{BeforeAndAfter, FunSuite, Matchers}
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class RoadwayFillerSpec extends FunSuite with Matchers with BeforeAndAfter {
 

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/process/RoadwayMapperSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/process/RoadwayMapperSpec.scala
@@ -7,7 +7,7 @@ import fi.vaylavirasto.viite.model.CalibrationPointType.RoadAddressCP
 import fi.vaylavirasto.viite.model.{AddrMRange, AdministrativeClass, Discontinuity, LinkGeomSource, RoadPart, SideCode, Track}
 import org.joda.time.DateTime
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{FunSuite, Matchers}
 
 class RoadwayMapperSpec extends FunSuite with Matchers{

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/util/DataImporterSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/util/DataImporterSpec.scala
@@ -5,7 +5,7 @@
 //import fi.liikennevirasto.viite.dao._
 //import org.mockito.Mockito.when
 //import org.scalatest.mockito.MockitoSugar
-//import org.scalatest.{FunSuite, Matchers}
+//import org.scalatest.matchers.should.Matchers
 //import slick.driver.JdbcDriver.backend.Database
 //import Database.dynamicSession
 //import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase


### PR DESCRIPTION
Mockito requires to be upgraded/changed, before scalatest, and scalatra can be updated.
So here we go.
MockitoSugar now from under scalatestplus,not anymore part of mockito-core.