### PR TITLE
VIITE-3211 fix validation bug

### DIFF
--- a/viite-backend/viite-main/src/main/scala/fi/vaylavirasto/viite/dynamicnetwork/DynamicRoadNetworkService.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/vaylavirasto/viite/dynamicnetwork/DynamicRoadNetworkService.scala
@@ -442,7 +442,7 @@ class DynamicRoadNetworkService(linearLocationDAO: LinearLocationDAO, roadwayDAO
 
         // if there are combined links (A + B = C)
         else if (otherChangesWithSameNewLinkId.nonEmpty) {
-          val oldLinkIds = otherChangesWithSameNewLinkId.map(_.oldLinkId)
+          val oldLinkIds = otherChangesWithSameNewLinkId.map(_.oldLinkId) ++ Seq(change.oldLinkId)
           val oldLinearLocations = linearLocations.filter(ll => oldLinkIds.contains(ll.linkId))
           val roadways = roadwayDAO.fetchAllByRoadwayNumbers(oldLinearLocations.map(_.roadwayNumber).toSet)
           // group the roadways with roadPart and track


### PR DESCRIPTION
the change sets' old link was not included in the variable "oldLinkIds", this resulted the following variables to have incorrect data stored in them, which led to wrong behaviour (the bug itself)