### PR TITLE
Viite-3094: Viite-3213 ScalikeJDBC configuration implementation

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -17,6 +17,9 @@ object Digiroad2Build extends Build {
   val SlickVersion = "3.0.3" // 3.1.x and further requires significant changes in the database code, or library change maybe. // 3.4.x and further requires scala 2.12
   val JodaSlickMapperVersion = "2.2.0" // provides slick 3.1.1, joda-time 2.7, and joda-convert 1.7
 
+  val ScalikeJdbcVersion = "3.4.2" // version for Scala version 2.11 - 2.13
+  val ScalikeJdbcJodaTimeVersion = ScalikeJdbcVersion // Should match your ScalikeJdbcVersion
+
   val AkkaVersion = "2.5.32" // 2.6.x and up requires Scala 2.12 or greater
   val JsonJacksonVersion    = "3.7.0-M11" // 3.7.0-M12 and up: could not find implicit value for evidence parameter of type org.json4s.AsJsonInput[org.json4s.StreamInput] //  4.0.6 last Scala 2.11 version
   val JettyVersion          = "9.3.30.v20211001"
@@ -49,11 +52,19 @@ object Digiroad2Build extends Build {
   val newRelic       = "com.newrelic.agent.java" % "newrelic-api"      % "8.12.0"
   val javaxServletApi= "javax.servlet"           % "javax.servlet-api" % JavaxServletVersion % "provided"
 
-  lazy val apacheHttp  = Seq(httpCore, httpClient)
-  lazy val joda        = Seq(jodaConvert, jodaTime)
-  lazy val mockitoTest = Seq(mockitoCore, mockito4X)
-  lazy val scalaTestTra= Seq(scalaTest, scalatraTest)
-  lazy val scalatraLibs= Seq(scalatraJson, scalatraAuth, scalatraSwagger)
+  val scalikeJdbc     = "org.scalikejdbc" %% "scalikejdbc"     % ScalikeJdbcVersion
+  val scalikeConfig   = "org.scalikejdbc" %% "scalikejdbc-config" % ScalikeJdbcVersion
+  val scalikeJodaTime = "org.scalikejdbc" %% "scalikejdbc-joda-time" % ScalikeJdbcJodaTimeVersion
+  val scalikeLogback  = "ch.qos.logback"  %  "logback-classic"    % "1.2.3"
+  //val scalikeTest     = "org.scalikejdbc" %% "scalikejdbc-test" % ScalikeJdbcVersion % "test"
+  // one  possible way to handle scalatests but need more refactoring of the code
+
+  lazy val apacheHttp      = Seq(httpCore, httpClient)
+  lazy val joda            = Seq(jodaConvert, jodaTime)
+  lazy val mockitoTest     = Seq(mockitoCore, mockito4X)
+  lazy val scalaTestTra    = Seq(scalaTest, scalatraTest)
+  lazy val scalatraLibs    = Seq(scalatraJson, scalatraAuth, scalatraSwagger)
+  lazy val scalikeJdbcLibs = Seq(scalikeJdbc, scalikeConfig, scalikeJodaTime, scalikeLogback)
 
   val geoToolsDependencies: Seq[ModuleID] = Seq(
     "org.geotools" % "gt-graph"       % GeoToolsVersion,
@@ -124,7 +135,8 @@ object Digiroad2Build extends Build {
         "net.postgis" % "postgis-jdbc"     % "2023.1.0" // dep postgresql, and from 2.5.0 and up: postgis-geometry
       ) ++ joda
         ++ apacheHttp
-        ++ mockitoTest,
+        ++ mockitoTest
+        ++ scalikeJdbcLibs,
       unmanagedResourceDirectories in Compile += baseDirectory.value / ".." / "conf"
     )
   ) dependsOn (baseJar, geoJar)

--- a/project/build.scala
+++ b/project/build.scala
@@ -55,16 +55,13 @@ object Digiroad2Build extends Build {
   val scalikeJdbc     = "org.scalikejdbc" %% "scalikejdbc"     % ScalikeJdbcVersion
   val scalikeConfig   = "org.scalikejdbc" %% "scalikejdbc-config" % ScalikeJdbcVersion
   val scalikeJodaTime = "org.scalikejdbc" %% "scalikejdbc-joda-time" % ScalikeJdbcJodaTimeVersion
-  val scalikeLogback  = "ch.qos.logback"  %  "logback-classic"    % "1.2.3"
-  //val scalikeTest     = "org.scalikejdbc" %% "scalikejdbc-test" % ScalikeJdbcVersion % "test"
-  // one  possible way to handle scalatests but need more refactoring of the code
 
   lazy val apacheHttp      = Seq(httpCore, httpClient)
   lazy val joda            = Seq(jodaConvert, jodaTime)
   lazy val mockitoTest     = Seq(mockitoCore, mockito4X)
   lazy val scalaTestTra    = Seq(scalaTest, scalatraTest)
   lazy val scalatraLibs    = Seq(scalatraJson, scalatraAuth, scalatraSwagger)
-  lazy val scalikeJdbcLibs = Seq(scalikeJdbc, scalikeConfig, scalikeJodaTime, scalikeLogback)
+  lazy val scalikeJdbcLibs = Seq(scalikeJdbc, scalikeConfig, scalikeJodaTime)
 
   val geoToolsDependencies: Seq[ModuleID] = Seq(
     "org.geotools" % "gt-graph"       % GeoToolsVersion,

--- a/viite-backend/conf/env.properties
+++ b/viite-backend/conf/env.properties
@@ -26,3 +26,8 @@ awsConnectionEnabled=false
 apiS3ObjectTTLSeconds=300
 kgvEndpoint=https://api.vaylapilvi.fi/paikkatiedot/ogc/features/v1/collections
 kgvApiKey=
+
+# ScalikeJDBC Configuration
+scalikejdbc.jdbc.url=jdbc:postgresql://localhost:5432/viite
+scalikejdbc.jdbc.user=viite
+scalikejdbc.jdbc.password=viite

--- a/viite-backend/database/src/main/scala/fi/liikennevirasto/digiroad2/util/ViiteProperties.scala
+++ b/viite-backend/database/src/main/scala/fi/liikennevirasto/digiroad2/util/ViiteProperties.scala
@@ -35,6 +35,11 @@ trait ViiteProperties {
 
   def getAuthenticationBasicUsername(baseAuth: String = ""): String
   def getAuthenticationBasicPassword(baseAuth: String = ""): String
+
+  // ScalikeJDBC properties
+  val scalikeJdbcUrl: String
+  val scalikeJdbcUser: String
+  val scalikeJdbcPassword: String
 }
 
 class ViitePropertiesFromEnv extends ViiteProperties {
@@ -75,6 +80,10 @@ class ViitePropertiesFromEnv extends ViiteProperties {
   val dynamicLinkNetworkS3BucketName: String = scala.util.Properties.envOrElse("dynamicLinkNetworkS3BucketName", null)
   val awsConnectionEnabled: Boolean = scala.util.Properties.envOrElse("awsConnectionEnabled", "true").toBoolean
   val apiS3ObjectTTLSeconds: String = scala.util.Properties.envOrElse("apiS3ObjectTTLSeconds", null)
+  // ScalikeJDBC property implementations
+  val scalikeJdbcUrl: String = scala.util.Properties.envOrElse("scalikejdbc.jdbc.url", null)
+  val scalikeJdbcUser: String = scala.util.Properties.envOrElse("scalikejdbc.jdbc.user", null)
+  val scalikeJdbcPassword: String = scala.util.Properties.envOrElse("scalikejdbc.jdbc.password", null)
 
   lazy val bonecpProperties: Properties = {
     val props = new Properties()
@@ -151,6 +160,10 @@ class ViitePropertiesFromFile extends ViiteProperties {
   override val dynamicLinkNetworkS3BucketName: String = scala.util.Properties.envOrElse("dynamicLinkNetworkS3BucketName", envProps.getProperty("dynamicLinkNetworkS3BucketName"))
   override val awsConnectionEnabled: Boolean = envProps.getProperty("awsConnectionEnabled", "true").toBoolean
   override val apiS3ObjectTTLSeconds: String = scala.util.Properties.envOrElse("apiS3ObjectTTLSeconds", envProps.getProperty("apiS3ObjectTTLSeconds"))
+  // ScalikeJDBC
+  override val scalikeJdbcUrl: String = scala.util.Properties.envOrElse("scalikeJdbcUrl", envProps.getProperty("scalikejdbc.jdbc.url"))
+  override val scalikeJdbcUser: String = scala.util.Properties.envOrElse("scalikeJdbcUser", envProps.getProperty("scalikejdbc.jdbc.user"))
+  override val scalikeJdbcPassword: String = scala.util.Properties.envOrElse("scalikeJdbcPassword", envProps.getProperty("scalikejdbc.jdbc.password"))
 
   override lazy val bonecpProperties: Properties = {
     val props = new Properties()
@@ -226,6 +239,12 @@ object ViiteProperties {
   lazy val dynamicLinkNetworkS3BucketName: String = properties.dynamicLinkNetworkS3BucketName
   lazy val awsConnectionEnabled: Boolean = properties.awsConnectionEnabled
   lazy val apiS3ObjectTTLSeconds: String = properties.apiS3ObjectTTLSeconds
+
+  // Scalike properties
+  lazy val scalikeJdbcUrl: String = properties.scalikeJdbcUrl
+  lazy val scalikeJdbcUser: String = properties.scalikeJdbcUser
+  lazy val scalikeJdbcPassword: String = properties.scalikeJdbcPassword
+
 
   def getAuthenticationBasicUsername(baseAuth: String = ""): String = properties.getAuthenticationBasicUsername(baseAuth)
   def getAuthenticationBasicPassword(baseAuth: String = ""): String = properties.getAuthenticationBasicPassword(baseAuth)

--- a/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/dao/BaseDAO.scala
+++ b/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/dao/BaseDAO.scala
@@ -8,29 +8,58 @@ import fi.vaylavirasto.viite.postgis.SessionProvider.session // As this is impor
 trait BaseDAO {
   protected def logger: Logger = LoggerFactory.getLogger(getClass)
 
+  /**
+   * Executes an UPDATE, INSERT, or DELETE query.
+   *
+   * @param updateQuery SQL query to execute
+   * @return The number of rows affected
+   */
   def runUpdateToDb(updateQuery: SQL[Nothing, NoExtractor]): Int = {
     updateQuery.update.apply()
   }
 
+  /**
+   * Executes a SELECT query and returns all results.
+   *
+   * @param query SQL query with result type A
+   * @tparam A Type to map the results to
+   * @return List of results mapped to type A
+   */
   def runSelectQuery[A](query: SQL[A, HasExtractor]): List[A] = {
     query.list().apply()
   }
 
+  /**
+   * Executes a SELECT query and returns the first result if any exists.
+   *
+   * @param query SQL query with result type A
+   * @tparam A Type to map the result to
+   * @return None if no results found, Some(result) if at least one exists
+   */
   def runSelectSingle[A](query: SQL[A, HasExtractor]): Option[A] = {
     query.single().apply()
   }
 
+  /**
+   * Executes a batch update query with multiple parameter sets.
+   *
+   * @param query query SQL query to execute
+   * @param batchParams Sequence of parameter sets, each set corresponding to one batch operation
+   * @return List of numbers indicating rows affected by each batch operation
+   */
   def runBatchUpdateToDb(query: SQL[Nothing, NoExtractor], batchParams: Seq[Seq[Any]]): List[Int] = {
     query.batch(batchParams: _*).apply()
   }
 
   /**
-   * Run a select query and return the first result as an Option
-   * Example usage: runSelectSingleFirstOptionWithType[Long](query)
-   * @param query The query to run
-   * @param mapper A function to map the result to the desired type
-   * @tparam T The type of the result
-   * @return The first result as an Option
+   * Executes a SELECT query and maps the first result using an implicit mapper function.
+   * Useful for queries returning a single column that needs type conversion.
+   * Example use: runSelectSingleFirstOptionWithType[Long](query)
+   *
+   * @param query SQL query to execute
+   * @param mapper Implicit function to convert WrappedResultSet to type T
+   * @tparam T Type to map the result to
+   * @return None if no results found, Some(T) if result exists
    */
   def runSelectSingleFirstOptionWithType[T](query: SQL[Nothing, NoExtractor])(implicit mapper: WrappedResultSet => T): Option[T] = {
     query.map(mapper).single().apply()

--- a/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/dao/BaseDAO.scala
+++ b/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/dao/BaseDAO.scala
@@ -1,25 +1,45 @@
 package fi.vaylavirasto.viite.dao
 
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
-import slick.jdbc.StaticQuery.interpolation
+import scalikejdbc._
 import org.slf4j.{Logger, LoggerFactory}
+import fi.vaylavirasto.viite.postgis.SessionProvider.session // As this is imported here, it is available in all classes that extend this trait
 
-
-class BaseDAO {
+// Methods to run queries using ScalikeJDBC and session provider
+trait BaseDAO {
   protected def logger: Logger = LoggerFactory.getLogger(getClass)
 
-  /* OLD Slick 3.0.0 way to run direct SQL update queries. */
-  def runUpdateToDb(updateQuery: String): Int = {
-    sqlu"""#$updateQuery""".buildColl.toList.head //sqlu"""#$updateQuery""".execute
+  def runUpdateToDb(updateQuery: SQL[Nothing, NoExtractor]): Int = {
+    updateQuery.update.apply()
   }
 
-//  def queryTemplate[T](queryString: String): List[T] = {
-//    val query: DBIO[Seq[T]] = sql"""$queryString""".as[T]
-//    val f_result: Future[Seq[T]] = db.run(query)
-//
-//    var longValues: List[T] = List()
-//    // You use futures like this..?
-//    f_result.onSuccess { case longs => longValues = longs.toList }
-//    longValues
-//  }
+  def runSelectQuery[A](query: SQL[A, HasExtractor]): List[A] = {
+    query.list().apply()
+  }
+
+  def runSelectSingle[A](query: SQL[A, HasExtractor]): Option[A] = {
+    query.single().apply()
+  }
+
+  def runBatchUpdateToDb(query: SQL[Nothing, NoExtractor], batchParams: Seq[Seq[Any]]): List[Int] = {
+    query.batch(batchParams: _*).apply()
+  }
+
+  /**
+   * Run a select query and return the first result as an Option
+   * Example usage: runSelectSingleFirstOptionWithType[Long](query)
+   * @param query The query to run
+   * @param mapper A function to map the result to the desired type
+   * @tparam T The type of the result
+   * @return The first result as an Option
+   */
+  def runSelectSingleFirstOptionWithType[T](query: SQL[Nothing, NoExtractor])(implicit mapper: WrappedResultSet => T): Option[T] = {
+    query.map(mapper).single().apply()
+  }
+
+  // Implicit conversions for common types
+  implicit val longMapper: WrappedResultSet => Long = _.long(1)
+  implicit val stringMapper: WrappedResultSet => String = _.string(1)
+  //implicit val linkMapper: WrappedResultSet => Link = _.link(1)
+  // Add more implicit mappers as needed
+
 }

--- a/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/postgis/DbUtils.scala
+++ b/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/postgis/DbUtils.scala
@@ -1,18 +1,15 @@
 package fi.vaylavirasto.viite.postgis
 
 //import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
-import slick.jdbc.StaticQuery.interpolation
-
-import java.sql.Date
+import fi.vaylavirasto.viite.postgis.SessionProvider.session
+import scalikejdbc.{NoExtractor, SQL}
 
 /** BaseDAO functionality: duplicate for import/referencing problems.
-  * Trade usage to BaseDAO functions where ever possible. */
+ * Trade usage to BaseDAO functions where ever possible. */
 object DbUtils {
 
-  /* OLD Slick 3.0.0 way to run direct SQL update queries. */
-  def runUpdateToDb(updateQuery: String) = {
-    sqlu"""#$updateQuery""".buildColl.toList.head
+  def runUpdateToDb(updateQuery: SQL[Nothing, NoExtractor]): Int = {
+    updateQuery.update.apply()
   }
 
 }

--- a/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/postgis/GeometryDbUtilsScalike.scala
+++ b/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/postgis/GeometryDbUtilsScalike.scala
@@ -1,0 +1,66 @@
+package fi.vaylavirasto.viite.postgis
+
+import fi.vaylavirasto.viite.geometry.{BoundingRectangle, GeometryUtils, Point}
+import net.postgis.jdbc.geometry.GeometryBuilder
+import org.postgresql.util.PGobject
+import scalikejdbc._
+
+object GeometryDbUtils {
+
+  // Returns SQLSyntax for use in WHERE clauses
+  def boundingBoxFilter(bounds: BoundingRectangle, geometryColumn: SQLSyntax): SQLSyntax = {
+    val leftBottomX = bounds.leftBottom.x
+    val leftBottomY = bounds.leftBottom.y
+    val rightTopX = bounds.rightTop.x
+    val rightTopY = bounds.rightTop.y
+    sqls"""
+      $geometryColumn && ST_MakeEnvelope($leftBottomX,
+                                         $leftBottomY,
+                                         $rightTopX,
+                                         $rightTopY,
+                                         3067)
+    """
+  }
+
+  // Returns String representation of a JGeometry object
+  def createJGeometry(points: Seq[Point]): String = {
+    if (points.nonEmpty) {
+      s"""LINESTRING(${points.map(p => s"""${p.x} ${p.y} ${p.z}""").mkString(", ")})"""
+    } else {
+      "LINESTRING EMPTY"
+    }
+  }
+
+  def createXYZMGeometry(points: Seq[(Point, Double)]): String = {
+    if (points.nonEmpty) {
+      s"""LINESTRING(${points.map(p => s"""${p._1.x} ${p._1.y} ${p._1.z} ${p._2}""").mkString(", ")})"""
+    } else {
+      s"LINESTRING EMPTY"
+    }
+  }
+
+  def createPointGeometry(point: Point): String = {
+    s"POINT(${point.x} ${point.y})"
+  }
+
+  def createRoundedPointGeometry(point: Point): String = {
+    s"POINT(${GeometryUtils.scaleToThreeDigits(point.x)} ${GeometryUtils.scaleToThreeDigits(point.y)})"
+  }
+
+  def loadJGeometryToGeometry(geometry: Option[Object]): Seq[Point] = {
+    if (geometry.nonEmpty) {
+      val pgObject = geometry.get.asInstanceOf[PGobject]
+      val geom = GeometryBuilder.geomFromString(pgObject.getValue)
+      val n = geom.numPoints()
+      var points: Seq[Point] = Seq()
+      for (i <- 1 to n) {
+        val point = geom.getPoint(i - 1)
+        points = points :+ Point(point.x, point.y, point.z)
+      }
+      points
+    } else {
+      Seq()
+    }
+  }
+
+}

--- a/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/postgis/PostGISDatabaseScalikeJDBC.scala
+++ b/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/postgis/PostGISDatabaseScalikeJDBC.scala
@@ -1,0 +1,83 @@
+package fi.vaylavirasto.viite.postgis
+
+import fi.liikennevirasto.digiroad2.util.ViiteProperties
+import scalikejdbc._
+import SessionProvider._
+
+object PostGISDatabaseScalikeJDBC {
+  // Load the PostgreSQL driver
+  Class.forName("org.postgresql.Driver")
+
+  // Initialize the connection pool with default settings
+  ConnectionPool.singleton(
+    url = ViiteProperties.scalikeJdbcUrl,
+    user = ViiteProperties.scalikeJdbcUser,
+    password = ViiteProperties.scalikeJdbcPassword
+  )
+
+  // Logging enabled for all queries for development purposes
+  GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(
+    enabled = true,
+    logLevel = 'info
+  )
+
+  /**
+    * For database operations that modify data only if the whole operation is successful
+    * @param databaseOperation The operation to run
+    * @tparam Result The return type of the operation
+    * @return The result of the operation
+    */
+  def runWithTransaction[Result](databaseOperation: => Result): Result = {
+    DB.localTx { session =>
+      withSession(session) {
+        databaseOperation
+      }
+    }
+  }
+
+  /**
+    * For database operations that only read data
+    * @param readOnlyOperation The operation to run
+    * @tparam Result The return type of the operation
+    * @return The result of the operation
+    */
+  def runWithReadOnlySession[Result](readOnlyOperation: => Result): Result = {
+    DB.readOnly { session =>
+      withSession(session) {
+        readOnlyOperation
+      }
+    }
+  }
+
+  /**
+    * For database operations that modify data and should be committed after the operation
+    * @param autoCommitOperation The operation to run
+    * @tparam Result The return type of the operation
+    * @return The result of the operation
+    */
+  def runWithAutoCommit[Result](autoCommitOperation: => Result): Result = {
+    DB.autoCommit { session =>
+      withSession(session) {
+        autoCommitOperation
+      }
+    }
+  }
+
+  /**
+    * For database operations that modify data and should be rolled back after the operation
+    * Used for testing
+    * @param testOperation The operation to run
+    * @tparam Result The return type of the operation
+    * @return The result of the operation
+    */
+  def runWithRollback[Result](testOperation: => Result): Result = {
+    DB.localTx { session: DBSession =>
+      withSession(session) {
+        val result = testOperation
+        session.connection.rollback()
+        result
+      }
+    }
+  }
+
+}

--- a/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/postgis/SessionProvider.scala
+++ b/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/postgis/SessionProvider.scala
@@ -1,0 +1,34 @@
+package fi.vaylavirasto.viite.postgis
+
+import fi.liikennevirasto.digiroad2.client.kgv.Extractor.logger
+import scalikejdbc._
+
+/**
+ * Provides a thread-local session for ScalikeJDBC to handle transactions.
+ * When SessionProvider.session is imported, the implicit session is used in queries without the need to pass it as a parameter
+ * For DAO classes this is used mainly through the BaseScalikeDAO trait methods (runSelectQuery for example), so the import is not needed
+ */
+object SessionProvider {
+  private val threadLocalSession = new ThreadLocal[DBSession]()
+
+  // Implicit session to be used in queries
+  implicit def session: DBSession = threadLocalSession.get() match {
+    case null =>
+      val errorMsg = "No DBSession is set. Ensure you are within a transaction or session."
+      logger.error(errorMsg)
+      throw new IllegalStateException(errorMsg)
+    case s => s
+  }
+
+  // Sets the session for the current thread for transaction handling
+  def withSession[T](dbSession: DBSession)(f: => T): T = {
+    val previousSession = threadLocalSession.get()
+    threadLocalSession.set(dbSession)
+    try {
+      f
+    } finally {
+      threadLocalSession.set(previousSession)
+    }
+  }
+
+}


### PR DESCRIPTION
1. Configuration for ScalikeJDBC
- Added library dependencies to build.scala
- Added properties for ScalikeJDBC to ViiteProperties.scala and env.poperties for local use
- Implemented database initialization file PostGISDatabaseScalikeJDBC.scala for db connection.

2. Helper methods for DAO classes and session handling
- Modified BaseDAO.scala to have necessary helper methods with ScalikeJDBC
- Created SessionProvider.scala to mimic the Slicks withDynSession implementation
- Created GeometryDbUtilsScalike.scala file that has the DB helper methods for geometry that were incorrectly in the PostGISDatabase file in the Slick version.
- Modified DbUtils.scala to have ScalikeJDBC implementation