### PR TITLE
Viite-3094/viite-3217/viite-3300 migrate road name, junction and node related files

### DIFF
--- a/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/dao/RoadNameDAO.scala
+++ b/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/dao/RoadNameDAO.scala
@@ -3,9 +3,7 @@ package fi.vaylavirasto.viite.dao
 import org.joda.time.DateTime
 import scalikejdbc._
 import scalikejdbc.jodatime.JodaWrappedResultSet.fromWrappedResultSetToJodaWrappedResultSet
-
 import java.sql.Date
-
 
 case class RoadName(id: Long, roadNumber: Long, roadName: String, startDate: Option[DateTime], endDate: Option[DateTime] = None,
                     validFrom: Option[DateTime] = None, validTo: Option[DateTime] = None, createdBy: String)
@@ -15,14 +13,14 @@ object RoadName extends SQLSyntaxSupport[RoadName] {
   override val tableName = "ROAD_NAME"
 
   def apply(rs: WrappedResultSet): RoadName = RoadName(
-    id = rs.long("id"),
-    roadNumber = rs.long("road_number"),
-    roadName = rs.string("road_name"),
-    startDate = rs.jodaDateTimeOpt("start_date"),
-    endDate = rs.jodaDateTimeOpt("end_date"),
-    validFrom = rs.jodaDateTimeOpt("valid_from"),
-    validTo = rs.jodaDateTimeOpt("valid_to"),
-    createdBy = rs.string("created_by")
+    id          = rs.long("id"),
+    roadNumber  = rs.long("road_number"),
+    roadName    = rs.string("road_name"),
+    startDate   = rs.jodaDateTimeOpt("start_date"),
+    endDate     = rs.jodaDateTimeOpt("end_date"),
+    validFrom   = rs.jodaDateTimeOpt("valid_from"),
+    validTo     = rs.jodaDateTimeOpt("valid_to"),
+    createdBy   = rs.string("created_by")
   )
 }
 case class RoadNameForRoadAddressBrowser(ely: Long, roadNumber: Long, roadName: String)
@@ -31,9 +29,9 @@ object RoadNameForRoadAddressBrowserScalike extends SQLSyntaxSupport[RoadNameFor
   override val tableName = "ROAD_NAME"
 
   def apply(rs: WrappedResultSet): RoadNameForRoadAddressBrowser = RoadNameForRoadAddressBrowser(
-    ely = rs.long("ely"),
-    roadNumber = rs.long("road_number"),
-    roadName = rs.string("road_name")
+    ely         = rs.long("ely"),
+    roadNumber  = rs.long("road_number"),
+    roadName    = rs.string("road_name")
   )
 }
 
@@ -122,7 +120,7 @@ object RoadNameDAO extends BaseDAO {
   def expire(id: Long, username: String): Int = {
     logger.debug(s"Expiring road name with id: $id, username: $username")
     val query = sql"""
-      UPDATE ROAD_NAME
+      UPDATE road_name
       SET valid_to = CURRENT_TIMESTAMP, created_by = $username
       WHERE id = $id
     """
@@ -264,7 +262,10 @@ object RoadNameDAO extends BaseDAO {
         ON rw.road_number = ${rn.roadNumber}
         AND rw.valid_to IS NULL $rwDateCondition
       WHERE ${rn.validTo} IS NULL
-      $roadNameDateCondition $elyCondition $roadNumberCondition $roadPartCondition
+      $roadNameDateCondition
+      $elyCondition
+      $roadNumberCondition
+      $roadPartCondition
       ORDER BY rw.ely, rw.road_number
     """
     }

--- a/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/dao/RoadNameDAO.scala
+++ b/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/dao/RoadNameDAO.scala
@@ -1,166 +1,131 @@
 package fi.vaylavirasto.viite.dao
 
-import fi.vaylavirasto.viite.util.DateTimeFormatters.finnishDateFormatter
-import java.sql.{Date, Timestamp}
-import com.github.tototoshi.slick.MySQLJodaSupport._ // Required for implicit functions' usage slick.jdbc.SetParameter[org.joda.time.DateTime] sql"""
 import org.joda.time.DateTime
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
-import slick.jdbc.{GetResult, PositionedResult, StaticQuery => Q}
-import slick.jdbc.StaticQuery.interpolation
+import scalikejdbc._
+import scalikejdbc.jodatime.JodaWrappedResultSet.fromWrappedResultSetToJodaWrappedResultSet
+
+import java.sql.Date
+
 
 case class RoadName(id: Long, roadNumber: Long, roadName: String, startDate: Option[DateTime], endDate: Option[DateTime] = None,
                     validFrom: Option[DateTime] = None, validTo: Option[DateTime] = None, createdBy: String)
 
+
+object RoadName extends SQLSyntaxSupport[RoadName] {
+  override val tableName = "ROAD_NAME"
+
+  def apply(rs: WrappedResultSet): RoadName = RoadName(
+    id = rs.long("id"),
+    roadNumber = rs.long("road_number"),
+    roadName = rs.string("road_name"),
+    startDate = rs.jodaDateTimeOpt("start_date"),
+    endDate = rs.jodaDateTimeOpt("end_date"),
+    validFrom = rs.jodaDateTimeOpt("valid_from"),
+    validTo = rs.jodaDateTimeOpt("valid_to"),
+    createdBy = rs.string("created_by")
+  )
+}
 case class RoadNameForRoadAddressBrowser(ely: Long, roadNumber: Long, roadName: String)
 
+object RoadNameForRoadAddressBrowserScalike extends SQLSyntaxSupport[RoadNameForRoadAddressBrowser] {
+  override val tableName = "ROAD_NAME"
+
+  def apply(rs: WrappedResultSet): RoadNameForRoadAddressBrowser = RoadNameForRoadAddressBrowser(
+    ely = rs.long("ely"),
+    roadNumber = rs.long("road_number"),
+    roadName = rs.string("road_name")
+  )
+}
+
 object RoadNameDAO extends BaseDAO {
+  private val rn = RoadName.syntax("rn") // rn is an alias for RoadNameScalike object to be used in queries
 
-  private val roadsNameQueryBase =
-    s"""select id,road_number,road_Name,start_date,end_date,valid_from,valid_To,created_By
-        from ROAD_NAME"""
+  // Base query to select all columns from ROAD_NAME table
+  private val selectAllFromRoadNameQuery = sqls"""
+  SELECT ${rn.id}, ${rn.roadNumber}, ${rn.roadName}, ${rn.startDate}, ${rn.endDate},
+         ${rn.validFrom}, ${rn.validTo}, ${rn.createdBy}
+  FROM ${RoadName.as(rn)}
+"""
 
-  implicit val getRoadNameRow: GetResult[RoadName] = new GetResult[RoadName] {
-    def apply(r: PositionedResult) = {
-      val roadNameId = r.nextLong()
-      val roadNumber = r.nextLong()
-      val roadName = r.nextString()
-      val startDate = r.nextDateOption().map(d => new DateTime(d.getTime))
-      val endDate = r.nextDateOption().map(d => new DateTime(d.getTime))
-      val validFrom = r.nextDateOption().map(d => new DateTime(d.getTime))
-      val validTo = r.nextDateOption().map(d => new DateTime(d.getTime))
-      val createdBy = r.nextString()
-
-      RoadName(roadNameId, roadNumber, roadName, startDate, endDate, validFrom, validTo, createdBy)
-    }
-  }
-
-  implicit val getRoadNameForRoadAddressBrowser: GetResult[RoadNameForRoadAddressBrowser] = new GetResult[RoadNameForRoadAddressBrowser] {
-    def apply(r: PositionedResult) = {
-      val ely = r.nextLong()
-      val roadNumber = r.nextLong()
-      val roadName = r.nextString()
-
-      RoadNameForRoadAddressBrowser(ely, roadNumber, roadName)
-    }
-  }
-
-  def dateParser(oDate: Option[DateTime]): String = {
-    oDate match {
-      case Some(date) =>
-        finnishDateFormatter.print(date)
-
-      case _=>
-        logger.error("Failed to parse date in RoadName search ")
-        "01.01.1900"
-    }
+  // Method to run select queries for RoadName objects
+  private def queryList(query: SQL[Nothing, NoExtractor]): Seq[RoadName] = {
+    runSelectQuery(query.map(RoadName.apply))
   }
 
   /**
-    * For checking date validity we convert string datre to datetime options
-    *
-    * @param dateString string formated date dd.mm.yyyy
-    * @return Joda datetime
-    */
-  private def optionStringToDateTime(dateString: Option[String]): Option[java.sql.Date] = {
-    dateString match {
-      case Some(dateString) =>
-        val splitDate = dateString.split('.')
-        Option(new java.sql.Date(splitDate(2).toInt, splitDate(1).toInt, splitDate(0).toInt))
-      case _ => None
-    }
-  }
-
-  private def queryList(query: String) = {
-    Q.queryNA[RoadName](query).iterator.toSeq
-  }
-
-  private def withHistoryFilter(query: String, startDate: Option[DateTime], endDate: Option[DateTime]): String = {
-    val startDateQuery = if (startDate.isDefined) s" and start_date >= to_date('${dateParser(startDate)}', 'dd.MM.YYYY')" else ""
-    val endDateQuery = if (endDate.isDefined) s" and end_date <= to_date('${dateParser(endDate)}', 'dd.MM.YYYY')" else ""
-    s"""$query $startDateQuery $endDateQuery"""
-  }
-
-  def getLatestRoadName(roadNumber: Long): Option[RoadName] = {
-    val query =
-      s"""$roadsNameQueryBase Where road_number = $roadNumber and valid_to is null and end_date is null"""
-    queryList(query).headOption
-  }
-
-  /**
-    * Get current roadName by roadNumber (endDate is null)
-    */
-  def getCurrentRoadNamesByRoadNumber(roadNumber: Long): Seq[RoadName] = {
-    val query =
-      s"""$roadsNameQueryBase where road_number = $roadNumber and end_date is null and valid_to is null """
-    queryList(query)
-  }
-
-  def getCurrentRoadNamesByRoadNumbers(roadNumbers: Seq[Long]): Seq[RoadName] = {
-    val query =
-      s"""$roadsNameQueryBase where road_number in (${roadNumbers.mkString(",")}) and end_date is null and valid_to is null """
-    queryList(query)
-  }
-
-  /**
-    * Return all the valid road names for the given road number
-    *
-    * @param roadNumber
-    */
+   * Get all road names from ROAD_NAME table with road number and optional start and end dates
+   *
+   * @param startDate Optional start date for the road names
+   * @param endDate   Optional end date for the road names
+   * @return List of RoadName objects
+   */
   def getAllByRoadNumber(roadNumber: Long, startDate: Option[DateTime] = None, endDate: Option[DateTime] = None): Seq[RoadName] = {
-    val query =
-      withHistoryFilter(s"""$roadsNameQueryBase Where road_number = $roadNumber and valid_to is null""", startDate, endDate)
+    val query = withHistoryFilter(
+      sqls"""
+            $selectAllFromRoadNameQuery
+            WHERE ${rn.roadNumber} = $roadNumber
+            AND ${rn.validTo} IS NULL
+            """,
+      startDate,
+      endDate
+    )
     queryList(query)
   }
 
   /**
-    * Return all the valid road names for the given road name
-    *
-    * @param roadName
-    */
+   * Get all road names from ROAD_NAME table with road name and optional start and end dates
+   *
+   * @param startDate Optional start date for the road names
+   * @param endDate   Optional end date for the road names
+   * @return List of RoadName objects
+   */
   def getAllByRoadName(roadName: String, startDate: Option[DateTime] = None, endDate: Option[DateTime] = None): Seq[RoadName] = {
-    val query =
-      withHistoryFilter(s"""$roadsNameQueryBase Where road_name = $roadName and valid_to is null""", startDate, endDate)
+    val baseQuery =
+      sqls"""
+        $selectAllFromRoadNameQuery
+        WHERE ${rn.roadName} = $roadName
+        AND ${rn.validTo} IS NULL
+        """
+    val query = withHistoryFilter(baseQuery, startDate, endDate)
     queryList(query)
   }
 
-  /**
-    * Return all the valid road names for the given road name and road number
-    *
-    * @param roadNumber
-    * @param roadName
-    */
   def getAllByRoadNumberAndName(roadNumber: Long, roadName: String, startDate: Option[DateTime] = None, endDate: Option[DateTime] = None): Seq[RoadName] = {
-    val query =
-      withHistoryFilter(s"""$roadsNameQueryBase Where road_name = '$roadName' and road_number = $roadNumber and valid_to is null""", startDate, endDate)
+    val baseQuery =
+      sqls"""
+        $selectAllFromRoadNameQuery
+        WHERE ${rn.roadName} = $roadName
+        AND ${rn.roadNumber} = $roadNumber
+        AND ${rn.validTo} IS NULL
+        """
+    val query = withHistoryFilter(baseQuery, startDate, endDate)
     queryList(query)
   }
 
-  /**
-    * Fetches road names that are updated after the given date.
-    *
-    * @param since
-    * @return
-    */
-  def getUpdatedRoadNames(since: DateTime, until: Option[DateTime]): Seq[RoadName] = {
-    val untilString = if (until.nonEmpty) s"AND CREATED_TIME <= to_timestamp('${new Timestamp(until.get.getMillis)}', 'YYYY-MM-DD HH24:MI:SS.FF')" else s""
-        sql"""
-        SELECT * FROM ROAD_NAME
-        WHERE road_number IN (
-            SELECT DISTINCT road_number FROM ROAD_NAME
-            WHERE valid_to IS NULL AND CREATED_TIME >= $since #$untilString
-          ) AND valid_to IS NULL
-        ORDER BY road_number, start_date desc
-      """.as[RoadName].list
+  // Helper method to add start and end date filters to a query
+  private def withHistoryFilter(query: SQLSyntax, startDate: Option[DateTime], endDate: Option[DateTime]): SQL[Nothing, NoExtractor] = {
+    val startDateQuery = startDate.map(date => sqls"AND ${rn.startDate} >= $date").getOrElse(sqls"")
+    val endDateQuery = endDate.map(date => sqls"AND ${rn.endDate} <= $date").getOrElse(sqls"")
+    sql"$query $startDateQuery $endDateQuery"
   }
 
   def getRoadNamesById(id: Long): Option[RoadName] = {
-    val query =
-      s"""$roadsNameQueryBase Where id = $id AND valid_to IS NULL"""
+    val query = sql"""
+      $selectAllFromRoadNameQuery
+      WHERE ${rn.id} = $id
+      AND ${rn.validTo}
+      IS NULL
+    """
     queryList(query).headOption
   }
 
   def expire(id: Long, username: String): Int = {
-    val query = s"""Update ROAD_NAME Set valid_to = current_timestamp, created_by = '$username' where id = $id"""
+    logger.debug(s"Expiring road name with id: $id, username: $username")
+    val query = sql"""
+      UPDATE ROAD_NAME
+      SET valid_to = CURRENT_TIMESTAMP, created_by = $username
+      WHERE id = $id
+    """
     runUpdateToDb(query)
   }
 
@@ -169,131 +134,144 @@ object RoadNameDAO extends BaseDAO {
     create(Seq(historyRoadName))
   }
 
-  def update(id: Long, fields: Map[String, String]): Int = {
-    val roadNumber = fields.get("roadNumber")
-    val roadName = fields.get("roadName")
-    val startDate = fields.get("startDate")
-    val endDate = fields.get("endDate")
+  def create(roadNames: Seq[RoadName]): List[Int] = {
+    logger.debug(s"Creating road names: ${roadNames.map(_.roadName).mkString(", ")}")
+    val column = RoadName.column
 
-    val numberFilter = if (roadNumber.isDefined) s" road_number = ${roadNumber.get} " else ""
-    val nameFilter = if (roadName.isDefined) s" road_name = '${roadName.get}' " else ""
-    val startDateFilter = if (startDate.isDefined) s" start_date = to_date('${startDate.get}','dd.MM.YYYY') " else ""
-    val endDateFilter = if (endDate.isDefined) s" end_date = to_date('${endDate.get}','dd.MM.YYYY') " else ""
-
-    val filters = Seq(numberFilter, nameFilter, startDateFilter, endDateFilter).filterNot(_ == "")
-    val query = s"""Update ROAD_NAME Set ${filters.mkString(",")} where id = $id"""
-    runUpdateToDb(query)
-  }
-
-  def create(roadNames: Seq[RoadName]): Unit = {
-    val query = s"insert into ROAD_NAME (id, road_number, road_name, start_date, created_by, end_date) values " +
-      s"(?, ?, ?, ?, ?, ?)"
-
-    val namesPS = dynamicSession.prepareStatement(query)
-
-    roadNames.foreach(roadName => {
-      val nextId = Sequences.nextRoadNameId
-      namesPS.setLong(1, nextId)
-      namesPS.setLong(2, roadName.roadNumber)
-      namesPS.setString(3, roadName.roadName)
-      namesPS.setDate(4, new Date(roadName.startDate.get.getMillis))
-      namesPS.setString(5, roadName.createdBy)
-      if (roadName.endDate.isDefined) {
-        namesPS.setDate(6, new Date(roadName.endDate.get.getMillis))
-      } else {
-        namesPS.setNull(6, java.sql.Types.DATE)
-      }
-      namesPS.addBatch()
-    })
-    namesPS.executeBatch()
-    namesPS.close()
-  }
-
-  /**
-    * generates required number of ? for preparedstatement when using (in) clause
-    *
-    * @param roads
-    * @return
-    */
-  protected def qMarksGenerator(roads: Set[Long]): String = {
-    val inClause = new StringBuilder
-    for (i <- roads) {
-      inClause.append("?, ")
+    val batchParams: Seq[Seq[Any]] = roadNames.map { roadName =>
+      Seq(
+        roadName.roadNumber,
+        roadName.roadName,
+        roadName.startDate.orNull,
+        roadName.createdBy,
+        roadName.endDate.orNull
+      )
     }
-    inClause.dropRight(2).toString()
+
+    val query = sql"""
+      INSERT INTO ROAD_NAME (
+        ${column.roadNumber},
+        ${column.roadName},
+        ${column.startDate},
+        ${column.createdBy},
+        ${column.endDate}
+      ) VALUES (?, ?, ?, ?, ?)
+    """
+
+    runBatchUpdateToDb(query, batchParams)
   }
 
 
   def expireByRoadNumber(roadNumbers: Set[Long], validTo: Long): Unit = {
     if (roadNumbers.isEmpty) return // dont even bother with empty set
-    val query = s" UPDATE ROAD_NAME SET VALID_TO = ? WHERE VALID_TO IS NULL AND ROAD_NUMBER in (${qMarksGenerator(roadNumbers)})"
-    val roadNamesPS = dynamicSession.prepareStatement(query)
-    roadNamesPS.setDate(1, new Date(validTo))
-    var index = 2
-    for (roadNumber <- roadNumbers) {
-      roadNamesPS.setLong(index, roadNumber)
-      index += 1
-    }
-    roadNamesPS.addBatch()
-    roadNamesPS.executeBatch()
-    roadNamesPS.close()
+
+    val updateQuery =
+      sql"""
+             UPDATE ROAD_NAME
+             SET VALID_TO = ?
+             WHERE VALID_TO IS NULL
+             AND ROAD_NUMBER in ($roadNumbers))
+         """
+
+    val batchParams = roadNumbers.map(roadNumber =>
+      Seq(new Date(validTo), roadNumber)
+    ).toSeq
+
+    runBatchUpdateToDb(updateQuery, batchParams)
+  }
+
+  def getUpdatedRoadNames(since: DateTime, until: Option[DateTime]): Seq[RoadName] = {
+    val query = sql"""
+      $selectAllFromRoadNameQuery
+      WHERE ${rn.roadNumber} IN (
+        SELECT DISTINCT ${rn.roadNumber}
+        FROM ${RoadName.as(rn)}
+        WHERE ${rn.validTo} IS NULL
+        AND ${rn.column("created_time")} >= $since
+        ${until.map(u => sqls"AND ${rn.column("created_time")} <= $u").getOrElse(sqls"")}
+      )
+      AND ${rn.validTo} IS NULL
+      ORDER BY ${rn.roadNumber}, ${rn.startDate} DESC
+    """
+
+    queryList(query)
+  }
+
+  /**
+   * Get current roadName by roadNumber (endDate is null)
+   */
+  def getCurrentRoadNamesByRoadNumber(roadNumber: Long): Seq[RoadName] = {
+    val query = sql"""
+      $selectAllFromRoadNameQuery
+      WHERE ${rn.roadNumber} = $roadNumber
+        AND ${rn.endDate} IS NULL
+        AND ${rn.validTo} IS NULL """
+    queryList(query)
+  }
+
+  /**
+   * Get current roadNames by roadNumbers (endDate is null)
+   */
+  def getCurrentRoadNamesByRoadNumbers(roadNumbers: Seq[Long]): Seq[RoadName] = {
+    val query = sql"""
+      $selectAllFromRoadNameQuery
+      WHERE ${rn.roadNumber} IN ($roadNumbers)
+        AND ${rn.endDate} IS NULL
+        AND ${rn.validTo} IS NULL
+    """
+
+    queryList(query)
+  }
+
+  def getLatestRoadName(roadNumber: Long): Option[RoadName] = {
+    val query =
+      sql"""
+           $selectAllFromRoadNameQuery
+           WHERE road_number = $roadNumber
+           AND valid_to IS NULL
+           AND end_date IS NULL
+           """
+    queryList(query).headOption
   }
 
   def fetchRoadNamesForRoadAddressBrowser(situationDate: Option[String], ely: Option[Long], roadNumber: Option[Long],
-                                          minRoadPartNumber: Option[Long], maxRoadPartNumber: Option[Long]) : Seq[RoadNameForRoadAddressBrowser]= {
+                                          minRoadPartNumber: Option[Long], maxRoadPartNumber: Option[Long]): Seq[RoadNameForRoadAddressBrowser] = {
+
+    val baseQuery = sqls"""
+    SELECT DISTINCT rw.ely AS ely, rw.road_number AS road_number, ${rn.roadName} AS road_name
+    FROM ${RoadName.as(rn)}
+  """
+
     def withOptionalParameters(situationDate: Option[String], ely: Option[Long], roadNumber: Option[Long],
-                               minRoadPartNumber: Option[Long], maxRoadPartNumber: Option[Long])(query: String): String = {
-      val rwDateCondition = "AND rw.START_DATE <='" + situationDate.get + "' AND (rw.END_DATE >= '" + situationDate.get + "' OR rw.END_DATE IS NULL)"
+                               minRoadPartNumber: Option[Long], maxRoadPartNumber: Option[Long])(baseQuery: SQLSyntax): SQL[Nothing, NoExtractor] = {
+      val rwDateCondition = sqls"AND rw.start_date <= $situationDate::date AND (rw.end_date >= $situationDate::date OR rw.end_date IS NULL)"
 
-      /**
-        * if the situationDate == RoadNameHistoryRow.startDate AND situationDate == RoadNameCurrentRow.endDate then RoadNameCurrentRow is picked
-        * example:
-        * situationDate = 15.11.2022
-        * historyRow  RoadName(name: "old road name", startDate: 1.12.2015, endDate: 15.11.2022)
-        * currentRow  RoadName(name: "new road name", startDate: 15.11.2022, endDate: NULL) <- currentRow is picked
-        */
-      val roadNameDateCondition = "AND rn.START_DATE <='" + situationDate.get + "' AND (rn.END_DATE > '" + situationDate.get + "' OR rn.END_DATE IS NULL)"
+      val roadNameDateCondition = sqls"AND ${rn.startDate} <= $situationDate::date AND (${rn.endDate} > $situationDate::date OR ${rn.endDate} IS NULL)"
 
-      val elyCondition = {
-        if (ely.nonEmpty)
-          s" AND rw.ely = ${ely.get}"
-        else
-          ""
+      val elyCondition = ely.map(e => sqls"AND rw.ely = $e").getOrElse(sqls"")
+      val roadNumberCondition = roadNumber.map(rn => sqls"AND rw.road_number = $rn").getOrElse(sqls"")
+
+      val roadPartCondition = (minRoadPartNumber, maxRoadPartNumber) match {
+        case (Some(minPart), Some(maxPart)) => sqls"AND rw.road_part_number BETWEEN $minPart AND $maxPart"
+        case (None, Some(maxPart)) => sqls"AND rw.road_part_number <= $maxPart"
+        case (Some(minPart), None) => sqls"AND rw.road_part_number >= $minPart"
+        case _ => sqls""
       }
 
-      val roadNumberCondition = {
-        if (roadNumber.nonEmpty)
-          s" AND rw.road_number = ${roadNumber.get}"
-        else
-          ""
-      }
-
-      val roadPartCondition = {
-        val parts = (minRoadPartNumber, maxRoadPartNumber)
-        parts match {
-          case (Some(minPart), Some(maxPart)) => s"AND rw.road_part_number BETWEEN $minPart AND $maxPart"
-          case (None, Some(maxPart)) => s"AND rw.road_part_number <= $maxPart"
-          case (Some(minPart), None) => s"AND rw.road_part_number >= $minPart"
-          case _ => ""
-        }
-      }
-
-      s"""$query
-          JOIN ROADWAY rw ON rw.road_number = rn.road_number AND rw.valid_to IS NULL $rwDateCondition
-          WHERE rn.valid_to IS NULL
-          $roadNameDateCondition $elyCondition $roadNumberCondition $roadPartCondition
-          ORDER BY rw.ely, rw.road_number """.stripMargin
+      sql"""
+      $baseQuery
+      JOIN ROADWAY rw
+        ON rw.road_number = ${rn.roadNumber}
+        AND rw.valid_to IS NULL $rwDateCondition
+      WHERE ${rn.validTo} IS NULL
+      $roadNameDateCondition $elyCondition $roadNumberCondition $roadPartCondition
+      ORDER BY rw.ely, rw.road_number
+    """
     }
 
-    def fetchRoadNames(queryFilter: String => String): Seq[RoadNameForRoadAddressBrowser] = {
-      val query =
-        """
-      SELECT DISTINCT rw.ely, rw.road_number, rn.road_name
-        FROM road_name rn
-      """
-      val filteredQuery = queryFilter(query)
-      Q.queryNA[RoadNameForRoadAddressBrowser](filteredQuery).iterator.toSeq
-    }
-    fetchRoadNames(withOptionalParameters(situationDate, ely, roadNumber, minRoadPartNumber, maxRoadPartNumber))
+    val fullQuery = withOptionalParameters(situationDate, ely, roadNumber, minRoadPartNumber, maxRoadPartNumber)(baseQuery)
+
+    // Use runSelectQuery from ScalikeJDBCBaseDAO to execute the query
+    runSelectQuery(fullQuery.map(RoadNameForRoadAddressBrowserScalike.apply))
   }
 }

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/NodesAndJunctionsService.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/NodesAndJunctionsService.scala
@@ -8,7 +8,7 @@ import fi.liikennevirasto.viite.process.RoadwayAddressMapper
 import fi.liikennevirasto.viite.util.CalibrationPointsUtils
 import fi.vaylavirasto.viite.geometry.{BoundingRectangle, Point}
 import fi.vaylavirasto.viite.model.{BeforeAfter, CalibrationPointLocation, CalibrationPointType, Discontinuity, NodePointType, RoadAddressChangeType, Track}
-import fi.vaylavirasto.viite.postgis.PostGISDatabase
+import fi.vaylavirasto.viite.postgis.PostGISDatabaseScalikeJDBC
 import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
 
@@ -17,11 +17,9 @@ import scala.util.control.NonFatal
 
 class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayPointDAO, linearLocationDAO: LinearLocationDAO, nodeDAO: NodeDAO, nodePointDAO: NodePointDAO, junctionDAO: JunctionDAO, junctionPointDAO: JunctionPointDAO, roadwayChangesDAO: RoadwayChangesDAO, projectReservedPartDAO: ProjectReservedPartDAO) {
 
-  def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
+  def runWithTransaction[T](f: => T): T = PostGISDatabaseScalikeJDBC.runWithTransaction(f)
 
-  def withDynTransactionNewOrExisting[T](f: => T): T = PostGISDatabase.withDynTransactionNewOrExisting(f)
-
-  def withDynSession[T](f: => T): T = PostGISDatabase.withDynSession(f)
+  def runWithReadOnlySession[T](f: => T): T = PostGISDatabaseScalikeJDBC.runWithReadOnlySession(f)
 
   private val logger = LoggerFactory.getLogger(getClass)
 
@@ -91,7 +89,7 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
       })
     }
 
-    withDynTransaction {
+    runWithTransaction {
       val nodeNumber = addOrUpdateNode(node, isObsoleteNode(junctions, nodePoints), username)
 
       val currentNodePoints = nodePointDAO.fetchByNodeNumber(nodeNumber)
@@ -140,7 +138,7 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
     */
 
   def areJunctionPointsOnReservedRoadPart(junctionPointIds: Seq[Long]): Boolean = {
-    withDynSession {
+    runWithReadOnlySession {
       val junctionPoints = junctionPointDAO.fetchByIds(junctionPointIds)
       val roadwayPoints = junctionPoints.map(jp => roadwayPointDAO.fetch(jp.roadwayPointId))
       val roadwayNumbers = roadwayPoints.map(rwp => rwp.roadwayNumber).toSet
@@ -152,7 +150,7 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
 
   // TODO remove this function and its usages when VIITE-2524 gets implemented
   def areJunctionPointsOnRoadwayChangingSpot(junctionPointIds: Seq[Long]): Boolean = {
-    withDynSession {
+    runWithReadOnlySession {
       val junctionPoints = junctionPointDAO.fetchByIds(junctionPointIds)
       val roadwayNumbers = junctionPoints.map(jp => jp.roadwayNumber).toSet
       if (roadwayNumbers.size < 2)
@@ -163,7 +161,7 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
   }
 
   def areJunctionPointsOnAdministrativeClassChangingSpot(junctionPointIds: Seq[Long]): Boolean = {
-    withDynSession {
+    runWithReadOnlySession {
       val junctionPoints = junctionPointDAO.fetchByIds(junctionPointIds)
       val roadwayNumbers = junctionPoints.map(jp => jp.roadwayNumber).toSet
       if (roadwayNumbers.size < 2)
@@ -189,7 +187,7 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
 
   def addOrUpdateNode(node: Node, isObsoleteNode: Boolean = false, username: String = "-"): Long = {
 
-    withDynTransactionNewOrExisting {
+    runWithTransaction {
       if (node.id == NewIdValue) {
         nodeDAO.create(Seq(node), username).headOption.get
       } else {
@@ -227,19 +225,19 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
   }
 
   def getNodesForRoadAddressBrowser(situationDate: Option[String], ely: Option[Long], roadNumber: Option[Long], minRoadPartNumber: Option[Long], maxRoadPartNumber: Option[Long]): Seq[NodeForRoadAddressBrowser] = {
-    withDynSession {
+    runWithReadOnlySession {
       nodeDAO.fetchNodesForRoadAddressBrowser(situationDate, ely, roadNumber, minRoadPartNumber, maxRoadPartNumber)
     }
   }
 
   def getJunctionsForRoadAddressBrowser(situationDate: Option[String], ely: Option[Long], roadNumber: Option[Long], minRoadPartNumber: Option[Long], maxRoadPartNumber: Option[Long]): Seq[JunctionForRoadAddressBrowser] = {
-    withDynSession {
+    runWithReadOnlySession {
       junctionDAO.fetchJunctionsForRoadAddressBrowser(situationDate, ely, roadNumber, minRoadPartNumber, maxRoadPartNumber)
     }
   }
 
   def getNodesByRoadAttributes(roadNumber: Long, minRoadPartNumber: Option[Long], maxRoadPartNumber: Option[Long]): Either[String, Seq[(Node, RoadAttributes)]] = {
-    withDynSession {
+    runWithReadOnlySession {
       try {
         // if the result set has more than 50 rows but the road attributes can't be narrowed down, it shows the results anyway
         nodeDAO.fetchByRoadAttributes(roadNumber, minRoadPartNumber, maxRoadPartNumber) match {
@@ -258,7 +256,7 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
   }
 
   def getNodesByBoundingBox(boundingRectangle: BoundingRectangle): Seq[Node] = {
-    withDynSession {
+    runWithReadOnlySession {
       time(logger, "Fetch nodes with junctions") {
         nodeDAO.fetchByBoundingBox(boundingRectangle)
       }
@@ -266,7 +264,7 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
   }
 
   def getJunctionPointsByJunctionIds(junctionIds: Seq[Long]): Seq[JunctionPoint] = {
-    withDynSession {
+    runWithReadOnlySession {
       junctionPointDAO.fetchByJunctionIds(junctionIds)
     }
   }
@@ -292,7 +290,7 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
   }
 
   def getNodesWithJunctionByBoundingBox(boundingRectangle: BoundingRectangle, raLinks: Seq[RoadAddressLink]): Map[Node, (Seq[NodePoint], Map[Junction, Seq[JunctionPoint]])] = {
-    withDynSession {
+    runWithReadOnlySession {
       time(logger, "Fetch nodes with junctions") {
         val junctionsByBoundingBox = getJunctionsByBoundingBox(boundingRectangle, raLinks)
         val nodesByBoundingBox = nodeDAO.fetchByBoundingBox(boundingRectangle)
@@ -331,7 +329,7 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
   }
 
   def getNodesWithTimeInterval(sinceDate: DateTime, untilDate: Option[DateTime]): Map[Option[Node], (Seq[NodePoint], Map[Junction, Seq[JunctionPoint]])] = {
-    withDynSession {
+    runWithReadOnlySession {
       val nodes = nodeDAO.fetchAllByDateRange(sinceDate, untilDate)
       val nodePoints = nodePointDAO.fetchByNodeNumbers(nodes.map(_.nodeNumber))
       val junctions = junctionDAO.fetchJunctionsByValidNodeNumbers(nodes.map(_.nodeNumber))
@@ -354,7 +352,7 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
   }
 
   def getNodePointTemplates(authorizedElys: Seq[Int]): Seq[NodePoint] = {
-    withDynSession {
+    runWithReadOnlySession {
       time(logger, "Fetch node point templates") {
         nodePointDAO.fetchTemplates().filter(template => authorizedElys.contains(template.elyCode))
       }
@@ -362,7 +360,7 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
   }
 
   def getNodePointTemplateById(id: Long): Option[NodePoint] = {
-    withDynSession {
+    runWithReadOnlySession {
       time(logger, "Fetch node point template by id") {
         nodePointDAO.fetchNodePointTemplateById(id)
       }
@@ -370,7 +368,7 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
   }
 
   def getJunctionTemplatesById(id: Long): Option[JunctionTemplate] = {
-    withDynSession {
+    runWithReadOnlySession {
       time(logger, "Fetch junction template by id") {
         junctionDAO.fetchJunctionTemplateById(id)
       }
@@ -378,13 +376,14 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
   }
 
   def getJunctionTemplates(authorizedElys: Seq[Int]): Seq[JunctionTemplate] = {
-    withDynSession {
+    runWithReadOnlySession {
       time(logger, "Fetch Junction templates") {
         junctionDAO.fetchTemplates().filter(jt => authorizedElys.contains(jt.elyCode))
       }
     }
   }
 
+  // TODO remove this if it's not used
   def getTemplatesByBoundingBox(boundingRectangle: BoundingRectangle): (Seq[NodePoint], Map[Junction, Seq[JunctionPoint]]) = {
     time(logger, "Fetch NodePoint and Junction + JunctionPoint templates") {
       val junctionPoints = junctionPointDAO.fetchByBoundingBox(boundingRectangle)
@@ -843,7 +842,7 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
   }
 
   def getNodePointTemplatesByBoundingBox(boundingRectangle: BoundingRectangle, raLinks: Seq[RoadAddressLink]): Seq[NodePoint] = {
-    withDynSession {
+   runWithReadOnlySession {
       time(logger, "Fetch nodes point templates") {
 
         val nodePointTemplate = nodePointDAO.fetchTemplatesByBoundingBox(boundingRectangle)
@@ -856,7 +855,7 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
   }
 
   def getJunctionsByBoundingBox(boundingRectangle: BoundingRectangle, raLinks: Seq[RoadAddressLink]): Map[Junction, Seq[JunctionPoint]] = {
-    withDynTransactionNewOrExisting {
+    runWithTransaction{
       time(logger, "Fetch junctions") {
         val junctions: Seq[Junction] = junctionDAO.fetchByBoundingBox(boundingRectangle)
         val junctionPoints: Seq[JunctionPoint] = junctionPointDAO.fetchByJunctionIds(junctions.map(_.id))
@@ -875,7 +874,7 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
   }
 
   def getJunctionTemplatesByBoundingBox(boundingRectangle: BoundingRectangle, raLinks: Seq[RoadAddressLink]): Map[JunctionTemplate, Seq[JunctionPoint]] = {
-    withDynSession {
+    runWithReadOnlySession {
       time(logger, "Fetch junction templates") {
         val junctions: Seq[JunctionTemplate] = junctionDAO.fetchTemplatesByBoundingBox(boundingRectangle)
         val junctionPoints: Seq[JunctionPoint] = junctionPointDAO.fetchByJunctionIds(junctions.map(_.id))

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/JunctionDAO.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/JunctionDAO.scala
@@ -30,56 +30,45 @@ class JunctionDAO extends BaseDAO {
 
   object Junction extends SQLSyntaxSupport[Junction] {
     override val tableName = "junction"
-    override val columns = Seq(
-      "id",
-      "junction_number",
-      "node_number",
-      "start_date",
-      "end_date",
-      "valid_from",
-      "valid_to",
-      "created_by",
-      "created_time"
-    )
 
     def apply(rs: WrappedResultSet): Junction = new Junction(
-      id = rs.long("id"),
-      junctionNumber = rs.longOpt("junction_number"),
-      nodeNumber = rs.longOpt("node_number"),
-      startDate = rs.jodaDateTime("start_date"),
-      endDate = rs.jodaDateTimeOpt("end_date"),
-      validFrom = rs.jodaDateTime("valid_from"),
-      validTo = rs.jodaDateTimeOpt("valid_to"),
-      createdBy = rs.string("created_by"),
-      createdTime = rs.jodaDateTimeOpt("created_time")
+      id              = rs.long("id"),
+      junctionNumber  = rs.longOpt("junction_number"),
+      nodeNumber      = rs.longOpt("node_number"),
+      startDate       = rs.jodaDateTime("start_date"),
+      endDate         = rs.jodaDateTimeOpt("end_date"),
+      validFrom       = rs.jodaDateTime("valid_from"),
+      validTo         = rs.jodaDateTimeOpt("valid_to"),
+      createdBy       = rs.string("created_by"),
+      createdTime     = rs.jodaDateTimeOpt("created_time")
     )
   }
 
   object JunctionTemplate extends SQLSyntaxSupport[JunctionTemplate] {
 
     def apply(rs: WrappedResultSet): JunctionTemplate = new JunctionTemplate(
-      id = rs.long("id"),
+      id        = rs.long("id"),
       startDate = rs.jodaDateTime("start_date"),
-      roadPart = RoadPart(rs.long("road_number"), rs.long("road_part_number")),
-      track = Track(rs.int("track")),
-      addrM = rs.long("addr_m"),
-      elyCode = rs.long("ely")
+      roadPart  = RoadPart(rs.long("road_number"), rs.long("road_part_number")),
+      track     = Track(rs.int("track")),
+      addrM     = rs.long("addr_m"),
+      elyCode   = rs.long("ely")
     )
   }
 
   object JunctionForRoadAddressBrowser extends SQLSyntaxSupport[JunctionForRoadAddressBrowser] {
 
     def apply(rs: WrappedResultSet): JunctionForRoadAddressBrowser = new JunctionForRoadAddressBrowser(
-      nodeNumber = rs.long("node_number"),
+      nodeNumber      = rs.long("node_number"),
       nodeCoordinates = Point(rs.long("xcoord"), rs.long("ycoord")),
-      nodeName = rs.stringOpt("name"),
-      nodeType = NodeType(rs.int("type")),
-      startDate = rs.jodaDateTime("start_date"),
-      junctionNumber = rs.longOpt("junction_number"),
-      roadPart = RoadPart(rs.long("road_number"), rs.long("road_part_number")),
-      track = rs.long("track"),
-      addrM = rs.long("addr_m"),
-      beforeAfter = parseBeforeAfterValue(rs.string("beforeafter"))
+      nodeName        = rs.stringOpt("name"),
+      nodeType        = NodeType(rs.int("type")),
+      startDate       = rs.jodaDateTime("start_date"),
+      junctionNumber  = rs.longOpt("junction_number"),
+      roadPart        = RoadPart(rs.long("road_number"), rs.long("road_part_number")),
+      track           = rs.long("track"),
+      addrM           = rs.long("addr_m"),
+      beforeAfter     = parseBeforeAfterValue(rs.string("beforeafter"))
     )
 
     private def parseBeforeAfterValue(beforeAfterToParse: String): Seq[Long] = {
@@ -88,23 +77,23 @@ class JunctionDAO extends BaseDAO {
   }
 
   object JunctionWithLinearLocation extends SQLSyntaxSupport[JunctionWithLinearLocation] {
-
+    // Helper method to parse the jsonb_agg string into a Seq[Long]
     def parseJsonbAgg(stringToParse: String): Seq[Long] = {
       val res = stringToParse.replaceAll("[\\[\\]\\s]", "")
       res.split(",").map(_.toLong).toSeq
     }
 
     def apply(rs: WrappedResultSet): JunctionWithLinearLocation = new JunctionWithLinearLocation(
-      id = rs.long("id"),
-      junctionNumber = rs.longOpt("junction_number"),
-      nodeNumber = rs.longOpt("node_number"),
-      startDate = rs.jodaDateTime("start_date"),
-      endDate = rs.jodaDateTimeOpt("end_date"),
-      validFrom = rs.jodaDateTime("valid_from"),
-      validTo = rs.jodaDateTimeOpt("valid_to"),
-      createdBy = rs.string("created_by"),
-      createdTime = rs.jodaDateTimeOpt("created_time"),
-      llId = parseJsonbAgg(rs.string("ll_id"))
+      id              = rs.long("id"),
+      junctionNumber  = rs.longOpt("junction_number"),
+      nodeNumber      = rs.longOpt("node_number"),
+      startDate       = rs.jodaDateTime("start_date"),
+      endDate         = rs.jodaDateTimeOpt("end_date"),
+      validFrom       = rs.jodaDateTime("valid_from"),
+      validTo         = rs.jodaDateTimeOpt("valid_to"),
+      createdBy       = rs.string("created_by"),
+      createdTime     = rs.jodaDateTimeOpt("created_time"),
+      llId            = parseJsonbAgg(rs.string("ll_id"))
     )
   }
 
@@ -146,7 +135,7 @@ class JunctionDAO extends BaseDAO {
   }
 
 
-  val selectAllFromJunctionQuery = sqls"""
+  lazy val selectAllFromJunctionQuery = sqls"""
     SELECT ${j.id}, ${j.junctionNumber}, ${j.nodeNumber}, ${j.startDate}, ${j.endDate},
            ${j.validFrom}, ${j.validTo}, ${j.createdBy}, ${j.createdTime}
     FROM ${Junction.as(j)}
@@ -163,7 +152,9 @@ class JunctionDAO extends BaseDAO {
       val query =
         sql"""
         $selectAllFromJunctionQuery
-        WHERE ${j.nodeNumber} in ($nodeNumbers) AND ${j.validTo} IS NULL AND ${j.endDate} IS NULL
+        WHERE ${j.nodeNumber} IN ($nodeNumbers)
+          AND ${j.validTo} IS NULL
+          AND ${j.endDate} IS NULL
         """
       queryList(query)
     }
@@ -176,7 +167,9 @@ class JunctionDAO extends BaseDAO {
       val query =
         sql"""
       $selectAllFromJunctionQuery
-      WHERE ${j.id} IN (${ids}) AND ${j.validTo} IS NULL AND end_date IS NULL
+      WHERE ${j.id} IN ($ids)
+        AND ${j.validTo} IS NULL
+        AND ${j.endDate} IS NULL
       """
       queryList(query)
     }
@@ -189,7 +182,7 @@ class JunctionDAO extends BaseDAO {
       val query =
         sql"""
       $selectAllFromJunctionQuery
-      WHERE id IN (${ids})
+      WHERE id IN ($ids)
       """
       queryList(query)
     }
@@ -260,7 +253,7 @@ class JunctionDAO extends BaseDAO {
          JOIN junction_point jp ON j.id = jp.junction_id
          JOIN roadway_point rp ON jp.roadway_point_id = rp.id
          JOIN roadway rw ON rp.roadway_number = rw.roadway_number
-         WHERE rw.roadway_number IN (${roadwayNumbers})
+         WHERE rw.roadway_number IN ($roadwayNumbers)
         """
       queryList(query)
     } else {
@@ -343,8 +336,9 @@ class JunctionDAO extends BaseDAO {
 
       sql"""
         $baseQuery $dateCondition $elyCondition $roadNumberCondition $roadPartCondition
-        GROUP BY node.node_number, xcoord, ycoord, node.name, node.TYPE, ${j.startDate}, ${j.junctionNumber}, ${rw.column("road_number")}, ${rw.track}, ${rw.column("road_part_number")}, rp.addr_m
-        ORDER BY ${rw.column("road_number")}, ${rw.column("road_part_number")}, rp.addr_m
+        GROUP BY  node.node_number, xcoord, ycoord, node.name, node.TYPE, ${j.startDate}, ${j.junctionNumber},
+                  ${rw.column("road_number")}, ${rw.track}, ${rw.column("road_part_number")}, rp.addr_m
+        ORDER BY  ${rw.column("road_number")}, ${rw.column("road_part_number")}, rp.addr_m
         """
     }
 
@@ -375,8 +369,8 @@ class JunctionDAO extends BaseDAO {
 
     val query =
       sql"""
-        insert into junction (id, junction_number, node_number, start_date, end_date, created_by)
-        values (?, ?, ?, ?, ?, ?)
+        INSERT INTO junction (id, junction_number, node_number, start_date, end_date, created_by)
+        VALUES (?, ?, ?, ?, ?, ?)
       """
 
     runBatchUpdateToDb(query, batchParams.toSeq)

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/NodeDAO.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/NodeDAO.scala
@@ -1,112 +1,118 @@
 package fi.liikennevirasto.viite.dao
 
 import java.sql.Timestamp
-import com.github.tototoshi.slick.MySQLJodaSupport._
 import fi.liikennevirasto.digiroad2.util.LogUtils.time
 import fi.liikennevirasto.viite.NewIdValue
 import fi.vaylavirasto.viite.dao.{BaseDAO, Sequences}
 import fi.vaylavirasto.viite.geometry.{BoundingRectangle, Point}
+import fi.vaylavirasto.viite.postgis.GeometryDbUtils
 import fi.vaylavirasto.viite.model.{NodePointType, NodeType, RoadPart}
-import fi.vaylavirasto.viite.postgis.PostGISDatabase
 import org.joda.time.DateTime
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
-import slick.jdbc.StaticQuery.interpolation
-import slick.jdbc.{GetResult, PositionedResult, StaticQuery => Q}
+import scalikejdbc._
+import scalikejdbc.jodatime.JodaWrappedResultSet.fromWrappedResultSetToJodaWrappedResultSet
 
 
 case class Node(id: Long, nodeNumber: Long, coordinates: Point, name: Option[String], nodeType: NodeType, startDate: DateTime, endDate: Option[DateTime], validFrom: DateTime, validTo: Option[DateTime],
                 createdBy: String, createdTime: Option[DateTime], editor: Option[String] = None, publishedTime: Option[DateTime] = None, registrationDate: DateTime)
 
+object Node extends SQLSyntaxSupport[Node] {
+  override val tableName = "NODE"
+
+  def apply(rs: WrappedResultSet): Node = Node(
+    id = rs.long("id"),
+    nodeNumber = rs.long("node_number"),
+    Point(rs.double("ST_X"), rs.double("ST_Y")),
+    name = rs.stringOpt("name"),
+    nodeType = NodeType(rs.int("type")),
+    startDate = rs.jodaDateTime("start_date"),
+    endDate = rs.jodaDateTimeOpt("end_date"),
+    validFrom = rs.jodaDateTime("valid_from"),
+    validTo = rs.jodaDateTimeOpt("valid_to"),
+    createdBy = rs.string("created_by"),
+    createdTime = rs.jodaDateTimeOpt("created_time"),
+    editor = rs.stringOpt("editor"),
+    publishedTime = rs.jodaDateTimeOpt("published_time"),
+    registrationDate = rs.jodaDateTime("registration_date")
+  )
+}
+
 case class RoadAttributes(roadPart: RoadPart, addrMValue: Long)
 
 case class NodeForRoadAddressBrowser(ely: Long, roadPart: RoadPart, addrM: Long, startDate: DateTime, nodeType: NodeType, name: Option[String], nodeCoordinates: Point, nodeNumber: Long)
+
+object NodeForRoadAddressBrowserScalike extends SQLSyntaxSupport[NodeForRoadAddressBrowser] {
+  def apply(rs: WrappedResultSet): NodeForRoadAddressBrowser = NodeForRoadAddressBrowser(
+    ely = rs.long("ely"),
+    roadPart = RoadPart(rs.long("road_number"), rs.long("road_part_number")),
+    addrM = rs.long("addr_m"),
+    startDate = rs.jodaDateTime("start_date"),
+    nodeType = NodeType(rs.int("type")),
+    name = rs.stringOpt("name"),
+    Point(rs.double("ST_X"), rs.double("ST_Y")),
+    nodeNumber = rs.int("node_number")
+  )
+}
 
 case class NodeWithJunctions(node: Node, junctionsWithCoordinates: Seq[JunctionWithCoordinateAndCrossingRoads])
 
 class NodeDAO extends BaseDAO {
 
-  implicit val getNode: GetResult[Node] = new GetResult[Node] {
-    def apply(r: PositionedResult): Node = {
-      val id = r.nextLong()
-      val nodeNumber = r.nextLong()
-      val coordX = r.nextLong()
-      val coordY = r.nextLong()
-      val name = r.nextStringOption()
-      val nodeType = NodeType.apply(r.nextInt())
-      val startDate = new DateTime(r.nextDate())
-      val endDate = r.nextDateOption().map(d => new DateTime(d))
-      val validFrom = new DateTime(r.nextDate()) // r.nextTimestampOption() do not work here
-      val validTo = r.nextTimestampOption().map(d => new DateTime(d))
-      val createdBy = r.nextString()
-      val createdTime = r.nextTimestampOption().map(d => new DateTime(d))
-      val editor = r.nextStringOption()
-      val publishedTime = r.nextTimestampOption().map(d => new DateTime(d))
-      val registrationDate = new DateTime(r.nextTimestamp())
+  private val n = Node.syntax("n")
 
-      Node(id, nodeNumber, Point(coordX, coordY), name, nodeType, startDate, endDate, validFrom, validTo, createdBy, createdTime, editor, publishedTime, registrationDate)
-    }
+  // Helper method to run select queries for Node objects
+  private def queryList(query: SQL[Nothing, NoExtractor]): List[Node] = {
+    runSelectQuery(query.map(Node.apply)).groupBy(_.id)
+      .map { case (_, list) => list.head }
+      .toList
+  }
+  private def querySingle(query: SQL[Nothing, NoExtractor]): Option[Node] = {
+    runSelectSingleOption(query.map(Node.apply))
   }
 
-  implicit val getNodeForRoadAddressBrowser: GetResult[NodeForRoadAddressBrowser] = new GetResult[NodeForRoadAddressBrowser] {
-    def apply(r: PositionedResult): NodeForRoadAddressBrowser = {
-      val ely = r.nextLong()
-      val roadNumber = r.nextLong()
-      val roadPartNumber = r.nextLong()
-      val addrM = r.nextLong()
-      val startDate = new DateTime(r.nextDate())
-      val nodeType = NodeType.apply(r.nextInt())
-      val name = r.nextStringOption()
-      val coordX = r.nextLong()
-      val coordY = r.nextLong()
-      val nodeNumber =r.nextLong()
-
-      NodeForRoadAddressBrowser(ely, RoadPart(roadNumber, roadPartNumber), addrM, startDate, nodeType, name, Point(coordX, coordY), nodeNumber)
-    }
-  }
-
-  private def queryList(query: String): List[Node] = {
-    Q.queryNA[Node](query).list.groupBy(_.id).map {
-      case (_, list) =>
-        list.head
-    }.toList
-  }
+  private lazy val selectAllFromNodeQuery = sqls"""
+  SELECT id, node_number, ST_X(coordinates), ST_Y(coordinates), name, type, start_date,
+         end_date, valid_from, valid_to, created_by, created_time, editor, published_time, registration_date
+  FROM   node n
+"""
 
   def fetchByNodeNumber(nodeNumber: Long): Option[Node] = {
-    sql"""
-      SELECT ID, NODE_NUMBER, ST_X(COORDINATES), ST_Y(COORDINATES), NAME, TYPE, START_DATE, END_DATE, VALID_FROM, VALID_TO, CREATED_BY, CREATED_TIME, EDITOR, PUBLISHED_TIME, REGISTRATION_DATE
-      from NODE N
+    val query = sql"""
+      $selectAllFromNodeQuery
       where NODE_NUMBER = $nodeNumber and valid_to is null and end_date is null
-      """.as[Node].firstOption
+      """
+    querySingle(query)
   }
 
   def fetchById(nodeId: Long): Option[Node] = {
-    sql"""
-      SELECT ID, NODE_NUMBER, ST_X(COORDINATES), ST_Y(COORDINATES), NAME, TYPE, START_DATE, END_DATE, VALID_FROM, VALID_TO, CREATED_BY, CREATED_TIME, EDITOR, PUBLISHED_TIME, REGISTRATION_DATE
-      from NODE N
+    val query = sql"""
+      $selectAllFromNodeQuery
       where ID = $nodeId and valid_to is null and end_date is null
-      """.as[Node].firstOption
+      """
+    querySingle(query)
   }
 
   def fetchId(nodeNumber: Long): Option[Long] = {
-    sql"""
+    val query = sql"""
       SELECT ID
       from NODE
       where NODE_NUMBER = $nodeNumber and valid_to is null and end_date is null
-      """.as[Long].firstOption
+      """
+    runSelectSingleOption(query.map(_.long("id"))) // Return the id
   }
 
   def fetchLatestId(nodeNumber: Long): Option[Long] = {
-    sql"""
+    val query = sql"""
       SELECT ID
       from NODE
       where NODE_NUMBER = $nodeNumber and valid_to is null
       order by created_time desc, end_date desc
-      """.as[Long].firstOption
+      """
+    runSelectSingleOption(query.map(_.long("id"))) // Return the id
   }
 
   def fetchAllValidNodes(): Seq[Node] = {
     val query =
-    s"""
+      sql"""
       SELECT n.id, n.node_number, ST_X(n.COORDINATES), ST_Y(n.COORDINATES), n."name", n."type", n.start_date, n.end_date, n.valid_from, n.valid_to, n.created_by, n.created_time, n.editor, n.published_time, n.registration_date
       FROM node n
       WHERE n.end_date IS NULL AND n.valid_to IS NULL
@@ -114,98 +120,84 @@ class NodeDAO extends BaseDAO {
     queryList(query)
   }
 
-  def fetchNodesForRoadAddressBrowser(situationDate: Option[String], ely: Option[Long], roadNumber: Option[Long], minRoadPartNumber: Option[Long], maxRoadPartNumber: Option[Long]): Seq[NodeForRoadAddressBrowser] = {
-    def withOptionalParameters(situationDate: Option[String], ely: Option[Long], roadNumber: Option[Long], minRoadPartNumber: Option[Long], maxRoadPartNumber: Option[Long])(query: String): String = {
-      val dateCondition = "AND rw.start_date <='" + situationDate.get + "'"
-
-      val elyCondition = {
-        if (ely.nonEmpty)
-          s" AND rw.ely = ${ely.get}"
-        else
-          ""
-      }
-
-      val roadNumberCondition = {
-        if (roadNumber.nonEmpty)
-          s" AND rw.road_number = ${roadNumber.get}"
-        else
-          ""
-      }
-
-      val roadPartCondition = {
-        val parts = (minRoadPartNumber, maxRoadPartNumber)
-        parts match {
-          case (Some(minPart), Some(maxPart)) => s"AND rw.road_part_number BETWEEN $minPart AND $maxPart"
-          case (None, Some(maxPart)) => s"AND rw.road_part_number <= $maxPart"
-          case (Some(minPart), None) => s"AND rw.road_part_number >= $minPart"
-          case _ => ""
-        }
-      }
-
-      s"""$query WHERE node.VALID_TO IS NULL AND node.END_DATE IS NULL
-        $dateCondition $elyCondition $roadNumberCondition $roadPartCondition
-        ORDER BY rw.ROAD_NUMBER, rw.ROAD_PART_NUMBER, rp.ADDR_M""".stripMargin
-    }
-
-    def fetchNodes(queryFilter: String => String): Seq[NodeForRoadAddressBrowser] = {
-      val query =
-        """
-      SELECT DISTINCT rw.ely, rw.ROAD_NUMBER, rw.ROAD_PART_NUMBER, rp.ADDR_M, node.START_DATE, node.type, node.NAME, ST_X(node.COORDINATES) AS xcoord, ST_Y(node.COORDINATES) AS ycoord, node.NODE_NUMBER
+  def fetchNodesForRoadAddressBrowser(situationDate: Option[String], ely: Option[Long], roadNumber: Option[Long],
+                                      minRoadPartNumber: Option[Long], maxRoadPartNumber: Option[Long]): Seq[NodeForRoadAddressBrowser] = {
+    val baseQuery =
+      sqls"""
+      SELECT DISTINCT rw.ely, rw.ROAD_NUMBER, rw.ROAD_PART_NUMBER, rp.ADDR_M, node.START_DATE, node.type, node.NAME, ST_X(node.COORDINATES), ST_Y(node.COORDINATES), node.NODE_NUMBER
 		  FROM NODE node
       JOIN NODE_POINT np ON node.NODE_NUMBER = np.NODE_NUMBER AND np.VALID_TO IS NULL
       JOIN ROADWAY_POINT rp ON np.ROADWAY_POINT_ID = rp.ID
       JOIN ROADWAY rw ON rp.ROADWAY_NUMBER = rw.ROADWAY_NUMBER AND rw.VALID_TO IS NULL AND rw.END_DATE IS null
       """
-      val filteredQuery = queryFilter(query)
-      Q.queryNA[NodeForRoadAddressBrowser](filteredQuery).iterator.toSeq
+
+    def withOptionalParameters(situationDate: Option[String], ely: Option[Long], roadNumber: Option[Long],
+                               minRoadPartNumber: Option[Long], maxRoadPartNumber: Option[Long])(query: SQLSyntax): SQL[Nothing, NoExtractor] = {
+      val dateCondition = situationDate.map { date => sqls"AND rw.start_date <= ${date}::date"}.getOrElse(sqls"")
+      val elyCondition = ely.map(ely => sqls" AND rw.ely = $ely").getOrElse(sqls"")
+      val roadNumberCondition = roadNumber.map(roadNumber => sqls" AND rw.road_number = $roadNumber").getOrElse(sqls"")
+
+      val roadPartCondition = {
+        val parts = (minRoadPartNumber, maxRoadPartNumber)
+        parts match {
+          case (Some(minPart), Some(maxPart)) => sqls"AND rw.road_part_number BETWEEN $minPart AND $maxPart"
+          case (None, Some(maxPart)) => sqls"AND rw.road_part_number <= $maxPart"
+          case (Some(minPart), None) => sqls"AND rw.road_part_number >= $minPart"
+          case _ => sqls""
+        }
+      }
+
+      sql"""$query WHERE node.VALID_TO IS NULL AND node.END_DATE IS NULL
+        $dateCondition $elyCondition $roadNumberCondition $roadPartCondition
+        ORDER BY rw.ROAD_NUMBER, rw.ROAD_PART_NUMBER, rp.ADDR_M"""
     }
-    fetchNodes(withOptionalParameters(situationDate, ely, roadNumber, minRoadPartNumber, maxRoadPartNumber))
+
+    val queryWithOptionalParameters = withOptionalParameters(situationDate, ely, roadNumber, minRoadPartNumber, maxRoadPartNumber)(baseQuery)
+    runSelectQuery(queryWithOptionalParameters.map(NodeForRoadAddressBrowserScalike.apply))
   }
 
-
-  def fetchByRoadAttributes(road_number: Long, minRoadPartNumber: Option[Long], maxRoadPartNumber: Option[Long]): Seq[(Node, RoadAttributes)] = {
-    val road_condition = (minRoadPartNumber.isDefined, maxRoadPartNumber.isDefined) match {
-      case (true, true) => s"AND rw.ROAD_PART_NUMBER >= ${minRoadPartNumber.get} AND rw.ROAD_PART_NUMBER <= ${maxRoadPartNumber.get}"
-      case (true, _) => s"AND rw.ROAD_PART_NUMBER = ${minRoadPartNumber.get}"
-      case (_, true) => s"AND rw.ROAD_PART_NUMBER = ${maxRoadPartNumber.get}"
-      case _ => ""
+  def fetchByRoadAttributes(roadNumber: Long, minRoadPartNumber: Option[Long], maxRoadPartNumber: Option[Long]): Seq[(Node, RoadAttributes)] = {
+    val roadCondition = (minRoadPartNumber.isDefined, maxRoadPartNumber.isDefined) match {
+      case (true, true) => sqls"AND rw.ROAD_PART_NUMBER >= ${minRoadPartNumber.get} AND rw.ROAD_PART_NUMBER <= ${maxRoadPartNumber.get}"
+      case (true, _) => sqls"AND rw.ROAD_PART_NUMBER = ${minRoadPartNumber.get}"
+      case (_, true) => sqls"AND rw.ROAD_PART_NUMBER = ${maxRoadPartNumber.get}"
+      case _ => sqls.empty
     }
 
     val query =
-      s"""
+      sql"""
         SELECT DISTINCT node.ID, node.NODE_NUMBER, ST_X(node.COORDINATES), ST_Y(node.COORDINATES), node.NAME, node.TYPE, node.START_DATE, node.END_DATE, node.VALID_FROM, node.VALID_TO,
-                        node.CREATED_BY, node.CREATED_TIME, node.REGISTRATION_DATE, rw.ROAD_NUMBER, rw.ROAD_PART_NUMBER, rp.ADDR_M
+                        node.CREATED_BY, node.CREATED_TIME, node.REGISTRATION_DATE, node.EDITOR, node.PUBLISHED_TIME, rw.ROAD_NUMBER, rw.ROAD_PART_NUMBER, rp.ADDR_M
         FROM NODE node
         JOIN NODE_POINT np ON node.NODE_NUMBER = np.NODE_NUMBER AND np.VALID_TO IS NULL
         JOIN ROADWAY_POINT rp ON np.ROADWAY_POINT_ID = rp.ID
         JOIN ROADWAY rw ON rp.ROADWAY_NUMBER = rw.ROADWAY_NUMBER AND rw.VALID_TO IS NULL AND rw.END_DATE IS NULL
           WHERE node.VALID_TO IS NULL AND node.END_DATE IS NULL
-          AND rw.ROAD_NUMBER = $road_number $road_condition
+          AND rw.ROAD_NUMBER = $roadNumber $roadCondition
         ORDER BY rw.ROAD_NUMBER, rw.ROAD_PART_NUMBER, rp.ADDR_M
       """
 
-    Q.queryNA[(Long, Long, Long, Long, Option[String], Option[Int], DateTime, Option[DateTime], DateTime, Option[DateTime],
-      String, Option[DateTime], DateTime, Long, Long, Long)](query).list.map {
-
-      case (id, nodeNumber, x, y, name, nodeType, startDate, endDate, validFrom, validTo,
-      createdBy, createdTime, registrationDate, roadNumber, roadPartNumber, addrMValue) =>
-
-        (Node(id, nodeNumber, Point(x, y), name, NodeType.apply(nodeType.getOrElse(NodeType.UnknownNodeType.value)), startDate, endDate, validFrom, validTo, createdBy, createdTime, None, None, registrationDate),
-          RoadAttributes(RoadPart(roadNumber, roadPartNumber), addrMValue))
-    }
+    runSelectQuery(query.map(rs => {
+      val node = Node.apply(rs)
+      val roadAttributes = RoadAttributes(
+        roadPart = RoadPart(rs.long("ROAD_NUMBER"), rs.long("ROAD_PART_NUMBER")),
+        addrMValue = rs.long("ADDR_M")
+      )
+      (node, roadAttributes)
+    }))
   }
 
   def publish(id: Long, editor: String = "-"): Unit = {
-    runUpdateToDb(s"""
-        Update NODE Set PUBLISHED_TIME = CURRENT_TIMESTAMP, EDITOR = '$editor' Where ID = $id
+    runUpdateToDb(sql"""
+        Update NODE Set PUBLISHED_TIME = CURRENT_TIMESTAMP, EDITOR = $editor Where ID = $id
     """)
   }
 
   def create(nodes: Iterable[Node], createdBy: String = "-"): Seq[Long] = {
 
-    val ps = dynamicSession.prepareStatement(
-      """insert into NODE (ID, NODE_NUMBER, COORDINATES, NAME, TYPE, START_DATE, END_DATE, CREATED_BY, REGISTRATION_DATE)
-      values (?, ?, ST_GeomFromText(?, 3067), ?, ?, ?, ?, ?, ?)""".stripMargin)
+    val query =
+      sql"""insert into NODE (ID, NODE_NUMBER, COORDINATES, NAME, TYPE, START_DATE, END_DATE, CREATED_BY, REGISTRATION_DATE)
+      values (?, ?, ST_GeomFromText(?, 3067), ?, ?, ?, ?, ?, ?)"""
 
     // Set ids for the nodes without one
     val (ready, idLess) = nodes.partition(_.id != NewIdValue)
@@ -214,46 +206,41 @@ class NodeDAO extends BaseDAO {
       x._1.copy(id = x._2)
     )
 
-    var nodeNumbers = scala.collection.mutable.MutableList[Long]()
-    createNodes.foreach {
-      node =>
-        val nodeNumber = if (node.nodeNumber == NewIdValue) {
-          Sequences.nextNodeNumber
-        } else {
-          node.nodeNumber
-        }
-        nodeNumbers += nodeNumber
-        ps.setLong(1, node.id)
-        ps.setLong(2, nodeNumber)
-        ps.setString(3, PostGISDatabase.createRoundedPointGeometry(node.coordinates))
-        if (node.name.isDefined) {
-          ps.setString(4, node.name.get)
-        } else {
-          ps.setNull(4, java.sql.Types.VARCHAR)
-        }
-        ps.setLong(5, node.nodeType.value)
-        ps.setDate(6, new java.sql.Date(node.startDate.getMillis))
-        if (node.endDate.isDefined) {
-          ps.setDate(7, new java.sql.Date(node.endDate.get.getMillis))
-        } else {
-          ps.setNull(7, java.sql.Types.DATE)
-        }
-        ps.setString(8, if (createdBy == null) "-" else createdBy)
-        ps.setTimestamp(9, new java.sql.Timestamp(node.registrationDate.getMillis))
-        ps.addBatch()
+    val batchParams = createNodes.map { node =>
+      val nodeNumber = if (node.nodeNumber == NewIdValue) {
+        Sequences.nextNodeNumber
+      } else {
+        node.nodeNumber
+      }
+      Seq(
+        node.id,
+        nodeNumber,
+        GeometryDbUtils.createRoundedPointGeometry(node.coordinates),
+        node.name.orNull,
+        node.nodeType.value,
+        new java.sql.Date(node.startDate.getMillis),
+        node.endDate.map(d => new java.sql.Date(d.getMillis)).orNull,
+        if (createdBy == null) "-" else createdBy,
+        new java.sql.Timestamp(node.registrationDate.getMillis)
+      )
     }
-    ps.executeBatch()
-    ps.close()
-    nodeNumbers
+
+    runBatchUpdateToDb(query, batchParams.toSeq)
+
+    batchParams.map(_(1).asInstanceOf[Long]).toSeq // Return the node numbers
   }
 
   def fetchByBoundingBox(boundingRectangle: BoundingRectangle): Seq[Node] = {
-    val extendedBoundingBoxRectangle = BoundingRectangle(boundingRectangle.leftBottom + boundingRectangle.diagonal.scale(scalar = .15),
-      boundingRectangle.rightTop - boundingRectangle.diagonal.scale(scalar = .15))
-    val boundingBoxFilter = PostGISDatabase.boundingBoxFilter(extendedBoundingBoxRectangle, geometryColumn = "coordinates")
-    val query = s"""
-      SELECT ID, NODE_NUMBER, ST_X(COORDINATES), ST_Y(COORDINATES), NAME, TYPE, START_DATE, END_DATE, VALID_FROM, VALID_TO, CREATED_BY, CREATED_TIME, EDITOR, PUBLISHED_TIME, REGISTRATION_DATE
-      FROM NODE N
+    val extendedBoundingBoxRectangle = BoundingRectangle(
+      boundingRectangle.leftBottom + boundingRectangle.diagonal.scale(scalar = .15),
+      boundingRectangle.rightTop   - boundingRectangle.diagonal.scale(scalar = .15)
+    )
+    val boundingBoxFilter = GeometryDbUtils.boundingBoxFilter(
+      extendedBoundingBoxRectangle,
+      geometryColumn = sqls"coordinates"
+    )
+    val query = sql"""
+        $selectAllFromNodeQuery
         WHERE $boundingBoxFilter
         AND END_DATE IS NULL AND VALID_TO IS NULL
     """
@@ -261,17 +248,17 @@ class NodeDAO extends BaseDAO {
   }
 
   /**
-    * Expires nodes (set their valid_to to the current system date).
-    *
-    * @param ids : Iterable[Long] - The ids of the nodes to expire.
-    * @return
-    */
+   * Expires nodes (set their valid_to to the current system date).
+   *
+   * @param ids : Iterable[Long] - The ids of the nodes to expire.
+   * @return
+   */
   def expireById(ids: Iterable[Long]): Unit = {
     if (ids.isEmpty)
       0
     else {
-      val query = s"""
-        UPDATE NODE SET valid_to = CURRENT_TIMESTAMP WHERE valid_to IS NULL AND id IN (${ids.mkString(", ")})
+      val query = sql"""
+        UPDATE NODE SET valid_to = CURRENT_TIMESTAMP WHERE valid_to IS NULL AND id IN ($ids)
       """
       logger.debug(s"******* Expiring nodes by ids: ${ids.mkString(", ")} \n    query: : $query")
       runUpdateToDb(query)
@@ -283,10 +270,9 @@ class NodeDAO extends BaseDAO {
       Seq()
     } else {
       // TODO - Might be needed to check node point type here - since calculate node points should not be considered to identify empty nodes
-      val query = s"""
-        SELECT ID, NODE_NUMBER, ST_X(COORDINATES), ST_Y(COORDINATES), NAME, TYPE, START_DATE, END_DATE, VALID_FROM, VALID_TO, CREATED_BY, CREATED_TIME, EDITOR, PUBLISHED_TIME, REGISTRATION_DATE
-        FROM NODE N
-          WHERE END_DATE IS NULL AND VALID_TO IS NULL AND NODE_NUMBER IN (${nodeNumbers.mkString(", ")})
+      val query = sql"""
+          $selectAllFromNodeQuery
+          WHERE END_DATE IS NULL AND VALID_TO IS NULL AND NODE_NUMBER IN ($nodeNumbers)
           AND NOT EXISTS (
             SELECT NULL FROM JUNCTION J WHERE N.NODE_NUMBER = J.NODE_NUMBER AND J.VALID_TO IS NULL AND J.END_DATE IS NULL
           ) AND NOT EXISTS (
@@ -299,13 +285,12 @@ class NodeDAO extends BaseDAO {
 
   def fetchAllByDateRange(sinceDate: DateTime, untilDate: Option[DateTime]): Seq[Node] = {
     time(logger, "Fetch nodes by date range") {
-      val untilString = if (untilDate.nonEmpty) s"AND PUBLISHED_TIME <= to_timestamp('${new Timestamp(untilDate.get.getMillis)}', 'YYYY-MM-DD HH24:MI:SS.FF')" else s""
+      val untilString = if (untilDate.nonEmpty) s"AND PUBLISHED_TIME <= to_timestamp(${new Timestamp(untilDate.get.getMillis)}, YYYY-MM-DD HH24:MI:SS.FF)" else s""
       val query =
-        s"""
-         SELECT ID, NODE_NUMBER, ST_X(COORDINATES), ST_Y(COORDINATES), NAME, TYPE, START_DATE, END_DATE, VALID_FROM, VALID_TO, CREATED_BY, CREATED_TIME, EDITOR, PUBLISHED_TIME, REGISTRATION_DATE
-         FROM NODE N
+        sql"""
+         $selectAllFromNodeQuery
          WHERE NODE_NUMBER IN (SELECT NODE_NUMBER FROM NODE NC WHERE
-         PUBLISHED_TIME IS NOT NULL AND PUBLISHED_TIME >= to_timestamp('${new Timestamp(sinceDate.getMillis)}', 'YYYY-MM-DD HH24:MI:SS.FF')
+         PUBLISHED_TIME IS NOT NULL AND PUBLISHED_TIME >= to_timestamp(${new Timestamp(sinceDate.getMillis)}, YYYY-MM-DD HH24:MI:SS.FF)
          $untilString)
          AND VALID_TO IS NULL
        """
@@ -319,7 +304,7 @@ class NodeDAO extends BaseDAO {
   // We find also nodes that have end_date not null to support change detection for tierekisteri for terminated nodes
   def fetchNodeNumbersByProject(projectId: Long): Seq[Long] = {
     val query =
-      s"""
+      sql"""
          SELECT DISTINCT N.NODE_NUMBER
          FROM NODE N
          INNER JOIN JUNCTION J
@@ -392,7 +377,7 @@ class NodeDAO extends BaseDAO {
          AND NP.VALID_TO IS NULL
          AND N.VALID_TO IS NULL
                """
-    Q.queryNA[Long](query).iterator.toSeq
+    runSelectQuery(query.map(rs => rs.long(1)))
   }
 
 }

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/NodePointDAO.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/NodePointDAO.scala
@@ -4,7 +4,7 @@ import fi.liikennevirasto.digiroad2.util.LogUtils.time
 import fi.liikennevirasto.viite.NewIdValue
 import fi.vaylavirasto.viite.dao.{BaseDAO, Sequences}
 import fi.vaylavirasto.viite.geometry.{BoundingRectangle, Point}
-import fi.vaylavirasto.viite.postgis.GeometryDbUtils
+import fi.vaylavirasto.viite.postgis.{GeometryDbUtils, PostGISDatabaseScalikeJDBC}
 import fi.vaylavirasto.viite.model.{AddrMRange, BeforeAfter, NodePointType, RoadPart, Track}
 import org.joda.time.DateTime
 import scalikejdbc._
@@ -17,33 +17,31 @@ case class NodePoint(id: Long, beforeAfter: BeforeAfter, roadwayPointId: Long, n
                      roadPart: RoadPart, track: Track, elyCode: Long, coordinates: Point = Point(0.0, 0.0))
 
 object NodePoint extends SQLSyntaxSupport[NodePoint] {
-  override val tableName = "NODE_POINT"
-
   def apply(rs: WrappedResultSet): NodePoint = NodePoint(
-    id = rs.long("id"),
-    beforeAfter = BeforeAfter(rs.int("before_after")),
-    roadwayPointId = rs.long("roadway_point_id"),
-    nodeNumber = rs.longOpt("node_number"),
-    nodePointType = NodePointType(rs.int("type")),
-    startDate = rs.jodaDateTimeOpt("start_date"),
-    endDate = rs.jodaDateTimeOpt("end_date"),
-    validFrom = rs.jodaDateTime("valid_from"),
-    validTo = rs.jodaDateTimeOpt("valid_to"),
-    createdBy = rs.string("created_by"),
-    createdTime = rs.jodaDateTimeOpt("created_time"),
-    roadwayNumber = rs.long("roadway_number"),
-    addrM = rs.long("addr_m"),
+    id                = rs.long("id"),
+    beforeAfter       = BeforeAfter(rs.int("before_after")),
+    roadwayPointId    = rs.long("roadway_point_id"),
+    nodeNumber        = rs.longOpt("node_number"),
+    nodePointType     = NodePointType(rs.int("type")),
+    startDate         = rs.jodaDateTimeOpt("start_date"),
+    endDate           = rs.jodaDateTimeOpt("end_date"),
+    validFrom         = rs.jodaDateTime("valid_from"),
+    validTo           = rs.jodaDateTimeOpt("valid_to"),
+    createdBy         = rs.string("created_by"),
+    createdTime       = rs.jodaDateTimeOpt("created_time"),
+    roadwayNumber     = rs.long("roadway_number"),
+    addrM             = rs.long("addr_m"),
     roadPart = RoadPart(
-      rs.longOpt("road_number").map(l => l).getOrElse(0L),
-      rs.longOpt("road_part_number").map(l => l).getOrElse(0L)
+      roadNumber      = rs.longOpt("road_number").map(l       => l).getOrElse(0L),
+      partNumber      = rs.longOpt("road_part_number").map(l  => l).getOrElse(0L)
     ),
-    track = rs.longOpt("track").map(l => Track.apply(l.toInt)).getOrElse(Track.Unknown),
-    elyCode = rs.longOpt("ely").map(l => l).getOrElse(0L)
+    track             = rs.longOpt("track").map(l  => Track.apply(l.toInt)).getOrElse(Track.Unknown),
+    elyCode           = rs.longOpt("ely").map(l    => l).getOrElse(0L)
   )
 }
 
 class NodePointDAO extends BaseDAO {
-  private val np = NodePoint.syntax("np")
+
   private def queryList(query: SQL[Nothing, NoExtractor]): List[NodePoint] = {
     runSelectQuery(query.map(NodePoint.apply))
       .groupBy(_.id)
@@ -52,18 +50,18 @@ class NodePointDAO extends BaseDAO {
   }
 
   /** Select/join clause for retrieving joined nodepoint~roadway_point~roadway, node~nodepoint data, where:
-   * <li>nodepoint must match preserved roadway_point by roadway_point_id, as well as </li>
-   * <li>roadway_point must match preserved roadway by roadway_number, and roadway must be eligible (end_date, and valid_to must be nulls) for it to match. </li>
+   * <li>nodepoint must match preserved roadway_point by roadway_point_id, AS well AS </li>
+   * <li>roadway_point must match preserved roadway by roadway_number, AND roadway must be eligible (end_date, AND valid_to must be nulls) for it to match. </li>
    * <li>The existence of the corresponding node is not required, but it is serached by node_number matching
-   *     that of node_point, and it must be still eligible for it to match.</li> */
+   *     that of node_point, AND it must be still eligible for it to match.</li> */
   lazy val selectFromNodePoint = sqls"""
-                             SELECT NP.ID, NP.BEFORE_AFTER, NP.ROADWAY_POINT_ID, NP.NODE_NUMBER, NP.TYPE, N.START_DATE, N.END_DATE,
-                                NP.VALID_FROM, NP.VALID_TO, NP.CREATED_BY, NP.CREATED_TIME, RP.ROADWAY_NUMBER, RP.ADDR_M,
-                                RW.ROAD_NUMBER, RW.ROAD_PART_NUMBER, RW.TRACK, RW.ELY
-                             FROM NODE_POINT NP
-                             JOIN ROADWAY_POINT RP ON (RP.ID = ROADWAY_POINT_ID)
-                             LEFT OUTER JOIN NODE N ON (N.NODE_NUMBER = np.NODE_NUMBER AND N.VALID_TO IS NULL AND N.END_DATE IS NULL)
-                             JOIN ROADWAY RW on (RW.ROADWAY_NUMBER = RP.ROADWAY_NUMBER AND RW.END_DATE IS NULL AND RW.VALID_TO IS NULL)
+                             SELECT np.id, np.before_after, np.roadway_point_id, np.node_number, np.type, n.start_date, n.end_date,
+                                np.valid_from, np.valid_to, np.created_by, np.created_time, rp.roadway_number, rp.addr_m,
+                                rw.road_number, rw.road_part_number, rw.track, rw.ely
+                             FROM node_point np
+                             JOIN roadway_point rp ON (rp.id = roadway_point_id)
+                             LEFT OUTER JOIN node n ON (n.node_number = np.node_number AND n.valid_to IS NULL AND n.end_date IS NULL)
+                             JOIN roadway rW on (rw.roadway_number = rp.roadway_number AND rw.end_date IS NULL AND rw.valid_to IS NULL)
                              """
 
   def fetchByIds(ids: Seq[Long]): Seq[NodePoint] = {
@@ -73,7 +71,7 @@ class NodePointDAO extends BaseDAO {
       val query =
         sql"""
             $selectFromNodePoint
-            where NP.id in ($ids) and NP.valid_to is null
+            WHERE np.id IN ($ids) AND np.valid_to IS NULL
          """
       queryList(query)
     }
@@ -83,48 +81,48 @@ class NodePointDAO extends BaseDAO {
     fetchByNodeNumbers(Seq(nodeNumber))
   }
 
-  /** Retrieves those eligible (valid_to is null) NodePoints, whose node_number matches any of  those in <i>nodeNumbers</i>.
-   * Uses {@link selectFromNodePoint} as the select/join clause. */
+  /** Retrieves those eligible (valid_to IS NULL) NodePoints, whose node_number matches any of  those IN <i>nodeNumbers</i>.
+   * Uses {@link selectFromNodePoint} AS the select/join clause. */
   def fetchByNodeNumbers(nodeNumbers: Seq[Long]): Seq[NodePoint] = {
     if (nodeNumbers.isEmpty) Seq()
     else {
       val query =
         sql"""
          $selectFromNodePoint
-         where N.node_number in ($nodeNumbers) and NP.valid_to is null
+         WHERE n.node_number IN ($nodeNumbers) AND np.valid_to IS NULL
        """
       queryList(query)
     }
   }
 
-  /** Retrieves those NodePoints, whose roadway_point_id matches any of  those in <i>roadwayPointIds</i>.
-   * Uses altered version of {@link selectFromNodePoint}, where roadway needs NOT to be eligible.
-   * Gets joined NodePoint, Node, RoadwayPoint, and Roadway info where
-   * nodePoint~roadPoint~roadway, and nodePoint~node,
-   * and <b>nodePoint is still eligible</b> (end_date, and valid_to are nulls) */
+  /** Retrieves those NodePoints, whose roadway_point_id matches any of  those IN <i>roadwayPointIds</i>.
+   * Uses altered version of {@link selectFromNodePoint}, WHERE roadway needs NOT to be eligible.
+   * Gets joined NodePoint, Node, RoadwayPoint, AND Roadway info where
+   * nodePoint~roadPoint~roadway, AND nodePoint~node,
+   * AND <b>nodePoint is still eligible</b> (end_date, AND valid_to are nulls) */
   def fetchByRoadwayPointIds(roadwayPointIds: Seq[Long]): Seq[NodePoint] = {
     if (roadwayPointIds.isEmpty) {
       Seq()
     } else {
       val query =
         sql"""
-          SELECT NP.ID, NP.BEFORE_AFTER, NP.ROADWAY_POINT_ID, NP.NODE_NUMBER, NP.TYPE, N.START_DATE, N.END_DATE,
-            NP.VALID_FROM, NP.VALID_TO, NP.CREATED_BY, NP.CREATED_TIME, RP.ROADWAY_NUMBER, RP.ADDR_M,
-            RW.ROAD_NUMBER, RW.ROAD_PART_NUMBER, RW.TRACK, RW.ELY
-          FROM NODE_POINT NP
-          JOIN ROADWAY_POINT RP ON (RP.ID = ROADWAY_POINT_ID)
-          LEFT OUTER JOIN NODE N ON (N.NODE_NUMBER = np.NODE_NUMBER AND N.VALID_TO IS NULL AND N.END_DATE IS NULL)
-          JOIN ROADWAY RW on (RW.ROADWAY_NUMBER = RP.ROADWAY_NUMBER)
-          where NP.ROADWAY_POINT_ID in ($roadwayPointIds) and NP.valid_to is null
+          SELECT np.id, np.before_after, np.roadway_point_id, np.node_number, np.type, n.start_date, n.end_date,
+            np.valid_from, np.valid_to, np.created_by, np.created_time, rp.roadway_number, rp.addr_m,
+            rw.road_number, rw.road_part_number, rw.track, rw.ely
+          FROM node_point np
+          JOIN roadway_point rp ON (rp.id = roadway_point_id)
+          LEFT OUTER JOIN node n ON (n.node_number = np.node_number AND n.valid_to IS NULL AND n.end_date IS NULL)
+          JOIN roadway rw ON (rw.roadway_number = rp.roadway_number)
+          WHERE np.roadway_point_id IN ($roadwayPointIds) AND np.valid_to IS NULL
         """
       logger.debug(s"******* Querying by roadwaypointId.s: ${roadwayPointIds.mkString(", ")} \n    query: : $query")
       queryList(query)
     }
   }
 
-  /** Gets joined NodePoint, Node, RoadwayPoint, and Roadway info where
-   * nodePoint~roadPoint~roadway, and nodePoint~node,
-   * and nodePoint is still eligible (end_date, and valid_to are nulls)
+  /** Gets joined NodePoint, Node, RoadwayPoint, AND Roadway info where
+   * nodePoint~roadPoint~roadway, AND nodePoint~node,
+   * AND nodePoint is still eligible (end_date, AND valid_to are nulls)
    * <b>but there is no more corresponding roadway available.</b>*/
   def fetchRoadwiseOrphansByRoadwayPointIds(roadwayPointIds: Seq[Long]): Seq[NodePoint] = {
     if (roadwayPointIds.isEmpty) {
@@ -132,44 +130,44 @@ class NodePointDAO extends BaseDAO {
     } else {
       val query =
         sql"""
-           SELECT NP.ID, NP.BEFORE_AFTER, NP.ROADWAY_POINT_ID, NP.NODE_NUMBER, NP.TYPE,
-                  N.START_DATE, N.END_DATE,
-                  NP.VALID_FROM, NP.VALID_TO, NP.CREATED_BY, NP.CREATED_TIME,
-                  RP.ROADWAY_NUMBER, RP.ADDR_M,
-                  RW.ROAD_NUMBER, RW.ROAD_PART_NUMBER, RW.TRACK, RW.ELY
-           FROM            NODE_POINT NP
-           INNER JOIN      ROADWAY_POINT RP ON (RP.ID = ROADWAY_POINT_ID)
-           LEFT OUTER JOIN NODE N     ON (N.NODE_NUMBER = np.NODE_NUMBER AND N.VALID_TO IS NULL AND N.END_DATE IS NULL)
-           LEFT OUTER JOIN ROADWAY RW ON (RW.ROADWAY_NUMBER = RP.ROADWAY_NUMBER)
-           WHERE           NP.ROADWAY_POINT_ID IN ($roadwayPointIds) AND NP.valid_to is null
-                           AND RW.ROADWAY_NUMBER is null
+           SELECT np.id, np.before_after, np.roadway_point_id, np.node_number, np.type,
+                  n.start_date, n.end_date,
+                  np.valid_from, np.valid_to, np.created_by, np.created_time,
+                  rp.roadway_number, rp.addr_m,
+                  rw.road_number, rw.road_part_number, rw.track, rw.ely
+           FROM            node_point np
+           INNER JOIN      roadway_point rp ON (rp.id = roadway_point_id)
+           LEFT OUTER JOIN node n           ON (n.node_number = np.node_number AND n.valid_to IS NULL AND n.end_date IS NULL)
+           LEFT OUTER JOIN roadway rw       ON (rw.roadway_number = rp.roadway_number)
+           WHERE           np.roadway_point_id IN ($roadwayPointIds) AND np.valid_to IS NULL
+                           AND rw.roadway_number IS NULL
         """
       logger.debug(s"******* Querying Roadwaywise orphan Nodes by roadwaypointId.s: ${roadwayPointIds.mkString(", ")} \n    query: : $query")
       queryList(query)
     }
   }
 
-  /** Get the eligible (valid_to is null) NodePoints that have the given roadwayPointId. */
+  /** Get the eligible (valid_to IS NULL) NodePoints that have the given roadwayPointId. */
   def fetchByRoadwayPointId(roadwayPointId: Long): Seq[NodePoint] = {
     val query =
       sql"""
      $selectFromNodePoint
-     where NP.ROADWAY_POINT_ID = $roadwayPointId and NP.valid_to is null
+     WHERE np.roadway_point_id = $roadwayPointId AND np.valid_to IS NULL
    """
     queryList(query)
   }
 
-  /** Get the eligible (valid_to is null) NodePoints and NodePoint templates that have the given roadwayNumber. */
+  /** Get the eligible (valid_to IS NULL) NodePoints AND NodePoint templates that have the given roadwayNumber. */
   def fetchByRoadwayNumber(roadwayNumber: Long): Seq[NodePoint] = {
     val query =
       sql"""
          $selectFromNodePoint
-         where RP.roadway_number = $roadwayNumber and NP.valid_to is null
+         WHERE rp.roadway_number = $roadwayNumber AND np.valid_to IS NULL
        """
     queryList(query)
   }
 
-  /** Get the eligible (valid_to is null) NodePoints that have a roadway number belonging to
+  /** Get the eligible (valid_to IS NULL) NodePoints that have a roadway number belonging to
    * the given roadwayNumbers sequence . */
   def fetchRoadAddressNodePoints(roadwayNumbers: Seq[Long]): Seq[NodePoint] = {
     if (roadwayNumbers.isEmpty) Seq()
@@ -177,8 +175,8 @@ class NodePointDAO extends BaseDAO {
       val query =
         sql"""
          $selectFromNodePoint
-         where RP.roadway_number in ($roadwayNumbers) and NP.valid_to is null
-         AND NP.TYPE = ${NodePointType.RoadNodePoint.value}
+         WHERE rp.roadway_number IN ($roadwayNumbers) AND np.valid_to IS NULL
+         AND np.type = ${NodePointType.RoadNodePoint.value}
        """
       queryList(query)
     }
@@ -187,14 +185,14 @@ class NodePointDAO extends BaseDAO {
   def fetchTemplatesByRoadwayNumber(roadwayNumber: Long): List[NodePoint] = {
     val query =
       sql"""
-        SELECT  NP.ID, NP.BEFORE_AFTER, NP.ROADWAY_POINT_ID, NP.NODE_NUMBER, NP.TYPE,
-                NULL AS START_DATE, NULL AS END_DATE,
-                NP.VALID_FROM, NP.VALID_TO, NP.CREATED_BY, NP.CREATED_TIME, RP.ROADWAY_NUMBER, RP.ADDR_M,
-                NULL AS ROAD_NUMBER, NULL AS ROAD_PART_NUMBER, NULL AS ElY, NULL AS TRACK
-        FROM NODE_POINT NP
-        JOIN ROADWAY_POINT RP ON (RP.ID = ROADWAY_POINT_ID)
-        JOIN ROADWAY RW ON (RP.ROADWAY_NUMBER = RW.ROADWAY_NUMBER AND RW.end_date is NULL AND RW.VALID_TO IS NULL)
-        where RP.roadway_number = $roadwayNumber and NP.valid_to is null and NP.node_number is null
+        SELECT  np.id, np.before_after, np.roadway_point_id, np.node_number, np.type,
+                NULL AS start_date, NULL AS end_date,
+                np.valid_from, np.valid_to, np.created_by, np.created_time, rp.roadway_number, rp.addr_m,
+                NULL AS road_number, NULL AS road_part_number, NULL AS ElY, NULL AS track
+        FROM node_point np
+        JOIN roadway_point rp ON (rp.id = roadway_point_id)
+        JOIN roadway rW ON (rp.roadway_number = rw.roadway_number AND rw.end_date is NULL AND rw.valid_to IS NULL)
+        WHERE rp.roadway_number = $roadwayNumber AND np.valid_to IS NULL AND np.node_number IS NULL
       """
     queryList(query)
   }
@@ -204,12 +202,13 @@ class NodePointDAO extends BaseDAO {
       if (roadwayNumbers.isEmpty) {
         sql""
       } else {
-        sql"""SELECT NP.ID, NP.BEFORE_AFTER, NP.ROADWAY_POINT_ID, NP.NODE_NUMBER, NP.TYPE, NULL, NULL,
-          NP.VALID_FROM, NP.VALID_TO, NP.CREATED_BY, NP.CREATED_TIME, RP.ROADWAY_NUMBER, RP.ADDR_M, RW.ROAD_NUMBER, RW.ROAD_PART_NUMBER, RW.TRACK, rw.ELY
-          FROM NODE_POINT NP
-          JOIN ROADWAY_POINT RP ON (RP.ID = ROADWAY_POINT_ID)
-          JOIN ROADWAY RW ON (RP.ROADWAY_NUMBER = RW.ROADWAY_NUMBER AND RW.end_date is NULL AND RW.VALID_TO IS NULL)
-          where RP.roadway_number in ($roadwayNumbers) and NP.valid_to is null and NP.node_number is null
+        sql"""
+          SELECT  np.id, np.before_after, np.roadway_point_id, np.node_number, np.type, NULL, NULL,
+                  np.valid_from, np.valid_to, np.created_by, np.created_time, rp.roadway_number, rp.addr_m, rw.road_number, rw.road_part_number, rw.track, rw.ely
+          FROM node_point np
+          JOIN roadway_point rp ON (rp.id = roadway_point_id)
+          JOIN roadway rW ON (rp.roadway_number = rw.roadway_number AND rw.end_date is NULL AND rw.valid_to IS NULL)
+          WHERE rp.roadway_number IN ($roadwayNumbers) AND np.valid_to IS NULL AND np.node_number IS NULL
        """
       }
     queryList(query)
@@ -218,13 +217,14 @@ class NodePointDAO extends BaseDAO {
   def fetchTemplates() : Seq[NodePoint] = {
     val query =
       sql"""
-         SELECT DISTINCT NP.ID, NP.BEFORE_AFTER, NP.ROADWAY_POINT_ID, NULL AS NODE_NUMBER, NP.TYPE, NULL AS START_DATE, NULL AS END_DATE,
-         NP.VALID_FROM, NP.VALID_TO, NP.CREATED_BY, NP.CREATED_TIME, RP.ROADWAY_NUMBER, RP.ADDR_M, RW.ROAD_NUMBER, RW.ROAD_PART_NUMBER, RW.TRACK, rw.ELY
-         FROM NODE_POINT NP
-         JOIN ROADWAY_POINT RP ON (RP.ID = ROADWAY_POINT_ID)
-         JOIN LINEAR_LOCATION LL ON (LL.ROADWAY_NUMBER = RP.ROADWAY_NUMBER AND LL.VALID_TO IS NULL)
-         JOIN ROADWAY RW ON (RP.ROADWAY_NUMBER = RW.ROADWAY_NUMBER AND RW.end_date is NULL AND RW.VALID_TO IS NULL)
-         where NP.valid_to is null and NP.node_number is null
+         SELECT DISTINCT  np.id, np.before_after, np.roadway_point_id, NULL AS node_number, np.type, NULL AS start_date,
+                          NULL AS end_date, np.valid_from, np.valid_to, np.created_by, np.created_time, rp.roadway_number,
+                          rp.addr_m, rw.road_number, rw.road_part_number, rw.track, rw.ely
+         FROM node_point np
+         JOIN roadway_point rp ON (rp.id = roadway_point_id)
+         JOIN linear_location ll ON (ll.roadway_number = rp.roadway_number AND ll.valid_to IS NULL)
+         JOIN roadway rW ON (rp.roadway_number = rw.roadway_number AND rw.end_date is NULL AND rw.valid_to IS NULL)
+         WHERE np.valid_to IS NULL AND np.node_number IS NULL
        """
     queryList(query)
   }
@@ -232,13 +232,14 @@ class NodePointDAO extends BaseDAO {
   def fetchNodePointTemplateById(id: Long): Option[NodePoint] = {
     val query =
       sql"""
-         SELECT DISTINCT NP.ID, NP.BEFORE_AFTER, NP.ROADWAY_POINT_ID, NP.NODE_NUMBER, NP.TYPE, NULL, NULL,
-         NP.VALID_FROM, NP.VALID_TO, NP.CREATED_BY, NP.CREATED_TIME, RP.ROADWAY_NUMBER, RP.ADDR_M, RW.ROAD_NUMBER, RW.ROAD_PART_NUMBER, RW.TRACK, rw.ELY
-         FROM NODE_POINT NP
-         JOIN ROADWAY_POINT RP ON (RP.ID = ROADWAY_POINT_ID)
-         JOIN LINEAR_LOCATION LL ON (LL.ROADWAY_NUMBER = RP.ROADWAY_NUMBER AND LL.VALID_TO IS NULL)
-         JOIN ROADWAY RW ON (RP.ROADWAY_NUMBER = RW.ROADWAY_NUMBER AND RW.end_date is NULL AND RW.VALID_TO IS NULL)
-         where NP.id = $id AND NP.node_number is null and NP.valid_to is null
+         SELECT DISTINCT np.id, np.before_after, np.roadway_point_id, np.node_number, np.type,
+                NULL AS start_date, NULL AS end_date, np.valid_from, np.valid_to, np.created_by, np.created_time,
+                rp.roadway_number, rp.addr_m, rw.road_number, rw.road_part_number, rw.track, rw.ely
+         FROM node_point np
+         JOIN roadway_point rp ON (rp.id = roadway_point_id)
+         JOIN linear_location ll ON (ll.roadway_number = rp.roadway_number AND ll.valid_to IS NULL)
+         JOIN roadway rw ON (rp.roadway_number = rw.roadway_number AND rw.end_date is NULL AND rw.valid_to IS NULL)
+         WHERE np.id = $id AND np.node_number IS NULL AND np.valid_to IS NULL
        """
     runSelectSingleOption(query.map(NodePoint.apply))
   }
@@ -248,17 +249,18 @@ class NodePointDAO extends BaseDAO {
       val extendedBoundingRectangle = BoundingRectangle(boundingRectangle.leftBottom + boundingRectangle.diagonal.scale(.15),
         boundingRectangle.rightTop - boundingRectangle.diagonal.scale(.15))
 
-      val boundingBoxFilter = GeometryDbUtils.boundingBoxFilter(extendedBoundingRectangle, sqls"LL.geometry")
+      val boundingBoxFilter = GeometryDbUtils.boundingBoxFilter(extendedBoundingRectangle, sqls"ll.geometry")
 
       val query =
         sql"""
-          SELECT NP.ID, NP.BEFORE_AFTER, NP.ROADWAY_POINT_ID, NP.NODE_NUMBER, NP.TYPE, NULL AS start_date, NULL AS end_date,
-            NP.VALID_FROM, NP.VALID_TO, NP.CREATED_BY, NP.CREATED_TIME, RP.ROADWAY_NUMBER, RP.ADDR_M, RW.ROAD_NUMBER, RW.ROAD_PART_NUMBER, RW.TRACK, RW.ELY
-          FROM NODE_POINT NP
-          JOIN ROADWAY_POINT RP ON (RP.ID = ROADWAY_POINT_ID)
-          JOIN LINEAR_LOCATION LL ON (LL.ROADWAY_NUMBER = RP.ROADWAY_NUMBER AND LL.VALID_TO IS NULL)
-          JOIN ROADWAY RW ON (RP.ROADWAY_NUMBER = RW.ROADWAY_NUMBER AND RW.VALID_TO IS NULL AND RW.END_DATE IS NULL)
-          where $boundingBoxFilter AND NP.node_number is null and NP.valid_to is null
+          SELECT  np.id, np.before_after, np.roadway_point_id, np.node_number, np.type, NULL AS start_date, NULL AS end_date,
+                  np.valid_from, np.valid_to, np.created_by, np.created_time, rp.roadway_number, rp.addr_m, rw.road_number,
+                  rw.road_part_number, rw.track, rw.ely
+          FROM node_point np
+          JOIN roadway_point rp ON (rp.id = roadway_point_id)
+          JOIN linear_location ll ON (ll.roadway_number = rp.roadway_number AND ll.valid_to IS NULL)
+          JOIN roadway rW ON (rp.roadway_number = rw.roadway_number AND rw.valid_to IS NULL AND rw.end_date IS NULL)
+          WHERE $boundingBoxFilter AND np.node_number IS NULL AND np.valid_to IS NULL
         """
       queryList(query)
     }
@@ -287,7 +289,7 @@ class NodePointDAO extends BaseDAO {
 
     val query =
       sql"""
-            INSERT INTO NODE_POINT (ID, BEFORE_AFTER, ROADWAY_POINT_ID, NODE_NUMBER, TYPE, CREATED_BY)
+            INSERT INTO NODE_POINT (ID, before_after, roadway_point_id, node_number, type, created_by)
             VALUES (?, ?, ?, ?, ?, ?)
       """
 
@@ -307,7 +309,7 @@ class NodePointDAO extends BaseDAO {
   def expireById(ids: Iterable[Long]): Int = {
     val query =
       sql"""
-        Update NODE_POINT Set valid_to = CURRENT_TIMESTAMP where valid_to IS NULL and id in ($ids)
+        UPDATE NODE_POINT SET valid_to = CURRENT_TIMESTAMP WHERE valid_to IS NULL AND id IN ($ids)
       """
     if (ids.isEmpty)
       0
@@ -320,26 +322,26 @@ class NodePointDAO extends BaseDAO {
   def expireByNodeNumberAndType(nodeNumber: Long, nodePointType: NodePointType): Unit = {
     val query =
       sql"""
-        Update NODE_POINT Set valid_to = CURRENT_TIMESTAMP where valid_to IS NULL AND node_number = $nodeNumber
+        UPDATE node_point SET valid_to = CURRENT_TIMESTAMP WHERE valid_to IS NULL AND node_number = $nodeNumber
         AND type = ${nodePointType.value}
       """
-    logger.debug(s"Expiring by number and type: $nodeNumber, ${nodePointType.value} \n    query: : $query")
+    logger.debug(s"Expiring by number AND type: $nodeNumber, ${nodePointType.value} \n    query: : $query")
     runUpdateToDb(query)
   }
 
   def fetchCalculatedNodePointsForNodeNumber(nodeNumber: Long): Seq[NodePoint] = {
     val query =
       sql"""
-       SELECT NP.ID, NP.BEFORE_AFTER, NP.ROADWAY_POINT_ID, NP.NODE_NUMBER, NP.TYPE,
-            NULL AS START_DATE, NULL AS END_DATE,
-            NP.VALID_FROM, NP.VALID_TO, NP.CREATED_BY, NP.CREATED_TIME,
-            RP.ROADWAY_NUMBER, RP.ADDR_M,
-            NULL as ROAD_NUMBER, NULL as ROAD_PART_NUMBER, NULL as TRACK, NULL as ELY
-       FROM NODE_POINT NP
-       JOIN ROADWAY_POINT RP ON (RP.ID = ROADWAY_POINT_ID)
-       where NP.valid_to is null and NP.node_number = $nodeNumber
-       AND NP.type = 2
-       ORDER BY NP.ID
+       SELECT np.id, np.before_after, np.roadway_point_id, np.node_number, np.type,
+            NULL AS start_date, NULL AS end_date,
+            np.valid_from, np.valid_to, np.created_by, np.created_time,
+            rp.roadway_number, rp.addr_m,
+            NULL AS road_number, NULL AS road_part_number, NULL AS track, NULL AS ely
+       FROM node_point np
+       JOIN roadway_point rp ON (rp.id = roadway_point_id)
+       WHERE np.valid_to IS NULL AND np.node_number = $nodeNumber
+       AND np.type = 2
+       ORDER BY np.id
      """.map(NodePoint.apply)
 
     runSelectQuery(query)
@@ -350,32 +352,35 @@ class NodePointDAO extends BaseDAO {
   def fetchRoadPartsInfoForNode(nodeNumber: Long): Seq[RoadPartInfo] = {
     val query =
       sql"""
-         SELECT R.ROAD_NUMBER, R.ROADWAY_NUMBER, R.ROAD_PART_NUMBER, JP.BEFORE_AFTER, JP.ROADWAY_POINT_ID, RP.ADDR_M,
-                R.TRACK, R.START_ADDR_M, R.END_ADDR_M, R.ID
-         FROM ROADWAY R, ROADWAY_POINT RP, JUNCTION_POINT JP, JUNCTION J
-         WHERE J.NODE_NUMBER = $nodeNumber
-         AND J.ID = JP.JUNCTION_ID
-         AND JP.ROADWAY_POINT_ID = RP.ID
-         AND R.ROADWAY_NUMBER = RP.ROADWAY_NUMBER
-         AND JP.VALID_TO IS NULL
-         AND J.VALID_TO IS NULL
-         AND J.END_DATE IS NULL
-         AND R.END_DATE IS NULL AND R.VALID_TO IS NULL
-         AND (R.ROAD_NUMBER BETWEEN 1 AND 19999 OR R.ROAD_NUMBER BETWEEN 40000 AND 69999)
-         ORDER BY R.ROAD_NUMBER, R.ROAD_PART_NUMBER, R.TRACK, R.ROADWAY_NUMBER
+         SELECT r.road_number, r.roadway_number, r.road_part_number, jp.before_after, jp.roadway_point_id, rp.addr_m,
+                r.track, r.start_addr_m, r.end_addr_m, r.id
+         FROM roadway r, roadway_point rp, junction_point jp, junction j
+         WHERE j.node_number = $nodeNumber
+         AND j.id = jp.junction_id
+         AND jp.roadway_point_id = rp.id
+         AND r.roadway_number = rp.roadway_number
+         AND jp.valid_to IS NULL
+         AND j.valid_to IS NULL
+         AND j.end_date IS NULL
+         AND r.end_date IS NULL AND r.valid_to IS NULL
+         AND (r.road_number BETWEEN 1 AND 19999 OR r.road_number BETWEEN 40000 AND 69999)
+         ORDER BY r.road_number, r.road_part_number, r.track, r.roadway_number
        """
     runSelectQuery(query.map(rs => RoadPartInfo(
-      roadPart = RoadPart(
-        rs.longOpt("road_number").getOrElse(0L),
-        rs.longOpt("road_part_number").getOrElse(0L)
+      roadPart        = RoadPart(
+        roadNumber    = rs.longOpt("road_number").getOrElse(0L),
+        partNumber    = rs.longOpt("road_part_number").getOrElse(0L)
       ),
-      roadwayNumber = rs.long("roadway_number"),
-      beforeAfter = rs.long("before_after"),
-      roadwayPointId = rs.long("roadway_point_id"),
-      addrM = rs.long("addr_m"),
-      track = rs.long("track"),
-      addrMRange = AddrMRange(rs.long("start_addr_m"), rs.long("end_addr_m")),
-      roadwayId = rs.long("id")
+      roadwayNumber   = rs.long("roadway_number"),
+      beforeAfter     = rs.long("before_after"),
+      roadwayPointId  = rs.long("roadway_point_id"),
+      addrM           = rs.long("addr_m"),
+      track           = rs.long("track"),
+      addrMRange      = AddrMRange(
+        start         = rs.long("start_addr_m"),
+        end           = rs.long("end_addr_m")
+      ),
+      roadwayId       = rs.long("id")
     )))
   }
 
@@ -383,7 +388,7 @@ class NodePointDAO extends BaseDAO {
     val query =
       sql"""
      $selectFromNodePoint
-     where NP.ROADWAY_POINT_ID = $roadwayPointId and NP.valid_to is null and NP.node_number is null
+     WHERE np.roadway_point_id = $roadwayPointId AND np.valid_to IS NULL AND np.node_number IS NULL
    """
     queryList(query)
   }
@@ -391,22 +396,22 @@ class NodePointDAO extends BaseDAO {
   def fetchNodePointsCountForRoadAndRoadPart(roadPart: RoadPart, beforeAfter: Long, nodeNumber: Long): Option[Long] = {
     val query =
       sql"""
-          SELECT count(NP.ID)
-          FROM ROADWAY R, ROADWAY_POINT RP, NODE_POINT NP, NODE N
-          WHERE R.ROAD_NUMBER = ${roadPart.roadNumber}
-          AND R.ROAD_PART_NUMBER = ${roadPart.partNumber}
-          AND R.END_DATE IS NULL AND R.VALID_TO IS NULL
-          AND RP.ROADWAY_NUMBER = R.ROADWAY_NUMBER
-          AND NP.ROADWAY_POINT_ID = RP.ID
-          AND NP.NODE_NUMBER IS NOT NULL
-          AND NP.VALID_TO IS NULL
-          AND NP.TYPE = 1
-          AND NP.NODE_NUMBER = N.NODE_NUMBER
-          AND N.END_DATE IS NULL
-          AND N.VALID_TO IS NULL
-          AND N.NODE_NUMBER = $nodeNumber
-          GROUP BY R.ROAD_PART_NUMBER
-          ORDER BY R.ROAD_PART_NUMBER
+          SELECT COUNT(np.id)
+          FROM roadway r, roadway_point rp, node_point np, node n
+          WHERE r.road_number = ${roadPart.roadNumber}
+            AND r.road_part_number = ${roadPart.partNumber}
+            AND r.end_date IS NULL AND r.valid_to IS NULL
+            AND rp.roadway_number = r.roadway_number
+            AND np.roadway_point_id = rp.id
+            AND np.node_number IS NOT NULL
+            AND np.valid_to IS NULL
+            AND np.type = 1
+            AND np.node_number = n.node_number
+            AND n.end_date IS NULL
+            AND n.valid_to IS NULL
+            AND n.node_number = $nodeNumber
+          GROUP BY r.road_part_number
+          ORDER BY r.road_part_number
        """
     runSelectSingleFirstOptionWithType[Long](query)
   }
@@ -414,25 +419,25 @@ class NodePointDAO extends BaseDAO {
   def fetchAverageAddrM(roadPart: RoadPart, nodeNumber: Long): Long = {
     val query =
       sql"""
-        SELECT AVG(RP.ADDR_M)
-        FROM ROADWAY_POINT RP
-        INNER JOIN ROADWAY R
-          ON (R.ROAD_NUMBER = ${roadPart.roadNumber}
-            AND R.ROAD_PART_NUMBER = ${roadPart.partNumber}
-            AND R.END_DATE IS NULL AND R.VALID_TO IS NULL
-            AND RP.ROADWAY_NUMBER = R.ROADWAY_NUMBER)
-        INNER JOIN JUNCTION_POINT JP
-          ON (JP.ROADWAY_POINT_ID = RP.ID
-            AND JP.VALID_TO IS NULL)
-        INNER JOIN JUNCTION J
-          ON (J.ID = JP.JUNCTION_ID
-            AND J.VALID_TO IS NULL
-            AND J.END_DATE IS NULL)
-        INNER JOIN NODE N
-          ON (J.NODE_NUMBER = N.NODE_NUMBER
-            AND N.END_DATE IS NULL
-            AND N.VALID_TO IS NULL
-            AND N.NODE_NUMBER = $nodeNumber)
+        SELECT AVG(rp.addr_m)
+        FROM roadway_point rp
+        INNER JOIN roadway r
+          ON (r.road_number = ${roadPart.roadNumber}
+            AND r.road_part_number = ${roadPart.partNumber}
+            AND r.end_date IS NULL AND r.valid_to IS NULL
+            AND rp.roadway_number = r.roadway_number)
+        INNER JOIN junction_point jp
+          ON (jp.roadway_point_id = rp.id
+            AND jp.valid_to IS NULL)
+        INNER JOIN junction j
+          ON (j.id = jp.junction_id
+            AND j.valid_to IS NULL
+            AND j.end_date IS NULL)
+        INNER JOIN node n
+          ON (j.node_number = n.node_number
+            AND n.end_date IS NULL
+            AND n.valid_to IS NULL
+            AND n.node_number = $nodeNumber)
      """
     runSelectSingle(query.map(rs => rs.bigDecimal(1).longValue)) // The result for AVG is a BigDecimal
   }
@@ -441,23 +446,23 @@ class NodePointDAO extends BaseDAO {
   def fetchAddrMForAverage(roadPart: RoadPart): Seq[NodePoint] = {
     val query =
       sql"""
-          SELECT NULL AS ID, NULL, NULL, NULL, NULL, NULL, NULL,
-          RP.CREATED_TIME, JP.VALID_TO, RP.CREATED_TIME, RP.CREATED_TIME, RP.ROADWAY_NUMBER, RP.ADDR_M, R.ROAD_NUMBER, R.ROAD_PART_NUMBER, R.TRACK, R.ELY
-          FROM ROADWAY_POINT RP
-          INNER JOIN ROADWAY R
-            ON (R.ROAD_NUMBER = ${roadPart.roadNumber}
-              AND R.ROAD_PART_NUMBER = ${roadPart.partNumber}
-              AND R.END_DATE IS NULL AND R.VALID_TO IS NULL
-              AND RP.ROADWAY_NUMBER = R.ROADWAY_NUMBER)
-          INNER JOIN JUNCTION_POINT JP
-            ON (JP.ROADWAY_POINT_ID = RP.ID AND JP.VALID_TO IS NULL)
-          INNER JOIN JUNCTION J
-             ON (J.ID = JP.JUNCTION_ID
-             AND JP.VALID_TO IS NULL
-             AND J.VALID_TO IS NULL
-             AND J.END_DATE IS NULL
-             AND J.NODE_NUMBER IS NOT NULL)
-          ORDER BY R.ROAD_NUMBER, R.ROAD_PART_NUMBER
+          SELECT  NULL AS id, NULL AS before_after, NULL AS roadway_point_id, NULL AS node_number, NULL AS type, NULL AS start_date, NULL AS end_date,
+                  rp.created_time, jp.valid_to, rp.created_time, rp.created_time, rp.roadway_number, rp.addr_m, r.road_number, r.road_part_number, r.track, r.ely
+          FROM roadway_point rp
+          INNER JOIN roadway r
+            ON (r.road_number = ${roadPart.roadNumber}
+              AND r.road_part_number = ${roadPart.partNumber}
+              AND r.end_date IS NULL AND r.valid_to IS NULL
+              AND rp.roadway_number = r.roadway_number)
+          INNER JOIN junction_point jp
+            ON (jp.roadway_point_id = rp.id AND jp.valid_to IS NULL)
+          INNER JOIN junction j
+             ON (j.id = jp.junction_id
+             AND jp.valid_to IS NULL
+             AND j.valid_to IS NULL
+             AND j.end_date IS NULL
+             AND j.node_number IS NOT NULL)
+          ORDER BY r.road_number, r.road_part_number
        """
     queryList(query)
   }

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/NodePointDAO.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/NodePointDAO.scala
@@ -4,12 +4,11 @@ import fi.liikennevirasto.digiroad2.util.LogUtils.time
 import fi.liikennevirasto.viite.NewIdValue
 import fi.vaylavirasto.viite.dao.{BaseDAO, Sequences}
 import fi.vaylavirasto.viite.geometry.{BoundingRectangle, Point}
+import fi.vaylavirasto.viite.postgis.GeometryDbUtils
 import fi.vaylavirasto.viite.model.{AddrMRange, BeforeAfter, NodePointType, RoadPart, Track}
-import fi.vaylavirasto.viite.postgis.PostGISDatabase
-import fi.vaylavirasto.viite.util.DateTimeFormatters.dateOptTimeFormatter
 import org.joda.time.DateTime
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
-import slick.jdbc.{GetResult, PositionedResult, StaticQuery => Q}
+import scalikejdbc._
+import scalikejdbc.jodatime.JodaWrappedResultSet.fromWrappedResultSetToJodaWrappedResultSet
 
 
 case class NodePoint(id: Long, beforeAfter: BeforeAfter, roadwayPointId: Long, nodeNumber: Option[Long], nodePointType: NodePointType = NodePointType.UnknownNodePointType,
@@ -17,60 +16,64 @@ case class NodePoint(id: Long, beforeAfter: BeforeAfter, roadwayPointId: Long, n
                      createdBy: String, createdTime: Option[DateTime], roadwayNumber: Long, addrM : Long,
                      roadPart: RoadPart, track: Track, elyCode: Long, coordinates: Point = Point(0.0, 0.0))
 
+object NodePoint extends SQLSyntaxSupport[NodePoint] {
+  override val tableName = "NODE_POINT"
+
+  def apply(rs: WrappedResultSet): NodePoint = NodePoint(
+    id = rs.long("id"),
+    beforeAfter = BeforeAfter(rs.int("before_after")),
+    roadwayPointId = rs.long("roadway_point_id"),
+    nodeNumber = rs.longOpt("node_number"),
+    nodePointType = NodePointType(rs.int("type")),
+    startDate = rs.jodaDateTimeOpt("start_date"),
+    endDate = rs.jodaDateTimeOpt("end_date"),
+    validFrom = rs.jodaDateTime("valid_from"),
+    validTo = rs.jodaDateTimeOpt("valid_to"),
+    createdBy = rs.string("created_by"),
+    createdTime = rs.jodaDateTimeOpt("created_time"),
+    roadwayNumber = rs.long("roadway_number"),
+    addrM = rs.long("addr_m"),
+    roadPart = RoadPart(
+      rs.longOpt("road_number").map(l => l).getOrElse(0L),
+      rs.longOpt("road_part_number").map(l => l).getOrElse(0L)
+    ),
+    track = rs.longOpt("track").map(l => Track.apply(l.toInt)).getOrElse(Track.Unknown),
+    elyCode = rs.longOpt("ely").map(l => l).getOrElse(0L)
+  )
+}
+
 class NodePointDAO extends BaseDAO {
+  private val np = NodePoint.syntax("np")
+  private def queryList(query: SQL[Nothing, NoExtractor]): List[NodePoint] = {
+    runSelectQuery(query.map(NodePoint.apply))
+      .groupBy(_.id)
+      .map {case  (_, nodePoints) => nodePoints.head} // Remove duplicates
+      .toList
+  }
 
   /** Select/join clause for retrieving joined nodepoint~roadway_point~roadway, node~nodepoint data, where:
-    * <li>nodepoint must match preserved roadway_point by roadway_point_id, as well as </li>
-    * <li>roadway_point must match preserved roadway by roadway_number, and roadway must be eligible (end_date, and valid_to must be nulls) for it to match. </li>
-    * <li>The existence of the corresponding node is not required, but it is serached by node_number matching
-    *     that of node_point, and it must be still eligible for it to match.</li> */
-  val selectFromNodePoint = """SELECT NP.ID, NP.BEFORE_AFTER, NP.ROADWAY_POINT_ID, NP.NODE_NUMBER, NP.TYPE, N.START_DATE, N.END_DATE,
-                             NP.VALID_FROM, NP.VALID_TO, NP.CREATED_BY, NP.CREATED_TIME, RP.ROADWAY_NUMBER, RP.ADDR_M,
-                             RW.ROAD_NUMBER, RW.ROAD_PART_NUMBER, RW.TRACK, RW.ELY
+   * <li>nodepoint must match preserved roadway_point by roadway_point_id, as well as </li>
+   * <li>roadway_point must match preserved roadway by roadway_number, and roadway must be eligible (end_date, and valid_to must be nulls) for it to match. </li>
+   * <li>The existence of the corresponding node is not required, but it is serached by node_number matching
+   *     that of node_point, and it must be still eligible for it to match.</li> */
+  lazy val selectFromNodePoint = sqls"""
+                             SELECT NP.ID, NP.BEFORE_AFTER, NP.ROADWAY_POINT_ID, NP.NODE_NUMBER, NP.TYPE, N.START_DATE, N.END_DATE,
+                                NP.VALID_FROM, NP.VALID_TO, NP.CREATED_BY, NP.CREATED_TIME, RP.ROADWAY_NUMBER, RP.ADDR_M,
+                                RW.ROAD_NUMBER, RW.ROAD_PART_NUMBER, RW.TRACK, RW.ELY
                              FROM NODE_POINT NP
                              JOIN ROADWAY_POINT RP ON (RP.ID = ROADWAY_POINT_ID)
                              LEFT OUTER JOIN NODE N ON (N.NODE_NUMBER = np.NODE_NUMBER AND N.VALID_TO IS NULL AND N.END_DATE IS NULL)
-                             JOIN ROADWAY RW on (RW.ROADWAY_NUMBER = RP.ROADWAY_NUMBER AND RW.END_DATE IS NULL AND RW.VALID_TO IS NULL) """
-
-  implicit val getNodePoint: GetResult[NodePoint] = new GetResult[NodePoint] {
-    def apply(r: PositionedResult): NodePoint = {
-      val id = r.nextLong()
-      val beforeAfter = r.nextLong()
-      val roadwayPointId = r.nextLong()
-      val nodeNumber = r.nextLongOption()
-      val nodePointType = NodePointType.apply(r.nextInt())
-      val startDate   = r.nextDateOption.map(d => dateOptTimeFormatter.parseDateTime(d.toString))
-      val endDate     = r.nextDateOption.map(d => dateOptTimeFormatter.parseDateTime(d.toString))
-      val validFrom   = dateOptTimeFormatter.parseDateTime(r.nextDate.toString)
-      val validTo     = r.nextDateOption.map(d => dateOptTimeFormatter.parseDateTime(d.toString))
-      val createdBy   = r.nextString()
-      val createdTime = r.nextDateOption.map(d => dateOptTimeFormatter.parseDateTime(d.toString))
-      val roadwayNumber = r.nextLong()
-      val addrM = r.nextLong()
-      val roadNumber = r.nextLongOption().map(l => l).getOrElse(0L)
-      val roadPartNumber = r.nextLongOption().map(l => l).getOrElse(0L)
-      val track = r.nextLongOption().map(l => Track.apply(l.toInt)).getOrElse(Track.Unknown)
-      val ely = r.nextLongOption().map(l => l).getOrElse(0L)
-
-      NodePoint(id, BeforeAfter.apply(beforeAfter), roadwayPointId, nodeNumber, nodePointType, startDate, endDate, validFrom, validTo, createdBy, createdTime, roadwayNumber, addrM, RoadPart(roadNumber, roadPartNumber), track, ely)
-    }
-  }
-
-  private def queryList(query: String): List[NodePoint] = {
-    Q.queryNA[NodePoint](query).list.groupBy(_.id).map {
-      case (_, list) =>
-        list.head
-    }.toList
-  }
+                             JOIN ROADWAY RW on (RW.ROADWAY_NUMBER = RP.ROADWAY_NUMBER AND RW.END_DATE IS NULL AND RW.VALID_TO IS NULL)
+                             """
 
   def fetchByIds(ids: Seq[Long]): Seq[NodePoint] = {
     if (ids.isEmpty) {
       Seq()
     } else {
       val query =
-        s"""
+        sql"""
             $selectFromNodePoint
-            where NP.id in (${ids.mkString(", ")}) and NP.valid_to is null
+            where NP.id in ($ids) and NP.valid_to is null
          """
       queryList(query)
     }
@@ -81,30 +84,30 @@ class NodePointDAO extends BaseDAO {
   }
 
   /** Retrieves those eligible (valid_to is null) NodePoints, whose node_number matches any of  those in <i>nodeNumbers</i>.
-    * Uses {@link selectFromNodePoint} as the select/join clause. */
+   * Uses {@link selectFromNodePoint} as the select/join clause. */
   def fetchByNodeNumbers(nodeNumbers: Seq[Long]): Seq[NodePoint] = {
     if (nodeNumbers.isEmpty) Seq()
     else {
       val query =
-        s"""
+        sql"""
          $selectFromNodePoint
-         where N.node_number in (${nodeNumbers.mkString(", ")}) and NP.valid_to is null
+         where N.node_number in ($nodeNumbers) and NP.valid_to is null
        """
       queryList(query)
     }
   }
 
   /** Retrieves those NodePoints, whose roadway_point_id matches any of  those in <i>roadwayPointIds</i>.
-    * Uses altered version of {@link selectFromNodePoint}, where roadway needs NOT to be eligible.
-    * Gets joined NodePoint, Node, RoadwayPoint, and Roadway info where
-    * nodePoint~roadPoint~roadway, and nodePoint~node,
-    * and <b>nodePoint is still eligible</b> (end_date, and valid_to are nulls) */
+   * Uses altered version of {@link selectFromNodePoint}, where roadway needs NOT to be eligible.
+   * Gets joined NodePoint, Node, RoadwayPoint, and Roadway info where
+   * nodePoint~roadPoint~roadway, and nodePoint~node,
+   * and <b>nodePoint is still eligible</b> (end_date, and valid_to are nulls) */
   def fetchByRoadwayPointIds(roadwayPointIds: Seq[Long]): Seq[NodePoint] = {
     if (roadwayPointIds.isEmpty) {
       Seq()
     } else {
       val query =
-        s"""
+        sql"""
           SELECT NP.ID, NP.BEFORE_AFTER, NP.ROADWAY_POINT_ID, NP.NODE_NUMBER, NP.TYPE, N.START_DATE, N.END_DATE,
             NP.VALID_FROM, NP.VALID_TO, NP.CREATED_BY, NP.CREATED_TIME, RP.ROADWAY_NUMBER, RP.ADDR_M,
             RW.ROAD_NUMBER, RW.ROAD_PART_NUMBER, RW.TRACK, RW.ELY
@@ -112,7 +115,7 @@ class NodePointDAO extends BaseDAO {
           JOIN ROADWAY_POINT RP ON (RP.ID = ROADWAY_POINT_ID)
           LEFT OUTER JOIN NODE N ON (N.NODE_NUMBER = np.NODE_NUMBER AND N.VALID_TO IS NULL AND N.END_DATE IS NULL)
           JOIN ROADWAY RW on (RW.ROADWAY_NUMBER = RP.ROADWAY_NUMBER)
-          where NP.ROADWAY_POINT_ID in (${roadwayPointIds.mkString(", ")}) and NP.valid_to is null
+          where NP.ROADWAY_POINT_ID in ($roadwayPointIds) and NP.valid_to is null
         """
       logger.debug(s"******* Querying by roadwaypointId.s: ${roadwayPointIds.mkString(", ")} \n    query: : $query")
       queryList(query)
@@ -120,15 +123,15 @@ class NodePointDAO extends BaseDAO {
   }
 
   /** Gets joined NodePoint, Node, RoadwayPoint, and Roadway info where
-    * nodePoint~roadPoint~roadway, and nodePoint~node,
-    * and nodePoint is still eligible (end_date, and valid_to are nulls)
-    * <b>but there is no more corresponding roadway available.</b>*/
+   * nodePoint~roadPoint~roadway, and nodePoint~node,
+   * and nodePoint is still eligible (end_date, and valid_to are nulls)
+   * <b>but there is no more corresponding roadway available.</b>*/
   def fetchRoadwiseOrphansByRoadwayPointIds(roadwayPointIds: Seq[Long]): Seq[NodePoint] = {
     if (roadwayPointIds.isEmpty) {
       Seq()
     } else {
       val query =
-        s"""
+        sql"""
            SELECT NP.ID, NP.BEFORE_AFTER, NP.ROADWAY_POINT_ID, NP.NODE_NUMBER, NP.TYPE,
                   N.START_DATE, N.END_DATE,
                   NP.VALID_FROM, NP.VALID_TO, NP.CREATED_BY, NP.CREATED_TIME,
@@ -138,7 +141,7 @@ class NodePointDAO extends BaseDAO {
            INNER JOIN      ROADWAY_POINT RP ON (RP.ID = ROADWAY_POINT_ID)
            LEFT OUTER JOIN NODE N     ON (N.NODE_NUMBER = np.NODE_NUMBER AND N.VALID_TO IS NULL AND N.END_DATE IS NULL)
            LEFT OUTER JOIN ROADWAY RW ON (RW.ROADWAY_NUMBER = RP.ROADWAY_NUMBER)
-           WHERE           NP.ROADWAY_POINT_ID IN (${roadwayPointIds.mkString(", ")}) AND NP.valid_to is null
+           WHERE           NP.ROADWAY_POINT_ID IN ($roadwayPointIds) AND NP.valid_to is null
                            AND RW.ROADWAY_NUMBER is null
         """
       logger.debug(s"******* Querying Roadwaywise orphan Nodes by roadwaypointId.s: ${roadwayPointIds.mkString(", ")} \n    query: : $query")
@@ -149,7 +152,7 @@ class NodePointDAO extends BaseDAO {
   /** Get the eligible (valid_to is null) NodePoints that have the given roadwayPointId. */
   def fetchByRoadwayPointId(roadwayPointId: Long): Seq[NodePoint] = {
     val query =
-      s"""
+      sql"""
      $selectFromNodePoint
      where NP.ROADWAY_POINT_ID = $roadwayPointId and NP.valid_to is null
    """
@@ -159,7 +162,7 @@ class NodePointDAO extends BaseDAO {
   /** Get the eligible (valid_to is null) NodePoints and NodePoint templates that have the given roadwayNumber. */
   def fetchByRoadwayNumber(roadwayNumber: Long): Seq[NodePoint] = {
     val query =
-      s"""
+      sql"""
          $selectFromNodePoint
          where RP.roadway_number = $roadwayNumber and NP.valid_to is null
        """
@@ -167,14 +170,14 @@ class NodePointDAO extends BaseDAO {
   }
 
   /** Get the eligible (valid_to is null) NodePoints that have a roadway number belonging to
-    * the given roadwayNumbers sequence . */
+   * the given roadwayNumbers sequence . */
   def fetchRoadAddressNodePoints(roadwayNumbers: Seq[Long]): Seq[NodePoint] = {
     if (roadwayNumbers.isEmpty) Seq()
     else {
       val query =
-        s"""
+        sql"""
          $selectFromNodePoint
-         where RP.roadway_number in (${roadwayNumbers.mkString(", ")}) and NP.valid_to is null
+         where RP.roadway_number in ($roadwayNumbers) and NP.valid_to is null
          AND NP.TYPE = ${NodePointType.RoadNodePoint.value}
        """
       queryList(query)
@@ -183,9 +186,11 @@ class NodePointDAO extends BaseDAO {
 
   def fetchTemplatesByRoadwayNumber(roadwayNumber: Long): List[NodePoint] = {
     val query =
-      s"""
-        SELECT NP.ID, NP.BEFORE_AFTER, NP.ROADWAY_POINT_ID, NP.NODE_NUMBER, NP.TYPE, NULL, NULL,
-        NP.VALID_FROM, NP.VALID_TO, NP.CREATED_BY, NP.CREATED_TIME, RP.ROADWAY_NUMBER, RP.ADDR_M, NULL, NULL, NULL, NULL
+      sql"""
+        SELECT  NP.ID, NP.BEFORE_AFTER, NP.ROADWAY_POINT_ID, NP.NODE_NUMBER, NP.TYPE,
+                NULL AS START_DATE, NULL AS END_DATE,
+                NP.VALID_FROM, NP.VALID_TO, NP.CREATED_BY, NP.CREATED_TIME, RP.ROADWAY_NUMBER, RP.ADDR_M,
+                NULL AS ROAD_NUMBER, NULL AS ROAD_PART_NUMBER, NULL AS ElY, NULL AS TRACK
         FROM NODE_POINT NP
         JOIN ROADWAY_POINT RP ON (RP.ID = ROADWAY_POINT_ID)
         JOIN ROADWAY RW ON (RP.ROADWAY_NUMBER = RW.ROADWAY_NUMBER AND RW.end_date is NULL AND RW.VALID_TO IS NULL)
@@ -197,14 +202,14 @@ class NodePointDAO extends BaseDAO {
   def fetchTemplatesByRoadwayNumbers(roadwayNumbers: Set[Long]): List[NodePoint] = {
     val query =
       if (roadwayNumbers.isEmpty) {
-        ""
+        sql""
       } else {
-        s"""SELECT NP.ID, NP.BEFORE_AFTER, NP.ROADWAY_POINT_ID, NP.NODE_NUMBER, NP.TYPE, NULL, NULL,
+        sql"""SELECT NP.ID, NP.BEFORE_AFTER, NP.ROADWAY_POINT_ID, NP.NODE_NUMBER, NP.TYPE, NULL, NULL,
           NP.VALID_FROM, NP.VALID_TO, NP.CREATED_BY, NP.CREATED_TIME, RP.ROADWAY_NUMBER, RP.ADDR_M, RW.ROAD_NUMBER, RW.ROAD_PART_NUMBER, RW.TRACK, rw.ELY
           FROM NODE_POINT NP
           JOIN ROADWAY_POINT RP ON (RP.ID = ROADWAY_POINT_ID)
           JOIN ROADWAY RW ON (RP.ROADWAY_NUMBER = RW.ROADWAY_NUMBER AND RW.end_date is NULL AND RW.VALID_TO IS NULL)
-          where RP.roadway_number in (${roadwayNumbers.mkString(", ")}) and NP.valid_to is null and NP.node_number is null
+          where RP.roadway_number in ($roadwayNumbers) and NP.valid_to is null and NP.node_number is null
        """
       }
     queryList(query)
@@ -212,8 +217,8 @@ class NodePointDAO extends BaseDAO {
 
   def fetchTemplates() : Seq[NodePoint] = {
     val query =
-      s"""
-         SELECT DISTINCT NP.ID, NP.BEFORE_AFTER, NP.ROADWAY_POINT_ID, NULL AS NODE_NUMBER, NP.TYPE, NULL, NULL,
+      sql"""
+         SELECT DISTINCT NP.ID, NP.BEFORE_AFTER, NP.ROADWAY_POINT_ID, NULL AS NODE_NUMBER, NP.TYPE, NULL AS START_DATE, NULL AS END_DATE,
          NP.VALID_FROM, NP.VALID_TO, NP.CREATED_BY, NP.CREATED_TIME, RP.ROADWAY_NUMBER, RP.ADDR_M, RW.ROAD_NUMBER, RW.ROAD_PART_NUMBER, RW.TRACK, rw.ELY
          FROM NODE_POINT NP
          JOIN ROADWAY_POINT RP ON (RP.ID = ROADWAY_POINT_ID)
@@ -226,7 +231,7 @@ class NodePointDAO extends BaseDAO {
 
   def fetchNodePointTemplateById(id: Long): Option[NodePoint] = {
     val query =
-      s"""
+      sql"""
          SELECT DISTINCT NP.ID, NP.BEFORE_AFTER, NP.ROADWAY_POINT_ID, NP.NODE_NUMBER, NP.TYPE, NULL, NULL,
          NP.VALID_FROM, NP.VALID_TO, NP.CREATED_BY, NP.CREATED_TIME, RP.ROADWAY_NUMBER, RP.ADDR_M, RW.ROAD_NUMBER, RW.ROAD_PART_NUMBER, RW.TRACK, rw.ELY
          FROM NODE_POINT NP
@@ -235,7 +240,7 @@ class NodePointDAO extends BaseDAO {
          JOIN ROADWAY RW ON (RP.ROADWAY_NUMBER = RW.ROADWAY_NUMBER AND RW.end_date is NULL AND RW.VALID_TO IS NULL)
          where NP.id = $id AND NP.node_number is null and NP.valid_to is null
        """
-    queryList(query).headOption
+    runSelectSingleOption(query.map(NodePoint.apply))
   }
 
   def fetchTemplatesByBoundingBox(boundingRectangle: BoundingRectangle): Seq[NodePoint] = {
@@ -243,11 +248,11 @@ class NodePointDAO extends BaseDAO {
       val extendedBoundingRectangle = BoundingRectangle(boundingRectangle.leftBottom + boundingRectangle.diagonal.scale(.15),
         boundingRectangle.rightTop - boundingRectangle.diagonal.scale(.15))
 
-      val boundingBoxFilter = PostGISDatabase.boundingBoxFilter(extendedBoundingRectangle, "LL.geometry")
+      val boundingBoxFilter = GeometryDbUtils.boundingBoxFilter(extendedBoundingRectangle, sqls"LL.geometry")
 
       val query =
-        s"""
-          SELECT NP.ID, NP.BEFORE_AFTER, NP.ROADWAY_POINT_ID, NP.NODE_NUMBER, NP.TYPE, NULL, NULL,
+        sql"""
+          SELECT NP.ID, NP.BEFORE_AFTER, NP.ROADWAY_POINT_ID, NP.NODE_NUMBER, NP.TYPE, NULL AS start_date, NULL AS end_date,
             NP.VALID_FROM, NP.VALID_TO, NP.CREATED_BY, NP.CREATED_TIME, RP.ROADWAY_NUMBER, RP.ADDR_M, RW.ROAD_NUMBER, RW.ROAD_PART_NUMBER, RW.TRACK, RW.ELY
           FROM NODE_POINT NP
           JOIN ROADWAY_POINT RP ON (RP.ID = ROADWAY_POINT_ID)
@@ -261,10 +266,6 @@ class NodePointDAO extends BaseDAO {
 
   def create(nodePoints: Iterable[NodePoint]): Seq[Long] = {
 
-    val ps = dynamicSession.prepareStatement(
-      """insert into NODE_POINT (ID, BEFORE_AFTER, ROADWAY_POINT_ID, NODE_NUMBER, TYPE, CREATED_BY)
-      values (?, ?, ?, ?, ?, ?)""".stripMargin)
-
     // Set ids for the node points without one
     val (ready, idLess) = nodePoints.partition(_.id != NewIdValue)
     val newIds = Sequences.fetchNodePointIds(idLess.size)
@@ -272,36 +273,41 @@ class NodePointDAO extends BaseDAO {
       x._1.copy(id = x._2)
     )
 
-    createNodePoints.foreach {
+    val batchParams: Iterable[Seq[Any]] = createNodePoints.map {
       nodePoint =>
-        logger.info(s"Creating NodePoint with id : ${nodePoint.id}  roadwayNumber : ${nodePoint.roadwayNumber} addrM: ${nodePoint.addrM} beforeAfter: ${nodePoint.beforeAfter.value}")
-        ps.setLong(1, nodePoint.id)
-        ps.setLong(2, nodePoint.beforeAfter.value)
-        ps.setLong(3, nodePoint.roadwayPointId)
-        if (nodePoint.nodeNumber.isDefined) {
-          ps.setLong(4, nodePoint.nodeNumber.get)
-        } else {
-          ps.setNull(4, java.sql.Types.INTEGER)
-        }
-        ps.setInt(5, nodePoint.nodePointType.value)
-        ps.setString(6, nodePoint.createdBy)
-        ps.addBatch()
+        Seq(
+          nodePoint.id,
+          nodePoint.beforeAfter.value,
+          nodePoint.roadwayPointId,
+          nodePoint.nodeNumber,
+          nodePoint.nodePointType.value,
+          nodePoint.createdBy
+        )
     }
-    ps.executeBatch()
-    ps.close()
+
+    val query =
+      sql"""
+            INSERT INTO NODE_POINT (ID, BEFORE_AFTER, ROADWAY_POINT_ID, NODE_NUMBER, TYPE, CREATED_BY)
+            VALUES (?, ?, ?, ?, ?, ?)
+      """
+
+
+    runBatchUpdateToDb(query, batchParams.toSeq)
+
+    // Return the ids of the created node points
     createNodePoints.map(_.id).toSeq
   }
 
   /**
-    * Expires node points (set their valid_to to the current system date).
-    *
-    * @param ids : Iterable[Long] - The ids of the node points to expire.
-    * @return
-    */
+   * Expires node points (set their valid_to to the current system date).
+   *
+   * @param ids : Iterable[Long] - The ids of the node points to expire.
+   * @return
+   */
   def expireById(ids: Iterable[Long]): Int = {
     val query =
-      s"""
-        Update NODE_POINT Set valid_to = CURRENT_TIMESTAMP where valid_to IS NULL and id in (${ids.mkString(", ")})
+      sql"""
+        Update NODE_POINT Set valid_to = CURRENT_TIMESTAMP where valid_to IS NULL and id in ($ids)
       """
     if (ids.isEmpty)
       0
@@ -313,7 +319,7 @@ class NodePointDAO extends BaseDAO {
 
   def expireByNodeNumberAndType(nodeNumber: Long, nodePointType: NodePointType): Unit = {
     val query =
-      s"""
+      sql"""
         Update NODE_POINT Set valid_to = CURRENT_TIMESTAMP where valid_to IS NULL AND node_number = $nodeNumber
         AND type = ${nodePointType.value}
       """
@@ -323,24 +329,29 @@ class NodePointDAO extends BaseDAO {
 
   def fetchCalculatedNodePointsForNodeNumber(nodeNumber: Long): Seq[NodePoint] = {
     val query =
-      s"""
-         SELECT NP.ID, NP.BEFORE_AFTER, NP.ROADWAY_POINT_ID, NP.NODE_NUMBER, NP.TYPE, NULL, NULL,
-         NP.VALID_FROM, NP.VALID_TO, NP.CREATED_BY, NP.CREATED_TIME, RP.ROADWAY_NUMBER, RP.ADDR_M, NULL as ROAD_NUMBER, NULL as ROAD_PART_NUMBER, NULL as TRACK, NULL as ELY
-         FROM NODE_POINT NP
-         JOIN ROADWAY_POINT RP ON (RP.ID = ROADWAY_POINT_ID)
-         where NP.valid_to is null and NP.node_number = $nodeNumber
-         AND NP.type = 2
-         ORDER BY NP.ID
-       """
-    Q.queryNA[NodePoint](query).iterator.toSeq
+      sql"""
+       SELECT NP.ID, NP.BEFORE_AFTER, NP.ROADWAY_POINT_ID, NP.NODE_NUMBER, NP.TYPE,
+            NULL AS START_DATE, NULL AS END_DATE,
+            NP.VALID_FROM, NP.VALID_TO, NP.CREATED_BY, NP.CREATED_TIME,
+            RP.ROADWAY_NUMBER, RP.ADDR_M,
+            NULL as ROAD_NUMBER, NULL as ROAD_PART_NUMBER, NULL as TRACK, NULL as ELY
+       FROM NODE_POINT NP
+       JOIN ROADWAY_POINT RP ON (RP.ID = ROADWAY_POINT_ID)
+       where NP.valid_to is null and NP.node_number = $nodeNumber
+       AND NP.type = 2
+       ORDER BY NP.ID
+     """.map(NodePoint.apply)
+
+    runSelectQuery(query)
   }
 
   case class RoadPartInfo(roadPart: RoadPart, roadwayNumber: Long, beforeAfter: Long, roadwayPointId: Long, addrM: Long, track: Long, addrMRange: AddrMRange, roadwayId: Long)
 
   def fetchRoadPartsInfoForNode(nodeNumber: Long): Seq[RoadPartInfo] = {
     val query =
-      s"""
-         SELECT R.ROAD_NUMBER, R.ROADWAY_NUMBER, R.ROAD_PART_NUMBER, JP.BEFORE_AFTER, JP.ROADWAY_POINT_ID, RP.ADDR_M, R.TRACK, R.START_ADDR_M, R.END_ADDR_M, R.ID
+      sql"""
+         SELECT R.ROAD_NUMBER, R.ROADWAY_NUMBER, R.ROAD_PART_NUMBER, JP.BEFORE_AFTER, JP.ROADWAY_POINT_ID, RP.ADDR_M,
+                R.TRACK, R.START_ADDR_M, R.END_ADDR_M, R.ID
          FROM ROADWAY R, ROADWAY_POINT RP, JUNCTION_POINT JP, JUNCTION J
          WHERE J.NODE_NUMBER = $nodeNumber
          AND J.ID = JP.JUNCTION_ID
@@ -353,15 +364,24 @@ class NodePointDAO extends BaseDAO {
          AND (R.ROAD_NUMBER BETWEEN 1 AND 19999 OR R.ROAD_NUMBER BETWEEN 40000 AND 69999)
          ORDER BY R.ROAD_NUMBER, R.ROAD_PART_NUMBER, R.TRACK, R.ROADWAY_NUMBER
        """
-    Q.queryNA[(Long, Long, Long, Long, Long, Long, Long, Long, Long, Long)](query).list.map {
-      case (roadNumber, roadwayNumber, roadPartNumber, beforeAfter, roadwayPointId, addrM, track, startAddrM, endAddrM, roadwayId) =>
-        RoadPartInfo(RoadPart(roadNumber, roadPartNumber), roadwayNumber, beforeAfter, roadwayPointId, addrM, track, AddrMRange(startAddrM, endAddrM), roadwayId)
-    }
+    runSelectQuery(query.map(rs => RoadPartInfo(
+      roadPart = RoadPart(
+        rs.longOpt("road_number").getOrElse(0L),
+        rs.longOpt("road_part_number").getOrElse(0L)
+      ),
+      roadwayNumber = rs.long("roadway_number"),
+      beforeAfter = rs.long("before_after"),
+      roadwayPointId = rs.long("roadway_point_id"),
+      addrM = rs.long("addr_m"),
+      track = rs.long("track"),
+      addrMRange = AddrMRange(rs.long("start_addr_m"), rs.long("end_addr_m")),
+      roadwayId = rs.long("id")
+    )))
   }
 
   def fetchNodePointTemplateByRoadwayPointId(roadwayPointId: Long): Seq[NodePoint] = {
     val query =
-      s"""
+      sql"""
      $selectFromNodePoint
      where NP.ROADWAY_POINT_ID = $roadwayPointId and NP.valid_to is null and NP.node_number is null
    """
@@ -370,7 +390,7 @@ class NodePointDAO extends BaseDAO {
 
   def fetchNodePointsCountForRoadAndRoadPart(roadPart: RoadPart, beforeAfter: Long, nodeNumber: Long): Option[Long] = {
     val query =
-      s"""
+      sql"""
           SELECT count(NP.ID)
           FROM ROADWAY R, ROADWAY_POINT RP, NODE_POINT NP, NODE N
           WHERE R.ROAD_NUMBER = ${roadPart.roadNumber}
@@ -388,40 +408,40 @@ class NodePointDAO extends BaseDAO {
           GROUP BY R.ROAD_PART_NUMBER
           ORDER BY R.ROAD_PART_NUMBER
        """
-    Q.queryNA[Long](query).firstOption
+    runSelectSingleFirstOptionWithType[Long](query)
   }
 
   def fetchAverageAddrM(roadPart: RoadPart, nodeNumber: Long): Long = {
     val query =
-      s"""
-          SELECT AVG(RP.ADDR_M)
-          FROM ROADWAY_POINT RP
-          INNER JOIN ROADWAY R
-            ON (R.ROAD_NUMBER = ${roadPart.roadNumber}
-              AND R.ROAD_PART_NUMBER = ${roadPart.partNumber}
-              AND R.END_DATE IS NULL AND R.VALID_TO IS NULL
-              AND RP.ROADWAY_NUMBER = R.ROADWAY_NUMBER)
-          INNER JOIN JUNCTION_POINT JP
-            ON (JP.ROADWAY_POINT_ID = RP.ID
-              AND JP.VALID_TO IS NULL)
-          INNER JOIN JUNCTION J
-            ON (J.ID = JP.JUNCTION_ID
-              AND J.VALID_TO IS NULL
-              AND J.END_DATE IS NULL)
-          INNER JOIN NODE N
-            ON (J.NODE_NUMBER = N.NODE_NUMBER
-              AND N.END_DATE IS NULL
-              AND N.VALID_TO IS NULL
-              AND N.NODE_NUMBER = $nodeNumber)
-       """
-    Q.queryNA[Long](query).first
+      sql"""
+        SELECT AVG(RP.ADDR_M)
+        FROM ROADWAY_POINT RP
+        INNER JOIN ROADWAY R
+          ON (R.ROAD_NUMBER = ${roadPart.roadNumber}
+            AND R.ROAD_PART_NUMBER = ${roadPart.partNumber}
+            AND R.END_DATE IS NULL AND R.VALID_TO IS NULL
+            AND RP.ROADWAY_NUMBER = R.ROADWAY_NUMBER)
+        INNER JOIN JUNCTION_POINT JP
+          ON (JP.ROADWAY_POINT_ID = RP.ID
+            AND JP.VALID_TO IS NULL)
+        INNER JOIN JUNCTION J
+          ON (J.ID = JP.JUNCTION_ID
+            AND J.VALID_TO IS NULL
+            AND J.END_DATE IS NULL)
+        INNER JOIN NODE N
+          ON (J.NODE_NUMBER = N.NODE_NUMBER
+            AND N.END_DATE IS NULL
+            AND N.VALID_TO IS NULL
+            AND N.NODE_NUMBER = $nodeNumber)
+     """
+    runSelectSingle(query.map(rs => rs.bigDecimal(1).longValue)) // The result for AVG is a BigDecimal
   }
 
   // Only for debugging
   def fetchAddrMForAverage(roadPart: RoadPart): Seq[NodePoint] = {
     val query =
-      s"""
-          SELECT NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+      sql"""
+          SELECT NULL AS ID, NULL, NULL, NULL, NULL, NULL, NULL,
           RP.CREATED_TIME, JP.VALID_TO, RP.CREATED_TIME, RP.CREATED_TIME, RP.ROADWAY_NUMBER, RP.ADDR_M, R.ROAD_NUMBER, R.ROAD_PART_NUMBER, R.TRACK, R.ELY
           FROM ROADWAY_POINT RP
           INNER JOIN ROADWAY R
@@ -439,7 +459,7 @@ class NodePointDAO extends BaseDAO {
              AND J.NODE_NUMBER IS NOT NULL)
           ORDER BY R.ROAD_NUMBER, R.ROAD_PART_NUMBER
        """
-        queryList(query)
+    queryList(query)
   }
 
   def insertRoadNodePoint(roadwayPointId: Long, beforeAfter: BeforeAfter, nodeNumber: Long, username: String): Unit = {
@@ -455,5 +475,4 @@ class NodePointDAO extends BaseDAO {
       username, Some(DateTime.now()), 0L, 11,
       RoadPart(0, 0), null, 8)))
   }
-
 }

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/RoadwayDAO.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/RoadwayDAO.scala
@@ -1,20 +1,18 @@
 package fi.liikennevirasto.viite.dao
 
-import com.github.tototoshi.slick.MySQLJodaSupport._
 import fi.liikennevirasto.digiroad2.util.LogUtils.time
 import fi.liikennevirasto.viite._
 import fi.liikennevirasto.viite.dao.ProjectCalibrationPointDAO.BaseCalibrationPoint
 import fi.liikennevirasto.viite.model.RoadAddressLinkLike
 import fi.liikennevirasto.viite.process.InvalidAddressDataException
-import fi.vaylavirasto.viite.dao.{BaseDAO, Queries, Sequences}
+import fi.vaylavirasto.viite.dao.{BaseDAO, Sequences}
 import fi.vaylavirasto.viite.geometry.{GeometryUtils, Point, Vector3d}
 import fi.vaylavirasto.viite.model.{AddrMRange, AdministrativeClass, CalibrationPointType, Discontinuity, LinkGeomSource, RoadPart, SideCode, Track}
 import fi.vaylavirasto.viite.postgis.MassQuery
 import fi.vaylavirasto.viite.util.DateTimeFormatters.{basicDateFormatter, dateOptTimeFormatter}
 import org.joda.time.DateTime
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
-import slick.jdbc.{GetResult, PositionedResult, StaticQuery => Q}
-import slick.jdbc.StaticQuery.interpolation
+import scalikejdbc._
+import scalikejdbc.jodatime.JodaWrappedResultSet.fromWrappedResultSetToJodaWrappedResultSet
 
 sealed trait CalibrationCode {
   def value: Int
@@ -912,47 +910,72 @@ class RoadwayDAO extends BaseDAO {
   }
 
   def create(roadways: Iterable[Roadway]): Seq[Long] = {
-    val roadwayPS = dynamicSession.prepareStatement(
-      """
-        insert into ROADWAY (id, roadway_number, road_number, road_part_number,
-        TRACK, start_addr_m, end_addr_m, reversed, discontinuity, start_date, end_date, created_by,
-        ADMINISTRATIVE_CLASS, ely, terminated) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      """)
+    val column = Roadway.column
     val (ready, idLess) = roadways.partition(_.id != NewIdValue)
-    val plIds = Sequences.fetchRoadwayIds(idLess.size)
-    val createRoadways = ready ++ idLess.zip(plIds).map(x =>
-      x._1.copy(id = x._2)
-    )
-    createRoadways.foreach { case address =>
-      val roadwayNumber = if (address.roadwayNumber == NewIdValue) {
+    val newIds = Sequences.fetchRoadwayIds(idLess.size)
+    val createRoadways = ready ++ idLess.zip(newIds).map { case (rw, newId) =>
+      rw.copy(id = newId)
+    }
+
+    // Assign roadwayNumber if needed
+    val roadwaysWithNumbers = createRoadways.map { roadway =>
+      val roadwayNumber = if (roadway.roadwayNumber == NewIdValue) {
         Sequences.nextRoadwayNumber
       } else {
-        address.roadwayNumber
+        roadway.roadwayNumber
       }
-      roadwayPS.setLong(1, address.id)
-      roadwayPS.setLong(2, roadwayNumber)
-      roadwayPS.setLong(3, address.roadPart.roadNumber)
-      roadwayPS.setLong(4, address.roadPart.partNumber)
-      roadwayPS.setInt(5, address.track.value)
-      roadwayPS.setLong(6, address.addrMRange.start)
-      roadwayPS.setLong(7, address.addrMRange.end)
-      roadwayPS.setInt(8, if (address.reversed) 1 else 0)
-      roadwayPS.setInt(9, address.discontinuity.value)
-      roadwayPS.setDate(10, new java.sql.Date(address.startDate.getMillis))
-      if (address.endDate.isDefined) {
-        roadwayPS.setDate(11, new java.sql.Date(address.endDate.get.getMillis))
-      } else {
-        roadwayPS.setNull(11, java.sql.Types.DATE)
-      }
-      roadwayPS.setString(12, address.createdBy)
-      roadwayPS.setInt(13, address.administrativeClass.value)
-      roadwayPS.setLong(14, address.ely)
-      roadwayPS.setInt(15, address.terminated.value)
-      roadwayPS.addBatch()
+      roadway.copy(roadwayNumber = roadwayNumber)
     }
-    roadwayPS.executeBatch()
-    roadwayPS.close()
-    createRoadways.map(_.id).toSeq
+
+    // Prepare batch parameters
+    val batchParams: Seq[Seq[Any]] = roadwaysWithNumbers.map { roadway =>
+      Seq(
+        roadway.id,
+        roadway.roadwayNumber,
+        roadway.roadPart.roadNumber,
+        roadway.roadPart.partNumber,
+        roadway.track.value,
+        roadway.addrMRange.start,
+        roadway.addrMRange.end,
+        if (roadway.reversed) 1 else 0,
+        roadway.discontinuity.value,
+        new java.sql.Date(roadway.startDate.getMillis),
+        roadway.endDate.map(date => new java.sql.Date(date.getMillis)).orNull,
+        roadway.createdBy,
+        roadway.administrativeClass.value,
+        roadway.ely,
+        roadway.terminated.value
+      )
+    }.toSeq
+
+    // Construct the SQL insert query
+    val insertQuery = sql"""
+      INSERT INTO ROADWAY (
+        ${column.id},
+        ${column.roadwayNumber},
+        road_number,
+        road_part_number,
+        ${column.track},
+        start_addr_m,
+        end_addr_m,
+        ${column.reversed},
+        ${column.discontinuity},
+        ${column.startDate},
+        ${column.endDate},
+        ${column.createdBy},
+        ${column.administrativeClass},
+        ${column.ely},
+        ${column.terminated}
+      ) VALUES (
+        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+      )
+    """
+
+    // Execute the batch update
+    runBatchUpdateToDb(insertQuery, batchParams)
+
+    // Return the list of IDs
+    roadwaysWithNumbers.map(_.id).toSeq
   }
 
   // TODO Instead of returning Option[(Long, Long, ...)] return Option[RoadPartInfo]

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/RoadwayDAO.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/RoadwayDAO.scala
@@ -917,7 +917,7 @@ class RoadwayDAO extends BaseDAO {
       rw.copy(id = newId)
     }
 
-    // Assign roadwayNumber if needed
+    // Assign new roadway numbers to any roadways that don't have one
     val roadwaysWithNumbers = createRoadways.map { roadway =>
       val roadwayNumber = if (roadway.roadwayNumber == NewIdValue) {
         Sequences.nextRoadwayNumber

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/RoadNameServiceSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/RoadNameServiceSpec.scala
@@ -2,17 +2,18 @@ package fi.liikennevirasto.viite
 
 import fi.vaylavirasto.viite.dao.RoadNameDAO
 import fi.vaylavirasto.viite.postgis.DbUtils.runUpdateToDb
-import fi.vaylavirasto.viite.postgis.PostGISDatabase.runWithRollback
+import fi.vaylavirasto.viite.postgis.PostGISDatabaseScalikeJDBC.runWithRollback
 import org.joda.time.DateTime
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import scalikejdbc.scalikejdbcSQLInterpolationImplicitDef
 
 class RoadNameServiceSpec extends AnyFunSuite with Matchers {
   private val roadNameService = new RoadNameService
 
   test("Test roadNameService.getRoadNamesInTX() When searching for a newly create road name by it's road number Then return the entry for said road name.") {
     runWithRollback {
-      runUpdateToDb("""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME) values ('999','OTAVA-HIRVENSALMI-LEVÄLAHTI',to_date('01.01.1989','DD.MM.YYYY'),to_date('01.01.1996','DD.MM.YYYY'),to_date('17.01.2006','DD.MM.YYYY'),null,'TR',to_timestamp('14.03.2018 14:14:44','DD.MM.YYYY HH24:MI:SS'))""")
+      runUpdateToDb(sql"""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME) values ('999','OTAVA-HIRVENSALMI-LEVÄLAHTI',to_date('01.01.1989','DD.MM.YYYY'),to_date('01.01.1996','DD.MM.YYYY'),to_date('17.01.2006','DD.MM.YYYY'),null,'TR',to_timestamp('14.03.2018 14:14:44','DD.MM.YYYY HH24:MI:SS'))""")
       val search = roadNameService.getRoadNamesInTX(Some("999"), None, None, None)
       search.isRight should be(true)
       search match {
@@ -25,7 +26,7 @@ class RoadNameServiceSpec extends AnyFunSuite with Matchers {
 
   test("Test roadNameService.getRoadNamesInTX() When searching for a newly create road name by it's road number and name Then return the entry for said road name.") {
     runWithRollback {
-      runUpdateToDb("""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME) values ('999','OTAVA-HIRVENSALMI-LEVÄLAHTI',to_date('01.01.1989','DD.MM.YYYY'),to_date('01.01.1996','DD.MM.YYYY'),to_date('17.01.2006','DD.MM.YYYY'),null,'TR',to_timestamp('14.03.2018 14:14:44','DD.MM.YYYY HH24:MI:SS'))""")
+      runUpdateToDb(sql"""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME) values ('999','OTAVA-HIRVENSALMI-LEVÄLAHTI',to_date('01.01.1989','DD.MM.YYYY'),to_date('01.01.1996','DD.MM.YYYY'),to_date('17.01.2006','DD.MM.YYYY'),null,'TR',to_timestamp('14.03.2018 14:14:44','DD.MM.YYYY HH24:MI:SS'))""")
       val search = roadNameService.getRoadNamesInTX(Some("999"), Some("OTAVA-HIRVENSALMI-LEVÄLAHTI"), None, None)
       search.isRight should be(true)
       search match {
@@ -38,7 +39,7 @@ class RoadNameServiceSpec extends AnyFunSuite with Matchers {
 
   test("Test roadNameService.getRoadNamesInTX() When searching for a newly create road name by it's road name Then return the entry for said road name.") {
     runWithRollback {
-      runUpdateToDb("""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME) values ('999','OTAVA-HIRVENSALMI-LEVÄLAHTI',to_date('01.01.1989','DD.MM.YYYY'),to_date('01.01.1996','DD.MM.YYYY'),to_date('17.01.2006','DD.MM.YYYY'),null,'TR',to_timestamp('14.03.2018 14:14:44','DD.MM.YYYY HH24:MI:SS'))""")
+      runUpdateToDb(sql"""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME) values ('999','OTAVA-HIRVENSALMI-LEVÄLAHTI',to_date('01.01.1989','DD.MM.YYYY'),to_date('01.01.1996','DD.MM.YYYY'),to_date('17.01.2006','DD.MM.YYYY'),null,'TR',to_timestamp('14.03.2018 14:14:44','DD.MM.YYYY HH24:MI:SS'))""")
       val search = roadNameService.getRoadNamesInTX(Some("999"), Some("OTAVA-HIRVENSALMI-LEVÄLAHTI"), None, None)
       search.isRight should be(true)
       search match {
@@ -51,7 +52,7 @@ class RoadNameServiceSpec extends AnyFunSuite with Matchers {
 
   test("Test roadNameService.getRoadNamesInTX() When searching for a newly create road name by it's road number, name and date Then return the entry for said road name.") {
     runWithRollback {
-      runUpdateToDb("""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME) values ('999','OTAVA-HIRVENSALMI-LEVÄLAHTI',to_date('01.01.1989','DD.MM.YYYY'),to_date('01.01.1996','DD.MM.YYYY'),to_date('17.01.2006','DD.MM.YYYY'),null,'TR',to_timestamp('14.03.2018 14:14:44','DD.MM.YYYY HH24:MI:SS'))""")
+      runUpdateToDb(sql"""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME) values ('999','OTAVA-HIRVENSALMI-LEVÄLAHTI',to_date('01.01.1989','DD.MM.YYYY'),to_date('01.01.1996','DD.MM.YYYY'),to_date('17.01.2006','DD.MM.YYYY'),null,'TR',to_timestamp('14.03.2018 14:14:44','DD.MM.YYYY HH24:MI:SS'))""")
       val search = roadNameService.getRoadNamesInTX(Some("999"), Some("OTAVA-HIRVENSALMI-LEVÄLAHTI"), Some(DateTime.parse("1988-01-01")), None)
       search.isRight should be(true)
       search match {
@@ -64,7 +65,7 @@ class RoadNameServiceSpec extends AnyFunSuite with Matchers {
 
   test("Test roadNameService.getRoadNamesInTX() When searching for a newly create road name by it's road number, name and a wrong date Then returns none.") {
     runWithRollback {
-      runUpdateToDb("""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME) values ('999','OTAVA-HIRVENSALMI-LEVÄLAHTI',to_date('01.01.1989','DD.MM.YYYY'),to_date('01.01.1996','DD.MM.YYYY'),to_date('17.01.2006','DD.MM.YYYY'),null,'TR',to_timestamp('14.03.2018 14:14:44','DD.MM.YYYY HH24:MI:SS'))""")
+      runUpdateToDb(sql"""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME) values ('999','OTAVA-HIRVENSALMI-LEVÄLAHTI',to_date('01.01.1989','DD.MM.YYYY'),to_date('01.01.1996','DD.MM.YYYY'),to_date('17.01.2006','DD.MM.YYYY'),null,'TR',to_timestamp('14.03.2018 14:14:44','DD.MM.YYYY HH24:MI:SS'))""")
       val search = roadNameService.getRoadNamesInTX(Some("999"), Some("OTAVA-HIRVENSALMI-LEVÄLAHTI"), Some(DateTime.parse("1999-01-01")), None)
       search.isRight should be(true)
       search match {
@@ -77,7 +78,7 @@ class RoadNameServiceSpec extends AnyFunSuite with Matchers {
 
   test("Test roadNameService.getRoadNamesInTX() When searching for a newly create road name by it's road number, name and a wrong end date Then returns none.") {
     runWithRollback {
-      runUpdateToDb("""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME) values ('999','OTAVA-HIRVENSALMI-LEVÄLAHTI',to_date('01.01.1989','DD.MM.YYYY'),to_date('01.01.1996','DD.MM.YYYY'),to_date('17.01.2006','DD.MM.YYYY'),null,'TR',to_timestamp('14.03.2018 14:14:44','DD.MM.YYYY HH24:MI:SS'))""")
+      runUpdateToDb(sql"""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME) values ('999','OTAVA-HIRVENSALMI-LEVÄLAHTI',to_date('01.01.1989','DD.MM.YYYY'),to_date('01.01.1996','DD.MM.YYYY'),to_date('17.01.2006','DD.MM.YYYY'),null,'TR',to_timestamp('14.03.2018 14:14:44','DD.MM.YYYY HH24:MI:SS'))""")
       val search = roadNameService.getRoadNamesInTX(Some("999"), Some("OTAVA-HIRVENSALMI-LEVÄLAHTI"), None, Some(DateTime.parse("1979-01-01")))
       search.isRight should be(true)
       search match {
@@ -90,7 +91,7 @@ class RoadNameServiceSpec extends AnyFunSuite with Matchers {
 
   test("Test roadNameService.getRoadNamesInTX() When searching for a newly create road name by it's road number, name and  end date Then returns the entry for said road name.") {
     runWithRollback {
-      runUpdateToDb("""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME) values ('999','OTAVA-HIRVENSALMI-LEVÄLAHTI',to_date('01.01.1989','DD.MM.YYYY'),to_date('01.01.1996','DD.MM.YYYY'),to_date('17.01.2006','DD.MM.YYYY'),null,'TR',to_timestamp('14.03.2018 14:14:44','DD.MM.YYYY HH24:MI:SS'))""")
+      runUpdateToDb(sql"""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME) values ('999','OTAVA-HIRVENSALMI-LEVÄLAHTI',to_date('01.01.1989','DD.MM.YYYY'),to_date('01.01.1996','DD.MM.YYYY'),to_date('17.01.2006','DD.MM.YYYY'),null,'TR',to_timestamp('14.03.2018 14:14:44','DD.MM.YYYY HH24:MI:SS'))""")
       val search = roadNameService.getRoadNamesInTX(Some("999"), Some("OTAVA-HIRVENSALMI-LEVÄLAHTI"), None, Some(DateTime.parse("1999-01-01")))
       search.isRight should be(true)
       search match {
@@ -111,7 +112,7 @@ class RoadNameServiceSpec extends AnyFunSuite with Matchers {
 
   test("Test roadNameService.getUpdatedRoadNamesInTX() When using a date where there is one new road, without history Then returns the updated road name.") {
     runWithRollback {
-      runUpdateToDb("""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME) values ('999','ROAD ONE',to_date('02.02.3001','DD.MM.YYYY'),null,to_date('01.01.3001','DD.MM.YYYY'),null,'TR',to_timestamp('01.01.3001 14:14:44','DD.MM.YYYY HH24:MI:SS'))""")
+      runUpdateToDb(sql"""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME) values ('999','ROAD ONE',to_date('02.02.3001','DD.MM.YYYY'),null,to_date('01.01.3001','DD.MM.YYYY'),null,'TR',to_timestamp('01.01.3001 14:14:44','DD.MM.YYYY HH24:MI:SS'))""")
       val result = roadNameService.getUpdatedRoadNamesInTX(DateTime.parse("3001-01-01"), None)
       result.isRight should be(true)
       result.right.get.size should be(1)
@@ -120,8 +121,8 @@ class RoadNameServiceSpec extends AnyFunSuite with Matchers {
 
   test("Test roadNameService.getUpdatedRoadNamesInTX() When using a date where there is one new road, without history Then returns both the updated road name and the history one.") {
     runWithRollback {
-      runUpdateToDb("""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME) values ('999','ROAD ONE',to_date('02.02.3001','DD.MM.YYYY'),null,to_date('01.01.3001','DD.MM.YYYY'),null,'TR',to_timestamp('01.01.3001 14:14:44','DD.MM.YYYY HH24:MI:SS'))""")
-      runUpdateToDb("""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME) values ('999','OLD NAME',to_date('02.02.2901','DD.MM.YYYY'),to_date('01.01.3001','DD.MM.YYYY'),to_date('01.01.2901','DD.MM.YYYY'),null,'TR',to_timestamp('01.01.2901 12:00:00','DD.MM.YYYY HH24:MI:SS'))""")
+      runUpdateToDb(sql"""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME) values ('999','ROAD ONE',to_date('02.02.3001','DD.MM.YYYY'),null,to_date('01.01.3001','DD.MM.YYYY'),null,'TR',to_timestamp('01.01.3001 14:14:44','DD.MM.YYYY HH24:MI:SS'))""")
+      runUpdateToDb(sql"""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME) values ('999','OLD NAME',to_date('02.02.2901','DD.MM.YYYY'),to_date('01.01.3001','DD.MM.YYYY'),to_date('01.01.2901','DD.MM.YYYY'),null,'TR',to_timestamp('01.01.2901 12:00:00','DD.MM.YYYY HH24:MI:SS'))""")
       val result = roadNameService.getUpdatedRoadNamesInTX(DateTime.parse("3001-01-01"), None)
       result.isRight should be(true)
       result.right.get.size should be(2)
@@ -131,7 +132,7 @@ class RoadNameServiceSpec extends AnyFunSuite with Matchers {
   test("Test roadNameService.addOrUpdateRoadNamesInTX() and RoadNameDAO.getLatestRoadName() When creating a new road name and setting a end date on the \"current\" one Then returns only the \"current\".") {
     val roadNumber = 99
     runWithRollback {
-      runUpdateToDb(s"""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME)
+      runUpdateToDb(sql"""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME)
             values ($roadNumber, 'VICTORY RD.', to_date('01.01.1989','DD.MM.YYYY'), null, to_date('01.01.1989','DD.MM.YYYY'), null, 'User', to_timestamp('01.01.1989 14:14:44','DD.MM.YYYY HH24:MI:SS'))""")
       val search = RoadNameDAO.getLatestRoadName(roadNumber)
 
@@ -150,7 +151,7 @@ class RoadNameServiceSpec extends AnyFunSuite with Matchers {
   test("Test roadNameService.addOrUpdateRoadNamesInTX() and RoadNameDAO.getLatestRoadName() When updating a name from current one Then said update should expire and create an copy of it, with the new name.") {
     val roadNumber = 99
     runWithRollback {
-      runUpdateToDb(s"""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME)
+      runUpdateToDb(sql"""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME)
             values ($roadNumber, 'VICTORY RD.', to_date('01.01.1989','DD.MM.YYYY'), null, to_date('01.01.1989','DD.MM.YYYY'), null, 'User', to_timestamp('01.01.1989 14:14:44','DD.MM.YYYY HH24:MI:SS'))""")
       val search = RoadNameDAO.getLatestRoadName(roadNumber)
       val roadNames = Seq(
@@ -173,7 +174,7 @@ class RoadNameServiceSpec extends AnyFunSuite with Matchers {
 
   test("Test roadNameService.getUpdatedRoadNamesInTX() When searching in a interval of dates but in said interval there is only one name Then return that road names.") {
     runWithRollback {
-      runUpdateToDb("""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME) values ('999','ROAD ONE',to_date('02.02.3001','DD.MM.YYYY'),null,to_date('01.01.3001','DD.MM.YYYY'),null,'TR',to_timestamp('01.01.3001 14:14:44','DD.MM.YYYY HH24:MI:SS'))""")
+      runUpdateToDb(sql"""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME) values ('999','ROAD ONE',to_date('02.02.3001','DD.MM.YYYY'),null,to_date('01.01.3001','DD.MM.YYYY'),null,'TR',to_timestamp('01.01.3001 14:14:44','DD.MM.YYYY HH24:MI:SS'))""")
       val result = roadNameService.getUpdatedRoadNamesInTX(DateTime.parse("3001-01-01"), Some(DateTime.parse("3001-01-02")))
       result.isRight should be(true)
       result.right.get.size should be(1)
@@ -182,7 +183,7 @@ class RoadNameServiceSpec extends AnyFunSuite with Matchers {
 
   test("Test roadNameService.getUpdatedRoadNamesInTX() When searching in a interval of dates but the existing road name is outside of the interval Then return no road names.") {
     runWithRollback {
-      runUpdateToDb("""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME) values ('999','ROAD ONE',to_date('02.02.3001','DD.MM.YYYY'),null,to_date('01.01.3001','DD.MM.YYYY'),null,'TR',to_timestamp('01.01.3001 14:14:44','DD.MM.YYYY HH24:MI:SS'))""")
+      runUpdateToDb(sql"""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME) values ('999','ROAD ONE',to_date('02.02.3001','DD.MM.YYYY'),null,to_date('01.01.3001','DD.MM.YYYY'),null,'TR',to_timestamp('01.01.3001 14:14:44','DD.MM.YYYY HH24:MI:SS'))""")
       val result = roadNameService.getUpdatedRoadNamesInTX(DateTime.parse("3001-01-01"), Some(DateTime.parse("3001-01-01")))
       result.isRight should be(true)
       result.right.get.size should be(0)
@@ -191,8 +192,8 @@ class RoadNameServiceSpec extends AnyFunSuite with Matchers {
 
   test("Fetch updated road names, one update with history between given dates") {
     runWithRollback {
-      runUpdateToDb("""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME) values ('999','ROAD ONE',to_date('02.02.3001','DD.MM.YYYY'),null,to_date('01.01.3001','DD.MM.YYYY'),null,'TR',to_timestamp('01.01.3001 14:14:44','DD.MM.YYYY HH24:MI:SS'))""")
-      runUpdateToDb("""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME) values ('999','OLD NAME',to_date('02.02.2901','DD.MM.YYYY'),to_date('31.12.3000','DD.MM.YYYY'),to_date('01.01.2901','DD.MM.YYYY'),null,'TR',to_timestamp('01.01.2901 12:00:00','DD.MM.YYYY HH24:MI:SS'))""")
+      runUpdateToDb(sql"""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME) values ('999','ROAD ONE',to_date('02.02.3001','DD.MM.YYYY'),null,to_date('01.01.3001','DD.MM.YYYY'),null,'TR',to_timestamp('01.01.3001 14:14:44','DD.MM.YYYY HH24:MI:SS'))""")
+      runUpdateToDb(sql"""Insert into ROAD_NAME (ROAD_NUMBER,ROAD_NAME,START_DATE,END_DATE,VALID_FROM,VALID_TO,CREATED_BY,CREATED_TIME) values ('999','OLD NAME',to_date('02.02.2901','DD.MM.YYYY'),to_date('31.12.3000','DD.MM.YYYY'),to_date('01.01.2901','DD.MM.YYYY'),null,'TR',to_timestamp('01.01.2901 12:00:00','DD.MM.YYYY HH24:MI:SS'))""")
       val result = roadNameService.getUpdatedRoadNamesInTX(DateTime.parse("3001-01-01"), Some(DateTime.parse("3001-01-02")))
       result.isRight should be(true)
       result.right.get.size should be(2)

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/JunctionDAOSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/JunctionDAOSpec.scala
@@ -4,7 +4,7 @@ import fi.liikennevirasto.viite.NewIdValue
 import fi.vaylavirasto.viite.dao.Sequences
 import fi.vaylavirasto.viite.geometry.Point
 import fi.vaylavirasto.viite.model.{AddrMRange, AdministrativeClass, BeforeAfter, Discontinuity, NodePointType, NodeType, RoadPart, Track}
-import fi.vaylavirasto.viite.postgis.PostGISDatabase.runWithRollback
+import fi.vaylavirasto.viite.postgis.PostGISDatabaseScalikeJDBC.runWithRollback
 import org.joda.time.DateTime
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -120,8 +120,8 @@ class JunctionDAOSpec extends AnyFunSuite with Matchers {
       val roadwayNumber2 = Sequences.nextRoadwayNumber
       roadwayDAO.create(
         Seq(
-          Roadway(roadwayDAO.getNextRoadwayId, roadwayNumber1, roadPart, AdministrativeClass.State, Track.Combined, Discontinuity.EndOfRoad, AddrMRange(  0, 300), reversed = false, DateTime.parse("1992-10-08"), None, "test", Some("TEST ROAD 1"), 8, TerminationCode.NoTermination),
-          Roadway(roadwayDAO.getNextRoadwayId, roadwayNumber2, roadPart, AdministrativeClass.State, Track.Combined, Discontinuity.EndOfRoad, AddrMRange(300, 500), reversed = false, DateTime.parse("2021-01-01"), None, "test", Some("TEST ROAD 1"), 8, TerminationCode.NoTermination)
+          Roadway(Sequences.nextRoadwayId, roadwayNumber1, roadPart, AdministrativeClass.State, Track.Combined, Discontinuity.EndOfRoad, AddrMRange(  0, 300), reversed = false, DateTime.parse("1992-10-08"), None, "test", Some("TEST ROAD 1"), 8, TerminationCode.NoTermination),
+          Roadway(Sequences.nextRoadwayId, roadwayNumber2, roadPart, AdministrativeClass.State, Track.Combined, Discontinuity.EndOfRoad, AddrMRange(300, 500), reversed = false, DateTime.parse("2021-01-01"), None, "test", Some("TEST ROAD 1"), 8, TerminationCode.NoTermination)
 
         )
       )

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/JunctionPointDAOSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/JunctionPointDAOSpec.scala
@@ -3,7 +3,7 @@ package fi.liikennevirasto.viite.dao
 import fi.liikennevirasto.viite.NewIdValue
 import fi.vaylavirasto.viite.dao.Sequences
 import fi.vaylavirasto.viite.model.{AddrMRange, AdministrativeClass, BeforeAfter, Discontinuity, RoadPart, Track}
-import fi.vaylavirasto.viite.postgis.PostGISDatabase.runWithRollback
+import fi.vaylavirasto.viite.postgis.PostGISDatabaseScalikeJDBC.runWithRollback
 import org.joda.time.DateTime
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/NodePointDAOSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/NodePointDAOSpec.scala
@@ -8,7 +8,7 @@ import fi.liikennevirasto.viite.dao.TerminationCode.NoTermination
 import fi.vaylavirasto.viite.dao.Sequences
 import fi.vaylavirasto.viite.geometry.{BoundingRectangle, Point}
 import fi.vaylavirasto.viite.model.{AddrMRange, AdministrativeClass, BeforeAfter, Discontinuity, LinkGeomSource, NodePointType, NodeType, RoadPart, SideCode, Track}
-import fi.vaylavirasto.viite.postgis.PostGISDatabase.runWithRollback
+import fi.vaylavirasto.viite.postgis.PostGISDatabaseScalikeJDBC.runWithRollback
 
 class NodePointDAOSpec extends AnyFunSuite with Matchers {
 

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/RoadNameDAOSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/RoadNameDAOSpec.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.viite.dao
 
 import fi.vaylavirasto.viite.dao.{RoadName, RoadNameDAO, RoadNameForRoadAddressBrowser, Sequences}
 import fi.vaylavirasto.viite.model.{AddrMRange, AdministrativeClass, Discontinuity, RoadPart, Track}
-import fi.vaylavirasto.viite.postgis.PostGISDatabase.runWithRollback
+import fi.vaylavirasto.viite.postgis.PostGISDatabaseScalikeJDBC.runWithRollback
 import org.joda.time.DateTime
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers


### PR DESCRIPTION
Modified following files to use ScalikeJDBC:
- roadNameDAO
- RoadNameDAOSpec
- RoadNameService
- RoadNameServiceSpec
- JunctionDAO 
- JunctionDAOSpec 
- JunctionPointDAO  
- JunctionPointDAOSpec  
- NodeDAO 
- NodeDAOSpec 
- NodePointDAO  
- NodePointDAOSpec 
- NodesAndJunctionsService
- NodesAndJunctionsServiceSpec

withDynTransactionNewOrExisting in NodesAndJunctionsService is not needed with ScalikeJDBC because it handles nested transactions in the same way with the build in transaction method