### PR TITLE
Viite 3094/viite 3215 migrate remaning files in database module

### DIFF
--- a/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/PingApi.scala
+++ b/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/PingApi.scala
@@ -1,7 +1,7 @@
 package fi.liikennevirasto.digiroad2
 
 import fi.vaylavirasto.viite.dao.PingDAO
-import fi.vaylavirasto.viite.postgis.PostGISDatabase
+import fi.vaylavirasto.viite.postgis.PostGISDatabaseScalikeJDBC
 import org.scalatra.{InternalServerError, Ok, ScalatraServlet}
 import org.slf4j.LoggerFactory
 
@@ -9,7 +9,7 @@ class PingApi extends ScalatraServlet {
   private val logger = LoggerFactory.getLogger(getClass)
 
   get("/") {
-    PostGISDatabase.withDynSession {
+    PostGISDatabaseScalikeJDBC.runWithReadOnlyImplicitSession { implicit session =>
       try {
         val dbTime = PingDAO.getDbTime
         Ok(s"OK (DB Time: $dbTime)\n")

--- a/viite-backend/api/src/test/scala/fi/liikennevirasto/digiroad2/PingApiSpec.scala
+++ b/viite-backend/api/src/test/scala/fi/liikennevirasto/digiroad2/PingApiSpec.scala
@@ -12,4 +12,12 @@ class PingApiSpec extends AnyFunSuite with ScalatraSuite {
       response.status should be (200)
     }
   }
+
+  test("Ping API should return OK and database time in correct format") {
+    get("/ping") {
+      body should include("OK")
+      body should include("DB Time:")
+      body should fullyMatch regex """OK \(DB Time: \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\)\n"""
+    }
+  }
 }

--- a/viite-backend/database/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
+++ b/viite-backend/database/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
@@ -5,19 +5,13 @@ import fi.liikennevirasto.digiroad2.DigiroadEventBus
 import fi.liikennevirasto.digiroad2.client.kgv._
 import fi.liikennevirasto.digiroad2.util.KGVSerializer
 import fi.vaylavirasto.viite.geometry.{BoundingRectangle, GeometryUtils, Point}
-import fi.vaylavirasto.viite.model.{AdministrativeClass, RoadLink}
-import fi.vaylavirasto.viite.postgis.PostGISDatabase
-import org.joda.time.DateTime
+import fi.vaylavirasto.viite.model.RoadLink
 import org.slf4j.{Logger, LoggerFactory}
-import slick.jdbc.{GetResult, PositionedResult}
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
 
-case class IncompleteLink(linkId: Long, municipalityCode: Int, administrativeClass: AdministrativeClass)
-case class RoadLinkChangeSet(adjustedRoadLinks: Seq[RoadLink], incompleteLinks: Seq[IncompleteLink])
-case class ChangedRoadLinkFetched(link: RoadLink, value: String, createdAt: Option[DateTime], changeType: String /*TODO create and use ChangeType case object*/)
 
 //TODO delete all the references to frozen interface
 /**
@@ -30,16 +24,6 @@ case class ChangedRoadLinkFetched(link: RoadLink, value: String, createdAt: Opti
   */
 class RoadLinkService(val kgvClient: KgvRoadLink, val eventbus: DigiroadEventBus, val kgvSerializer: KGVSerializer, val useFrozenLinkInterface: Boolean) {
   val logger: Logger = LoggerFactory.getLogger(getClass)
-
-  def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
-
-  def withDynSession[T](f: => T): T = PostGISDatabase.withDynSession(f)
-
-  implicit val getDateTime = new GetResult[DateTime] {
-    def apply(r: PositionedResult): DateTime = {
-      new DateTime(r.nextTimestamp())
-    }
-  }
 
   def getRoadLinksAndComplementary(linkIds: Set[String]): Seq[RoadLink] = {
     fetchRoadLinkAndComplementaryData(linkIds)
@@ -85,8 +69,6 @@ class RoadLinkService(val kgvClient: KgvRoadLink, val eventbus: DigiroadEventBus
       Option(GeometryUtils.midPointGeometry(RoadLink.geometry))
     }
   }
-
-  def getRoadLinkByLinkId(linkId: String): Option[RoadLink] = getRoadLinksByLinkIds(Set(linkId)).headOption
 
   def getRoadLinksByLinkIds(linkIds: Set[String]): Seq[RoadLink] = {
     getRoadLinks(linkIds)
@@ -169,11 +151,6 @@ class RoadLinkService(val kgvClient: KgvRoadLink, val eventbus: DigiroadEventBus
     (links, changes, complementaryLinks)
   }
 
-  def getRoadLinksAndChangesFromVVH(municipality: Int): (Seq[RoadLink], Seq[ChangeInfo]) = {
-    val (roadLinks, changes, _) = reloadRoadLinksWithComplementaryAndChangesFromVVH(municipality)
-    (roadLinks, changes)
-  }
-
   def getRoadLinksWithComplementaryAndChangesFromVVH(municipality: Int): (Seq[RoadLink], Seq[ChangeInfo]) = {
     val (roadLinks, changes, complementaries) = reloadRoadLinksWithComplementaryAndChangesFromVVH(municipality)
     (roadLinks ++ complementaries, changes)
@@ -181,32 +158,6 @@ class RoadLinkService(val kgvClient: KgvRoadLink, val eventbus: DigiroadEventBus
 
   def getRoadLinksHistoryFromVVH(roadAddressesLinkIds: Set[String]): Seq[HistoryRoadLink] = {
       Nil
-  }
-
-  def getCurrentAndHistoryRoadLinks(linkIds: Set[String]): (Seq[RoadLink], Seq[HistoryRoadLink]) = {
-    val fut = for {
-      f2Result <- if (useFrozenLinkInterface) kgvClient.frozenTimeRoadLinkData.fetchByLinkIdsF(linkIds) else {
-        kgvClient.roadLinkData.fetchByLinkIdsF(linkIds)
-      }
-      f3Result <- kgvClient.complementaryData.fetchByLinkIdsF(linkIds)
-    } yield (f2Result, f3Result)
-
-    val (currentData, complementaryData) = Await.result(fut, Duration.Inf)
-    val uniqueHistoryData = Seq[HistoryRoadLink]()
-
-    (currentData ++ complementaryData, uniqueHistoryData)
-  }
-
-  def getAllRoadLinks(linkIds: Set[String]): (Seq[RoadLink], Seq[HistoryRoadLink]) = {
-    val fut = for {
-      f2Result <- kgvClient.roadLinkData.fetchByLinkIdsF(linkIds)
-      f3Result <- kgvClient.complementaryData.fetchByLinkIdsF(linkIds)
-    } yield (f2Result, f3Result)
-
-    val (currentData, complementaryData) = Await.result(fut, Duration.Inf)
-    val uniqueHistoryData = Seq[HistoryRoadLink]()
-
-    (currentData ++ complementaryData, uniqueHistoryData)
   }
 
   def getAllVisibleRoadLinks(linkIds: Set[String]): Seq[RoadLink] = {
@@ -257,10 +208,6 @@ class RoadLinkService(val kgvClient: KgvRoadLink, val eventbus: DigiroadEventBus
     } else kgvClient.roadLinkData.fetchByMunicipality(municipality)
   }
 
-  def getChangeInfoFromVVHF(bounds: BoundingRectangle, municipalities: Set[Int]): Future[Seq[ChangeInfo]] = {
-    Future(Seq()) //vvhClient.roadLinkChangeInfo.fetchByBoundsAndMunicipalitiesF(bounds, municipalities) VIITE-2789
-  }
-
   def getChangeInfoFromVVHF(linkIds: Set[String]): Future[Seq[ChangeInfo]] = {
     Future(Seq()) //vvhClient.roadLinkChangeInfo.fetchByLinkIdsF(linkIds) VIITE-2789
   }
@@ -274,11 +221,6 @@ class RoadLinkService(val kgvClient: KgvRoadLink, val eventbus: DigiroadEventBus
     val currentF       = if (useFrozenLinkInterface) kgvClient.frozenTimeRoadLinkData.fetchByMunicipalityAndRoadNumbersF(municipality, roadNumbers) else kgvClient.roadLinkData.fetchByMunicipalityAndRoadNumbersF(municipality, roadNumbers)
     val (compLinks, roadLink) = Await.result(complementaryF.zip(currentF), atMost = Duration.create(1, TimeUnit.HOURS))
     compLinks ++ roadLink
-  }
-
-  def getCurrentAndComplementaryRoadLinkFetcheds(linkIds: Set[String]): Seq[RoadLink] = {
-    val roadLinks = if (useFrozenLinkInterface) kgvClient.frozenTimeRoadLinkData.fetchByLinkIds(linkIds) else kgvClient.roadLinkData.fetchByLinkIds(linkIds)
-    kgvClient.complementaryData.fetchByLinkIds(linkIds) ++ roadLinks
   }
 
   def getCurrentAndComplementaryRoadLinks(linkIds: Set[String]): Seq[RoadLink] = {

--- a/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/dao/BaseDAO.scala
+++ b/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/dao/BaseDAO.scala
@@ -4,6 +4,7 @@ import scalikejdbc._
 import org.slf4j.{Logger, LoggerFactory}
 import fi.vaylavirasto.viite.postgis.SessionProvider.session
 import fi.vaylavirasto.viite.util.ViiteException
+import java.sql.Date
 
 // Methods to run queries using ScalikeJDBC and session provider
 trait BaseDAO {
@@ -39,6 +40,18 @@ trait BaseDAO {
    */
   def runSelectQuery[A](query: SQL[A, HasExtractor]): List[A] = {
     query.list().apply()
+  }
+
+  /**
+   * Executes a SELECT query and returns the first result.
+   * Example use: runSelectFirst(query.map(rs => rs.A("column_name")))
+   *
+   * @param query SQL query with result type A
+   * @tparam A Type to map the result to
+   * @return The first result as an A Type Option
+   */
+  def runSelectFirst[A](query: SQL[A, HasExtractor]): Option[A] = {
+      query.first().apply()
   }
 
   /**
@@ -121,6 +134,7 @@ trait BaseDAO {
   implicit val longMapper: WrappedResultSet => Long = _.long(1)
   implicit val stringMapper: WrappedResultSet => String = _.string(1)
   implicit val intMapper: WrappedResultSet => Int = _.int(1)
+  implicit val dateTimeMapper: WrappedResultSet => Date = _.date(1)
   // Add more implicit mappers as needed
 
 }

--- a/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/dao/MunicipalityDAO.scala
+++ b/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/dao/MunicipalityDAO.scala
@@ -1,35 +1,62 @@
 package fi.vaylavirasto.viite.dao
 
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
-import slick.jdbc.{StaticQuery => Q}
-import slick.jdbc.StaticQuery.interpolation
-
+import fi.vaylavirasto.viite.postgis.SessionProvider.session
+import scalikejdbc._
 /**
   * Created by venholat on 27.10.2016.
   */
-object MunicipalityDAO {
+object MunicipalityDAO extends BaseDAO {
 
   /** Digiroad's municipality to ELY code mapping.
    * Database ely_nro field naming is from the era when Viite was still part of the Digiroad codebase.
    * For Viite ELY codes, see @getViiteMunicipalityToElyMapping
    * @TODO What if this could be removed? Used only in the Fixture reset, and test spec code. */
-  def getDigiroadMunicipalityToElyMapping = {
-    Q.queryNA[(Long, Long)]("""SELECT id, ely_nro FROM MUNICIPALITY ORDER BY ely_nro ASC""").list.map(x => x._1 -> x._2).toMap
+  def getDigiroadMunicipalityToElyMapping: Map[Long, Long] = {
+    sql"""
+      SELECT id, ely_nro
+      FROM municipality
+      ORDER BY ely_nro ASC
+    """
+      .map(rs => rs.long("id") -> rs.long("ely_nro"))
+      .list()
+      .apply()
+      .toMap
   }
 
 /** Viite municipality to ELY code mapping.
  * Viite ELY codes for each municipality are persisted in the ROAD_MAINTAINER column in the DB.*/
-  def getViiteMunicipalityToElyMapping = {
-    Q.queryNA[(Long, Long)]("""SELECT id, ROAD_MAINTAINER_ID FROM MUNICIPALITY""").list.map(x => x._1 -> x._2).toMap
+  def getViiteMunicipalityToElyMapping: Map[Long, Long] = {
+    sql"""
+      SELECT id, road_maintainer_id
+      FROM municipality
+    """
+      .map(rs => rs.long("id") -> rs.long("ROAD_MAINTAINER_ID"))
+      .list()
+      .apply()
+      .toMap
   }
 
   /** Municipality to municipality name mapping */
-  def getMunicipalityNames = {
-    Q.queryNA[(Long, String)]("""SELECT ID, NAME_FI FROM MUNICIPALITY""").list.map(x => x._1 -> x._2).toMap
-  }
+  def getMunicipalityNames: Map[Long, String] = {
+    sql"""
+      SELECT id, name_fi
+      FROM municipality
+    """
+      .map(rs => rs.long("ID") -> rs.string("NAME_FI"))
+      .list()
+      .apply()
+      .toMap  }
 
 /** Get the municipality id corresponding to the given <i>municipalityName</i>. */
   def getMunicipalityIdByName(municipalityName: String): Map[Long, String] = {
-    sql"""SELECT ID, NAME_FI FROM MUNICIPALITY WHERE LOWER(name_fi) = LOWER($municipalityName)""".as[(Long, String)].toMap
+    sql"""
+      SELECT id, name_fi
+      FROM municipality
+      WHERE LOWER(name_fi) = LOWER($municipalityName)
+    """
+      .map(rs => rs.long("ID") -> rs.string("NAME_FI"))
+      .list()
+      .apply()
+      .toMap
   }
 }

--- a/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/dao/PingDAO.scala
+++ b/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/dao/PingDAO.scala
@@ -1,19 +1,18 @@
 package fi.vaylavirasto.viite.dao
 
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
-import slick.jdbc.{GetResult, PositionedResult, StaticQuery => Q}
+import scalikejdbc._
 
-object PingDAO {
+object PingDAO extends BaseDAO {
 
-  private implicit val getDbTimeRow: GetResult[String] = new GetResult[String] {
-    def apply(r: PositionedResult) = {
-      r.nextString()
-    }
+  // Get the current time from the database
+  // Example how to use ScalikeCDBC on basic level without helper methods
+  def getDbTime(implicit session: DBSession): String = {
+    sql"""SELECT TO_CHAR(NOW(), 'YYYY-MM-DD HH24:MI:SS')"""
+      .map(rs => rs.string(1)) // Get the first column as a string
+      .single() // single returns the 1 row as an Option
+      .apply() // Execute the query
+      .getOrElse( // Throw an exception if the result is None
+        throw new RuntimeException("Failed to get the current time from the database")
+      )
   }
-
-  def getDbTime: String = {
-    val query = "SELECT TO_CHAR(NOW(), 'YYYY-MM-DD HH24:MI:SS')"
-    Q.queryNA[String](query).iterator.toSeq.head
-  }
-
 }

--- a/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/dao/PostGISUserProvider.scala
+++ b/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/dao/PostGISUserProvider.scala
@@ -40,7 +40,7 @@ class PostGISUserProvider extends BaseDAO with UserProvider {
              FROM service_user
              WHERE lower(username) = ${username.toLowerCase}
              """
-      runSelectSingle(query.map(User.apply))
+      runSelectSingleOption(query.map(User.apply))
     }
   }
 

--- a/viite-backend/database/src/test/scala/fi/vaylavirasto/viite/dao/MunicipalityDaoSpec.scala
+++ b/viite-backend/database/src/test/scala/fi/vaylavirasto/viite/dao/MunicipalityDaoSpec.scala
@@ -2,7 +2,7 @@ package fi.vaylavirasto.viite.dao
 
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import fi.vaylavirasto.viite.postgis.PostGISDatabase.runWithRollback
+import fi.vaylavirasto.viite.postgis.PostGISDatabaseScalikeJDBC.runWithRollback
 
 
 /**

--- a/viite-backend/database/src/test/scala/fi/vaylavirasto/viite/dao/PostGISUserProviderSpec.scala
+++ b/viite-backend/database/src/test/scala/fi/vaylavirasto/viite/dao/PostGISUserProviderSpec.scala
@@ -2,10 +2,10 @@ package fi.vaylavirasto.viite.dao
 
 import fi.liikennevirasto.digiroad2.user.Configuration
 import fi.vaylavirasto.viite.postgis.DbUtils.runUpdateToDb
-import fi.vaylavirasto.viite.postgis.PostGISDatabase
-import fi.vaylavirasto.viite.postgis.PostGISDatabase.runWithRollback
+import fi.vaylavirasto.viite.postgis.PostGISDatabaseScalikeJDBC.{runWithAutoCommit, runWithRollback, runWithTransaction}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import scalikejdbc.scalikejdbcSQLInterpolationImplicitDef
 
 class PostGISUserProviderSpec extends AnyFunSuite with Matchers {
 
@@ -18,8 +18,13 @@ class PostGISUserProviderSpec extends AnyFunSuite with Matchers {
     "When trying to find a specific user name and creating a user for that user name " +
     "Then getUser() should return 'None' before creating, and the created user after creating it.") {
     runWithRollback {
-      PostGISDatabase.withDynSession {
-        runUpdateToDb(s"""DELETE FROM service_user WHERE username = '${TestUserName.toLowerCase()}'""")
+      runWithAutoCommit {
+        runUpdateToDb(
+          sql"""
+               DELETE FROM service_user
+               WHERE username = ${TestUserName.toLowerCase()}
+               """
+        )
       }
       provider.getUser(TestUserName) shouldBe None
       provider.createUser(TestUserName, Configuration(north = Some(1000)))

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/ProjectLinkDAO.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/ProjectLinkDAO.scala
@@ -268,14 +268,16 @@ class ProjectLinkDAO extends BaseDAO {
     def apply(rs: WrappedResultSet): ProjectLink = {
       // Calculate length of road address to avoid multiple calls to the database
       val roadAddressStartAddrM = rs.longOpt("ra_start_addr_m")
-      val roadAddressEndAddrM = rs.longOpt("ra_end_addr_m")
+      val roadAddressEndAddrM   = rs.longOpt("ra_end_addr_m")
       val roadAddressLength = roadAddressEndAddrM.map { endAddr =>
         endAddr - roadAddressStartAddrM.getOrElse(0L)
       }
 
       new ProjectLink(
         id            = rs.long("id"),
-        roadPart      = RoadPart(rs.long("road_number"), rs.long("road_part_number")),
+        roadPart      = RoadPart(
+          roadNumber  = rs.long("road_number"),
+          partNumber  = rs.long("road_part_number")),
         track         = Track(rs.int("track")),
         discontinuity = Discontinuity(rs.int("discontinuity_type")),
         addrMRange    = AddrMRange(
@@ -321,12 +323,12 @@ class ProjectLinkDAO extends BaseDAO {
           else
             projectRoadwayNumber
         },
-        roadName          = rs.stringOpt("road_name_pl"),
-        roadAddressLength = roadAddressLength,
+        roadName              = rs.stringOpt("road_name_pl"),
+        roadAddressLength     = roadAddressLength,
         roadAddressStartAddrM = roadAddressStartAddrM,
-        roadAddressEndAddrM = roadAddressEndAddrM,
-        roadAddressTrack = rs.intOpt("track").map(Track.apply),
-        roadAddressRoadPart = (rs.longOpt("ra_road_number"), rs.longOpt("ra_road_part_number")) match {
+        roadAddressEndAddrM   = roadAddressEndAddrM,
+        roadAddressTrack      = rs.intOpt("track").map(Track.apply),
+        roadAddressRoadPart   = (rs.longOpt("ra_road_number"), rs.longOpt("ra_road_part_number")) match {
           case (Some(roadNumber), Some(roadPartNumber)) => Some(RoadPart(roadNumber, roadPartNumber))
           case _ => None
         }

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/ProjectLinkDAO.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/ProjectLinkDAO.scala
@@ -200,7 +200,7 @@ class ProjectLinkDAO extends BaseDAO {
   project_link.roadway_number roadway_number
   from project prj JOIN project_link ON (prj.id = project_link.project_id)
     LEFT JOIN roadway on (roadway.id = project_link.roadway_id)
-    LEFT JOIN Linear_Location ON (Linear_Location.id = project_link.Linear_Location_Id)
+    LEFT JOIN linear_location ON (linear_location.id = project_link.linear_location_id)
     LEFT JOIN road_name rn ON (rn.road_number = project_link.road_number AND rn.end_date IS NULL AND rn.valid_to IS null)
 	  LEFT JOIN project_link_name pln ON (pln.road_number = project_link.road_number AND pln.project_id = project_link.project_id)
 	  """
@@ -257,7 +257,7 @@ class ProjectLinkDAO extends BaseDAO {
           plh.roadway_number AS roadway_number
           FROM project prj JOIN project_link_history plh ON (prj.id = plh.project_id)
             LEFT JOIN roadway ON (roadway.id = plh.roadway_id)
-            LEFT JOIN Linear_Location ON (Linear_Location.id = plh.Linear_Location_Id)
+            LEFT JOIN linear_location ON (linear_location.id = plh.linear_location_id)
             LEFT JOIN road_name rn ON (rn.road_number = plh.road_number AND rn.end_date IS NULL AND rn.valid_to IS null)
         	  LEFT JOIN project_link_name pln ON (pln.road_number = plh.road_number AND pln.project_id = plh.project_id)
      """
@@ -356,7 +356,7 @@ class ProjectLinkDAO extends BaseDAO {
             project_link.roadway_number AS project_roadway_number
           FROM project prj JOIN project_link ON (prj.id = project_link.project_id)
           LEFT JOIN roadway ON (roadway.id = project_link.roadway_id)
-          LEFT JOIN Linear_Location ON (Linear_Location.id = project_link.linear_location_id)
+          LEFT JOIN linear_location ON (linear_location.id = project_link.linear_location_id)
       """
 
   object ProjectRoadLinkChange extends SQLSyntaxSupport [ProjectRoadLinkChange]{
@@ -1076,11 +1076,13 @@ class ProjectLinkDAO extends BaseDAO {
           WHERE project_link.road_part_number=${roadPart.partNumber}
           AND project_link.road_number=${roadPart.roadNumber}
           AND project_link.start_addr_m = (SELECT MIN(project_link.start_addr_m) FROM project_link
-          LEFT JOIN
-          roadway ON ((roadway.road_number = project_link.road_number AND roadway.road_part_number = project_link.road_part_number) OR roadway.id = project_link.roadway_id)
-          LEFT JOIN
-          Linear_Location ON (Linear_Location.id = Project_Link.Linear_Location_Id)
-          WHERE project_link.project_id = $projectId AND ((project_link.road_part_number=${roadPart.partNumber} AND project_link.road_number=${roadPart.roadNumber}) OR project_link.roadway_id = roadway.id))
+          LEFT JOIN roadway ON (
+            (roadway.road_number = project_link.road_number AND roadway.road_part_number = project_link.road_part_number)
+            OR roadway.id = project_link.roadway_id)
+          LEFT JOIN linear_location ON (linear_location.id = project_link.linear_location_id)
+          WHERE project_link.project_id = $projectId
+          AND ((project_link.road_part_number=${roadPart.partNumber}
+          AND project_link.road_number=${roadPart.roadNumber}) OR project_link.roadway_id = roadway.id))
           ORDER BY project_link.road_number, project_link.road_part_number, project_link.start_addr_m, project_link.track
           """
     listQuery(query).headOption

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/ProjectLinkDAO.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/ProjectLinkDAO.scala
@@ -182,10 +182,10 @@ class ProjectLinkDAO extends BaseDAO {
     project_link.ely, project_link.reversed,
     project_link.connected_link_id,
   CASE
-    WHEN status = ${RoadAddressChangeType.NotHandled.value} THEN null
+    WHEN status = ${RoadAddressChangeType.NotHandled.value} THEN NULL
     WHEN status IN (${RoadAddressChangeType.Termination.value}, ${RoadAddressChangeType.Unchanged.value}) THEN roadway.START_DATE
     ELSE prj.start_date END AS start_date,
-  CASE WHEN status = ${RoadAddressChangeType.Termination.value} THEN prj.start_date - 1 ELSE null END as end_date,
+  CASE WHEN status = ${RoadAddressChangeType.Termination.value} THEN prj.start_date - 1 ELSE NULL END as end_date,
   project_link.ADJUSTED_TIMESTAMP,
   CASE
     WHEN rn.road_name IS NOT NULL AND rn.end_date IS NULL AND rn.valid_to IS NULL THEN rn.road_name
@@ -201,7 +201,7 @@ class ProjectLinkDAO extends BaseDAO {
   from project prj JOIN project_link ON (prj.id = project_link.project_id)
     LEFT JOIN roadway on (roadway.id = project_link.roadway_id)
     LEFT JOIN linear_location ON (linear_location.id = project_link.linear_location_id)
-    LEFT JOIN road_name rn ON (rn.road_number = project_link.road_number AND rn.end_date IS NULL AND rn.valid_to IS null)
+    LEFT JOIN road_name rn ON (rn.road_number = project_link.road_number AND rn.end_date IS NULL AND rn.valid_to IS NULL)
 	  LEFT JOIN project_link_name pln ON (pln.road_number = project_link.road_number AND pln.project_id = project_link.project_id)
 	  """
 
@@ -239,10 +239,10 @@ class ProjectLinkDAO extends BaseDAO {
           plh.reversed,
           plh.connected_link_id,
           CASE
-            WHEN status = ${RoadAddressChangeType.NotHandled.value} THEN null
+            WHEN status = ${RoadAddressChangeType.NotHandled.value} THEN NULL
             WHEN status IN (${RoadAddressChangeType.Termination.value}, ${RoadAddressChangeType.Unchanged.value}) THEN roadway.START_DATE
             ELSE prj.start_date END as start_date,
-          CASE WHEN status = ${RoadAddressChangeType.Termination.value} THEN prj.start_date - 1 ELSE null END as end_date,
+          CASE WHEN status = ${RoadAddressChangeType.Termination.value} THEN prj.start_date - 1 ELSE NULL END as end_date,
           plh.adjusted_timestamp,
           CASE
             WHEN rn.road_name IS NOT NULL AND rn.end_date IS NULL AND rn.valid_to IS NULL THEN rn.road_name
@@ -258,7 +258,7 @@ class ProjectLinkDAO extends BaseDAO {
           FROM project prj JOIN project_link_history plh ON (prj.id = plh.project_id)
             LEFT JOIN roadway ON (roadway.id = plh.roadway_id)
             LEFT JOIN linear_location ON (linear_location.id = plh.linear_location_id)
-            LEFT JOIN road_name rn ON (rn.road_number = plh.road_number AND rn.end_date IS NULL AND rn.valid_to IS null)
+            LEFT JOIN road_name rn ON (rn.road_number = plh.road_number AND rn.end_date IS NULL AND rn.valid_to IS NULL)
         	  LEFT JOIN project_link_name pln ON (pln.road_number = plh.road_number AND pln.project_id = plh.project_id)
      """
 

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/ProjectLinkDAO.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/ProjectLinkDAO.scala
@@ -1,6 +1,6 @@
 package fi.liikennevirasto.viite.dao
 
-import java.sql.{SQLException, Types}
+import java.sql.SQLException
 import java.util.Date
 import fi.liikennevirasto.digiroad2.util.LogUtils.time
 import fi.liikennevirasto.viite._
@@ -9,11 +9,10 @@ import fi.liikennevirasto.viite.util.CalibrationPointsUtils
 import fi.vaylavirasto.viite.dao.{BaseDAO, Sequences}
 import fi.vaylavirasto.viite.geometry.{GeometryUtils, Point, PolyLine, Vector3d}
 import fi.vaylavirasto.viite.model.{AddrMRange, AdministrativeClass, CalibrationPointType, Discontinuity, LinkGeomSource, RoadAddressChangeType, RoadPart, SideCode, Track}
-import fi.vaylavirasto.viite.postgis.PostGISDatabase
+import fi.vaylavirasto.viite.postgis.GeometryDbUtils
 import org.joda.time.DateTime
-import slick.driver.JdbcDriver.backend.Database.dynamicSession
-import slick.jdbc.{GetResult, PositionedResult, StaticQuery => Q}
-import slick.jdbc.StaticQuery.interpolation
+import scalikejdbc._
+import scalikejdbc.jodatime.JodaWrappedResultSet.fromWrappedResultSetToJodaWrappedResultSet
 
 
 //TODO naming SQL conventions
@@ -146,310 +145,459 @@ case class ProjectLink(id: Long, roadPart: RoadPart, track: Track, discontinuity
   }
 }
 
+
+object ProjectRoadLinkChange extends SQLSyntaxSupport [ProjectRoadLinkChange]{
+  def apply(rs: WrappedResultSet): ProjectRoadLinkChange = {
+/*
+    logger.warn(
+      s"""ProjRoadLinkCh ResultSet values:
+         |project_link_id = ${rs.anyOpt("project_link_id")}
+         |roadway_id = ${rs.anyOpt("roadway_id")}
+         |LINEAR_LOCATION_ID = ${rs.anyOpt("LINEAR_LOCATION_ID")}
+         |original_road_number = ${rs.anyOpt("original_road_number")}
+         |original_road_part_number = ${rs.anyOpt("original_road_part_number")}
+         |project_road_number = ${rs.anyOpt("project_road_number")}
+         |project_road_part_number = ${rs.anyOpt("project_road_part_number")}
+         |original_start_addr_m = ${rs.anyOpt("original_start_addr_m")}
+         |original_end_addr_m = ${rs.anyOpt("original_end_addr_m")}
+         |start_addr_m = ${rs.anyOpt("start_addr_m")}
+         |end_addr_m = ${rs.anyOpt("end_addr_m")}
+         |status = ${rs.anyOpt("status")}
+         |reversed = ${rs.anyOpt("reversed")}
+         |original_roadway_number = ${rs.anyOpt("original_roadway_number")}
+         |project_roadway_number = ${rs.anyOpt("project_roadway_number")}
+         |""".stripMargin)
+*/
+    new ProjectRoadLinkChange(
+      id = rs.long("project_link_id"),
+      roadwayId = rs.longOpt("roadway_id").getOrElse(0L),
+      originalLinearLocationId = rs.longOpt("LINEAR_LOCATION_ID").getOrElse(0L),
+      linearLocationId = 0,
+      originalRoadPart = RoadPart(
+        rs.longOpt("original_road_number").getOrElse(0L),
+        rs.longOpt("original_road_part_number").getOrElse(0L)
+      ),
+      roadPart = RoadPart(
+        rs.long("project_road_number"),
+        rs.long("project_road_part_number")
+        ),
+      originalStartAddr = rs.long("original_start_addr_m"),
+      originalEndAddr = rs.long("original_end_addr_m"),
+      newStartAddr = rs.long("start_addr_m"),
+      newEndAddr = rs.long("end_addr_m"),
+      status = RoadAddressChangeType(rs.int("status")),
+      reversed = rs.boolean("reversed"),
+      originalRoadwayNumber = rs.longOpt("original_roadway_number").getOrElse(0L),
+      newRoadwayNumber = rs.longOpt("project_roadway_number").getOrElse(0L)
+    )
+  }
+}
+
 class ProjectLinkDAO extends BaseDAO {
 
   val roadwayDAO = new RoadwayDAO
 
-  private val projectLinkQueryBase =
-    s"""select PROJECT_LINK.ID, PROJECT_LINK.PROJECT_ID, PROJECT_LINK.TRACK, PROJECT_LINK.DISCONTINUITY_TYPE,
-  PROJECT_LINK.ROAD_NUMBER, PROJECT_LINK.ROAD_PART_NUMBER, PROJECT_LINK.START_ADDR_M, PROJECT_LINK.END_ADDR_M,
-  PROJECT_LINK.ORIGINAL_START_ADDR_M, PROJECT_LINK.ORIGINAL_END_ADDR_M,
-  PROJECT_LINK.START_MEASURE, PROJECT_LINK.END_MEASURE, PROJECT_LINK.SIDE,
-  PROJECT_LINK.CREATED_BY, PROJECT_LINK.MODIFIED_BY, PROJECT_LINK.LINK_ID, PROJECT_LINK.GEOMETRY,
-  (PROJECT_LINK.END_MEASURE - PROJECT_LINK.START_MEASURE) as length,
-  PROJECT_LINK.START_CALIBRATION_POINT, PROJECT_LINK.END_CALIBRATION_POINT,
-  PROJECT_LINK.ORIG_START_CALIBRATION_POINT, PROJECT_LINK.ORIG_END_CALIBRATION_POINT,
-  PROJECT_LINK.STATUS, PROJECT_LINK.ADMINISTRATIVE_CLASS, PROJECT_LINK.LINK_SOURCE as source, PROJECT_LINK.ROADWAY_ID,
-  PROJECT_LINK.LINEAR_LOCATION_ID, PROJECT_LINK.ELY, PROJECT_LINK.REVERSED, PROJECT_LINK.CONNECTED_LINK_ID,
+  private lazy val projectLinkQueryBase =
+    sqls"""
+  SELECT
+    project_link.id,
+    project_link.project_id,
+    project_link.track,
+    project_link.discontinuity_type,
+    project_link.road_number,
+    project_link.road_part_number,
+    project_link.start_addr_m,
+    project_link.end_addr_m,
+    project_link.original_start_addr_m,
+    project_link.original_end_addr_m,
+    project_link.start_measure,
+    project_link.end_measure,
+    project_link.side,
+    project_link.created_by,
+    project_link.modified_by,
+    project_link.link_id,
+    project_link.geometry,
+    (project_link.end_measure - project_link.start_measure) AS length,
+    project_link.start_calibration_point,
+    project_link.end_calibration_point,
+    project_link.orig_start_calibration_point,
+    project_link.orig_end_calibration_point,
+    project_link.status,
+    project_link.administrative_class,
+    project_link.link_source,
+    project_link.roadway_id,
+    project_link.linear_location_id,
+    project_link.ely, project_link.reversed,
+    project_link.connected_link_id,
   CASE
-    WHEN STATUS = ${RoadAddressChangeType.NotHandled.value} THEN null
-    WHEN STATUS IN (${RoadAddressChangeType.Termination.value}, ${RoadAddressChangeType.Unchanged.value}) THEN ROADWAY.START_DATE
-    ELSE PRJ.START_DATE END as start_date,
-  CASE WHEN STATUS = ${RoadAddressChangeType.Termination.value} THEN PRJ.START_DATE - 1 ELSE null END as end_date,
+    WHEN status = ${RoadAddressChangeType.NotHandled.value} THEN null
+    WHEN status IN (${RoadAddressChangeType.Termination.value}, ${RoadAddressChangeType.Unchanged.value}) THEN ROADWAY.START_DATE
+    ELSE prj.start_date END AS start_date,
+  CASE WHEN STATUS = ${RoadAddressChangeType.Termination.value} THEN prj.start_date - 1 ELSE null END as end_date,
   PROJECT_LINK.ADJUSTED_TIMESTAMP,
   CASE
-    WHEN rn.road_name IS NOT NULL AND rn.END_DATE IS NULL AND rn.VALID_TO IS null THEN rn.road_name
+    WHEN rn.road_name IS NOT NULL AND rn.end_date IS NULL AND rn.valid_to IS NULL THEN rn.road_name
     WHEN rn.road_name IS NULL AND pln.road_name IS NOT NULL THEN pln.road_name
     END AS road_name_pl,
-  PROJECT_LINK.ORIGINAL_START_ADDR_M as RA_START_ADDR_M,
-  PROJECT_LINK.ORIGINAL_END_ADDR_M as RA_END_ADDR_M,
-  ROADWAY.TRACK as TRACK,
-  ROADWAY.ROAD_NUMBER as ROAD_NUMBER,
-  ROADWAY.ROAD_PART_NUMBER as ROAD_PART_NUMBER,
-  ROADWAY.ROADWAY_NUMBER,
-  PROJECT_LINK.ROADWAY_NUMBER
-  from PROJECT prj JOIN PROJECT_LINK ON (prj.id = PROJECT_LINK.PROJECT_ID)
-    LEFT JOIN ROADWAY ON (ROADWAY.ID = PROJECT_LINK.ROADWAY_ID)
-    LEFT JOIN Linear_Location ON (Linear_Location.ID = PROJECT_LINK.Linear_Location_Id)
-    LEFT JOIN ROAD_NAME rn ON (rn.road_number = project_link.road_number AND rn.END_DATE IS NULL AND rn.VALID_TO IS null)
-	  LEFT JOIN project_link_name pln ON (pln.road_number = project_link.road_number AND pln.project_id = project_link.project_id)  """
+  project_link.original_start_addr_m AS ra_start_addr_m,
+  project_link.original_end_addr_m AS ra_end_addr_m,
+  roadway.track AS ra_track,
+  roadway.road_number AS ra_road_number,
+  roadway.road_part_number AS ra_road_part_number,
+  roadway.roadway_number AS ra_roadway_number,
+  project_link.roadway_number roadway_number
+  from project prj JOIN project_link ON (prj.id = project_link.project_id)
+    LEFT JOIN roadway on (roadway.id = project_link.roadway_id)
+    LEFT JOIN Linear_Location ON (Linear_Location.ID = project_link.Linear_Location_Id)
+    LEFT JOIN road_name rn ON (rn.road_number = project_link.road_number AND rn.end_date IS NULL AND rn.VALID_TO IS null)
+	  LEFT JOIN project_link_name pln ON (pln.road_number = project_link.road_number AND pln.project_id = project_link.project_id)
+	  """
 
-  private val projectLinkHistoryQueryBase =
-    s"""
-        select plh.ID, plh.PROJECT_ID, plh.TRACK, plh.DISCONTINUITY_TYPE,
-          plh.ROAD_NUMBER, plh.ROAD_PART_NUMBER, plh.START_ADDR_M, plh.END_ADDR_M,
-          plh.ORIGINAL_START_ADDR_M, plh.ORIGINAL_END_ADDR_M,
-          plh.START_MEASURE, plh.END_MEASURE, plh.SIDE,
-          plh.CREATED_BY, plh.MODIFIED_BY, plh.LINK_ID, plh.GEOMETRY,
-          (plh.END_MEASURE - plh.START_MEASURE) as length,
-          plh.START_CALIBRATION_POINT, plh.END_CALIBRATION_POINT,
-          plh.ORIG_START_CALIBRATION_POINT, plh.ORIG_END_CALIBRATION_POINT,
-          plh.STATUS, plh.ADMINISTRATIVE_CLASS, plh.LINK_SOURCE as source, plh.ROADWAY_ID, plh.Linear_Location_Id, plh.ELY,
-          plh.REVERSED, plh.CONNECTED_LINK_ID,
+  private lazy val projectLinkHistoryQueryBase =
+    sqls"""
+        SELECT
+          plh.id,
+          plh.project_id,
+          plh.track,
+          plh.discontinuity_type,
+          plh.road_number,
+          plh.road_part_number,
+          plh.start_addr_m,
+          plh.end_addr_m,
+          plh.original_start_addr_m,
+          plh.original_end_addr_m,
+          plh.start_measure,
+          plh.end_measure,
+          plh.side,
+          plh.created_by,
+          plh.modified_by,
+          plh.link_id,
+          plh.geometry,
+          (plh.end_measure - plh.start_measure) as length,
+          plh.start_calibration_point,
+          plh.end_calibration_point,
+          plh.orig_start_calibration_point,
+          plh.orig_end_calibration_point,
+          plh.status,
+          plh.administrative_class,
+          plh.link_source,
+          plh.roadway_id,
+          plh.linear_location_id,
+          plh.ely,
+          plh.reversed,
+          plh.connected_link_id,
           CASE
             WHEN STATUS = ${RoadAddressChangeType.NotHandled.value} THEN null
             WHEN STATUS IN (${RoadAddressChangeType.Termination.value}, ${RoadAddressChangeType.Unchanged.value}) THEN ROADWAY.START_DATE
-            ELSE PRJ.START_DATE END as start_date,
-          CASE WHEN STATUS = ${RoadAddressChangeType.Termination.value} THEN PRJ.START_DATE - 1 ELSE null END as end_date,
-          plh.ADJUSTED_TIMESTAMP,
+            ELSE prj.start_date END as start_date,
+          CASE WHEN status = ${RoadAddressChangeType.Termination.value} THEN prj.start_date - 1 ELSE null END as end_date,
+          plh.adjusted_timestamp,
           CASE
             WHEN rn.road_name IS NOT NULL AND rn.END_DATE IS NULL AND rn.VALID_TO IS null THEN rn.road_name
             WHEN rn.road_name IS NULL AND pln.road_name IS NOT NULL THEN pln.road_name
             END AS road_name_pl,
-          ROADWAY.START_ADDR_M as RA_START_ADDR_M,
-          ROADWAY.END_ADDR_M as RA_END_ADDR_M,
-          ROADWAY.TRACK as TRACK,
-          ROADWAY.ROAD_NUMBER as ROAD_NUMBER,
-          ROADWAY.ROAD_PART_NUMBER as ROAD_PART_NUMBER,
-          ROADWAY.ROADWAY_NUMBER,
-          plh.ROADWAY_NUMBER
-          from PROJECT prj JOIN PROJECT_LINK_HISTORY plh ON (prj.id = plh.PROJECT_ID)
+          roadway.start_addr_m AS ra_start_addr_m,
+          roadway.end_addr_m AS ra_end_addr_m,
+          roadway.track AS ra_track,
+          roadway.road_number AS ra_road_number,
+          roadway.road_part_number AS ra_road_part_number,
+          roadway.roadway_number AS ra_roadway_number,
+          plh.roadway_number AS roadway_number
+          FROM project prj JOIN project_link_history plh ON (prj.id = plh.project_id)
             LEFT JOIN ROADWAY ON (ROADWAY.ID = plh.ROADWAY_ID)
             LEFT JOIN Linear_Location ON (Linear_Location.ID = plh.Linear_Location_Id)
             LEFT JOIN ROAD_NAME rn ON (rn.road_number = plh.road_number AND rn.END_DATE IS NULL AND rn.VALID_TO IS null)
         	  LEFT JOIN project_link_name pln ON (pln.road_number = plh.road_number AND pln.project_id = plh.project_id)
-     """.stripMargin
+     """
 
-  private val projectLinksChangeQueryBase =
-    s"""
-        select PROJECT_LINK.ID, ROADWAY.ID, PROJECT_LINK.LINEAR_LOCATION_ID, ROADWAY.ROAD_NUMBER, ROADWAY.ROAD_PART_NUMBER, PROJECT_LINK.ROAD_NUMBER, PROJECT_LINK.ROAD_PART_NUMBER, PROJECT_LINK.ORIGINAL_START_ADDR_M, PROJECT_LINK.ORIGINAL_END_ADDR_M,
-          PROJECT_LINK.START_ADDR_M, PROJECT_LINK.END_ADDR_M,
-          PROJECT_LINK.STATUS,
-          PROJECT_LINK.REVERSED,
-          ROADWAY.ROADWAY_NUMBER,
-          PROJECT_LINK.ROADWAY_NUMBER
-          from PROJECT prj JOIN PROJECT_LINK ON (prj.id = PROJECT_LINK.PROJECT_ID)
-          LEFT JOIN ROADWAY ON (ROADWAY.ID = PROJECT_LINK.ROADWAY_ID)
-          LEFT JOIN Linear_Location ON (Linear_Location.ID = PROJECT_LINK.Linear_Location_Id)
+  private lazy val projectLinksChangeQueryBase =
+    sqls"""
+          SELECT
+            project_link.id AS project_link_id,
+            roadway.id AS roadway_id,
+            project_link.linear_location_id,
+            roadway.road_number AS original_road_number,
+            roadway.road_part_number AS original_road_part_number,
+            project_link.road_number AS project_road_number,
+            project_link.road_part_number AS project_road_part_number,
+            project_link.original_start_addr_m,
+            project_link.original_end_addr_m,
+            project_link.start_addr_m,
+            project_link.end_addr_m,
+            project_link.status,
+            project_link.reversed,
+            roadway.roadway_number AS original_roadway_number,
+            project_link.roadway_number AS project_roadway_number
+          from project prj JOIN project_link ON (prj.id = project_link.project_id)
+          LEFT JOIN roadway ON (roadway.id = project_link.roadway_id)
+          LEFT JOIN Linear_Location ON (Linear_Location.ID = project_link.linear_location_id)
       """
 
-  implicit val getProjectLinkRow: GetResult[ProjectLink] = new GetResult[ProjectLink] {
-    def apply(r: PositionedResult): ProjectLink = {
-      val projectLinkId = r.nextLong()
-      val projectId = r.nextLong()
-      val trackCode = Track.apply(r.nextInt())
-      val discontinuityType = Discontinuity.apply(r.nextInt())
-      val roadNumber = r.nextLong()
-      val roadPartNumber = r.nextLong()
-      val startAddrM = r.nextLong()
-      val endAddrM = r.nextLong()
-      val originalStartAddrMValue = r.nextLong()
-      val originalEndAddrMValue = r.nextLong()
-      val startMValue = r.nextDouble()
-      val endMValue = r.nextDouble()
-      val sideCode = SideCode.apply(r.nextInt)
-      val createdBy = r.nextStringOption()
-      val modifiedBy = r.nextStringOption()
-      val linkId = r.nextString()
-      val geom = r.nextObjectOption()
-      val length = r.nextDouble()
-      val calibrationPoints = (CalibrationPointType.apply(r.nextInt), CalibrationPointType.apply(r.nextInt))
-      val originalCalibrationPointTypes = (CalibrationPointType.apply(r.nextInt), CalibrationPointType.apply(r.nextInt))
-      val status = RoadAddressChangeType.apply(r.nextInt())
-      val administrativeClass = AdministrativeClass.apply(r.nextInt())
-      val source = LinkGeomSource.apply(r.nextInt())
-      val roadwayId = r.nextLong()
-      val linearLocationId = r.nextLong()
-      val ely = r.nextLong()
-      val reversed = r.nextBoolean()
-      val connectedLinkId = r.nextStringOption()
-      val startDate = r.nextDateOption().map(d => new DateTime(d.getTime))
-      val endDate = r.nextDateOption().map(d => new DateTime(d.getTime))
-      val geometryTimeStamp = r.nextLong()
-      val roadName = r.nextString()
-      val roadAddressStartAddrM = r.nextLongOption()
-      val roadAddressEndAddrM = r.nextLongOption()
-      val roadAddressTrack = r.nextIntOption().map(Track.apply)
-      val roadAddressRoadNumber = r.nextLongOption()
-      val roadAddressRoadPartNumber = r.nextLongOption()
-      val roadwayNumber = r.nextLong()
-      val projectRoadwayNumber = r.nextLong()
+  object ProjectLink extends SQLSyntaxSupport[ProjectLink] {
+    override val tableName = "PROJECT_LINK"
 
-      val roadAddressRoadPart = if(roadAddressRoadNumber.nonEmpty && roadAddressRoadPartNumber.nonEmpty) { Some(RoadPart(roadAddressRoadNumber.get, roadAddressRoadPartNumber.get)) } else None
-      ProjectLink(projectLinkId, RoadPart(roadNumber, roadPartNumber), trackCode, discontinuityType, AddrMRange(startAddrM, endAddrM), AddrMRange(originalStartAddrMValue, originalEndAddrMValue), startDate, endDate, createdBy, linkId, startMValue, endMValue, sideCode, calibrationPoints, originalCalibrationPointTypes, PostGISDatabase.loadJGeometryToGeometry(geom), projectId, status, administrativeClass, source, length, roadwayId, linearLocationId, ely, reversed, connectedLinkId, geometryTimeStamp, if (projectRoadwayNumber == 0 || projectRoadwayNumber == NewIdValue) roadwayNumber else projectRoadwayNumber, Some(roadName), roadAddressEndAddrM.map(endAddr => endAddr - roadAddressStartAddrM.getOrElse(0L)), roadAddressStartAddrM, roadAddressEndAddrM, roadAddressTrack, roadAddressRoadPart)
+    def apply(rs: WrappedResultSet): ProjectLink = {
+/*
+            // Debug metadata
+            val meta = rs.underlying.getMetaData
+            val columnCount = meta.getColumnCount
+
+            for (i <- 1 to columnCount) {
+              logger.warn(s"Column $i: Name=${meta.getColumnName(i)}, " +
+                s"Label=${meta.getColumnLabel(i)}, " +
+                s"Type=${meta.getColumnTypeName(i)}")
+            }
+
+      logger.warn(
+        s"""ResultSet values:
+   id = ${rs.anyOpt("id")}
+   road_number = ${rs.anyOpt("road_number")}
+   road_part_number = ${rs.anyOpt("road_part_number")}
+   track = ${rs.anyOpt("track")}
+   discontinuity_type = ${rs.anyOpt("discontinuity_type")}
+   start_addr_m = ${rs.anyOpt("start_addr_m")}
+   end_addr_m = ${rs.anyOpt("end_addr_m")}
+   original_start_addr_m = ${rs.anyOpt("original_start_addr_m")}
+   original_end_addr_m = ${rs.anyOpt("original_end_addr_m")}
+   start_date = ${rs.anyOpt("start_date")}
+   end_date = ${rs.anyOpt("end_date")}
+   created_by = ${rs.anyOpt("created_by")}
+   link_id = ${rs.anyOpt("link_id")}
+
+   start_measure = ${rs.anyOpt("start_measure")}
+   end_measure = ${rs.anyOpt("end_measure")}
+   side = ${rs.anyOpt("side")}
+   start_calibration_point = ${rs.anyOpt("start_calibration_point")}
+   end_calibration_point = ${rs.anyOpt("end_calibration_point")}
+   orig_start_calibration_point = ${rs.anyOpt("orig_start_calibration_point")}
+   orig_end_calibration_point = ${rs.anyOpt("orig_end_calibration_point")}
+   geometry = ${rs.anyOpt("geometry")}
+   project_id = ${rs.anyOpt("project_id")}
+   status = ${rs.anyOpt("status")}
+   administrative_class = ${rs.anyOpt("administrative_class")}
+   link_source = ${rs.anyOpt("link_source")}
+   length = ${rs.anyOpt("length")}
+   roadway_id = ${rs.anyOpt("roadway_id")}
+   linear_location_id = ${rs.anyOpt("linear_location_id")}
+
+
+   ely = ${rs.anyOpt("ely")}
+   reversed = ${rs.anyOpt("reversed")}
+   connected_link_id = ${rs.anyOpt("connected_link_id")}
+   adjusted_timestamp = ${rs.anyOpt("adjusted_timestamp")}
+   roadway_number = ${rs.anyOpt("roadway_number")}
+   ra_roadway_number = ${rs.anyOpt("ra_roadway_number")}
+   road_name_pl = ${rs.anyOpt("road_name_pl")}
+   ra_start_addr_m = ${rs.anyOpt("ra_start_addr_m")}
+   ra_end_addr_m = ${rs.anyOpt("ra_end_addr_m")}
+     """)
+
+*/
+
+      new ProjectLink(
+        id = rs.long("id"),
+        roadPart = RoadPart(rs.long("road_number"), rs.long("road_part_number")),
+        track = Track(rs.int("track")),
+        discontinuity = Discontinuity(rs.int("discontinuity_type")),
+        addrMRange = AddrMRange(rs.long("start_addr_m"), rs.long("end_addr_m")),
+        originalAddrMRange = AddrMRange(rs.long("original_start_addr_m"), rs.long("original_end_addr_m")),
+        startDate = rs.jodaDateTimeOpt("start_date"),
+        endDate = rs.jodaDateTimeOpt("end_date"),
+        createdBy = rs.stringOpt("created_by"),
+        linkId = rs.string("link_id"),
+        startMValue = rs.double("start_measure"),
+        endMValue = rs.double("end_measure"),
+        sideCode = SideCode(rs.intOpt("side").getOrElse(0)),
+        calibrationPointTypes = (
+          CalibrationPointType(rs.int("start_calibration_point")),
+          CalibrationPointType(rs.int("end_calibration_point"))
+        ),
+        originalCalibrationPointTypes = (
+          CalibrationPointType(rs.int("orig_start_calibration_point")),
+          CalibrationPointType(rs.int("orig_end_calibration_point"))
+        ),
+        geometry = GeometryDbUtils.loadJGeometryToGeometry(rs.anyOpt("geometry")),
+        projectId = rs.long("project_id"),
+        status = RoadAddressChangeType(rs.int("status")),
+        administrativeClass = AdministrativeClass(rs.int("administrative_class")),
+        linkGeomSource = LinkGeomSource(rs.int("link_source")),
+        geometryLength = rs.double("length"),
+        roadwayId = rs.longOpt("roadway_id").getOrElse(0L),
+        linearLocationId = rs.longOpt("linear_location_id").getOrElse(0L),
+        ely = rs.long("ely"),
+        reversed = rs.boolean("reversed"),
+        connectedLinkId = rs.stringOpt("connected_link_id"),
+        linkGeometryTimeStamp = rs.long("adjusted_timestamp"),
+        roadwayNumber = {
+          val projectRoadwayNumber = rs.longOpt("roadway_number").getOrElse(0L)
+          val roadwayNumber = rs.longOpt("ra_roadway_number").getOrElse(0L)
+          if (projectRoadwayNumber == 0 || projectRoadwayNumber == NewIdValue)
+            roadwayNumber
+          else
+            projectRoadwayNumber
+        },
+        roadName = rs.stringOpt("road_name_pl"),
+        roadAddressLength = rs.longOpt("ra_end_addr_m").map(
+          endAddr => endAddr - rs.longOpt("ra_start_addr_m").getOrElse(0L)
+        ),
+        roadAddressStartAddrM = rs.longOpt("ra_start_addr_m"),
+        roadAddressEndAddrM = rs.longOpt("ra_end_addr_m"),
+        roadAddressTrack = rs.intOpt("track").map(Track.apply),
+        roadAddressRoadPart = (rs.longOpt("ra_road_number"), rs.longOpt("ra_road_part_number")) match {
+          case (Some(roadNumber), Some(roadPartNumber)) => Some(RoadPart(roadNumber, roadPartNumber))
+          case _ => None
+        }
+      )
     }
   }
 
-  implicit val getProjectLinksChangeRow: GetResult[ProjectRoadLinkChange] = new GetResult[ProjectRoadLinkChange] {
-    def apply(r: PositionedResult): ProjectRoadLinkChange = {
-      val projectLinkId = r.nextLong()
-      val roadwayId = r.nextLong()
-      val originalLinearLocationId = r.nextLong()
-      val originalRoadNumber = r.nextLong()
-      val originalRoadPartNumber = r.nextLong()
-      val roadNumber = r.nextLong()
-      val roadPartNumber = r.nextLong()
-      val originalStartAddrMValue = r.nextLong()
-      val originalEndAddrMValue = r.nextLong()
-      val startAddrM = r.nextLong()
-      val endAddrM = r.nextLong()
-      val status = RoadAddressChangeType.apply(r.nextInt())
-      val reversed = r.nextBoolean()
-      val roadwayNumber = r.nextLong()
-      val projectRoadwayNumber = r.nextLong()
-
-      ProjectRoadLinkChange(projectLinkId, roadwayId, originalLinearLocationId, 0, RoadPart(originalRoadNumber, originalRoadPartNumber), RoadPart(originalRoadNumber, originalRoadPartNumber), originalStartAddrMValue, originalEndAddrMValue, startAddrM, endAddrM,
-        status, reversed, roadwayNumber, projectRoadwayNumber)
-    }
+  private def listQuery(query: SQL[Nothing, NoExtractor]): Seq[ProjectLink] = {
+    runSelectQuery(query.map(ProjectLink.apply))
   }
 
-  private def listQuery(query: String): Seq[ProjectLink] = {
-    Q.queryNA[ProjectLink](query).iterator.toSeq
-  }
-
-  private def changesListQuery(query: String): Seq[ProjectRoadLinkChange] = {
-    Q.queryNA[ProjectRoadLinkChange](query).iterator.toSeq
+  private def changesListQuery(query: SQL[Nothing, NoExtractor]): Seq[ProjectRoadLinkChange] = {
+    runSelectQuery(query.map(ProjectRoadLinkChange.apply))
   }
 
   def create(links: Seq[ProjectLink]): Seq[Long] = {
     if (links.nonEmpty)
     time(logger, "Create project links") {
-      val addressPS = dynamicSession.prepareStatement("""
-        insert into PROJECT_LINK (id, project_id, road_number, road_part_number, TRACK, discontinuity_type,
-          START_ADDR_M, END_ADDR_M, ORIGINAL_START_ADDR_M, ORIGINAL_END_ADDR_M, created_by, modified_by,
+      val insertQuery = sql"""
+        INSERT INTO project_link (id, project_id, road_number, road_part_number, track, discontinuity_type,
+          start_addr_m, end_addr_m, original_start_addr_m, original_end_addr_m, created_by, modified_by,
           start_calibration_point, end_calibration_point, orig_start_calibration_point, orig_end_calibration_point,
-          status, ADMINISTRATIVE_CLASS, roadway_id, linear_location_id, connected_link_id, ely, roadway_number, reversed, geometry,
+          status, administrative_class, roadway_id, linear_location_id, connected_link_id, ely, roadway_number, reversed, geometry,
           link_id, SIDE, start_measure, end_measure, adjusted_timestamp, link_source, modified_date)
-          values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ST_GeomFromText(?, 3067), ?, ?, ?, ?, ?, ?, ?)
-        """)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ST_GeomFromText(?, 3067), ?, ?, ?, ?, ?, ?, ?)
+        """
+
       val (ready, idLess) = links.partition(_.id != NewIdValue)
       val plIds = Sequences.fetchProjectLinkIds(idLess.size)
       val projectLinks = ready ++ idLess.zip(plIds).map(x =>
         x._1.copy(id = x._2)
       )
-      projectLinks.toList.foreach { pl =>
-        addressPS.setLong(1, pl.id)
-        addressPS.setLong(2, pl.projectId)
-        addressPS.setLong(3, pl.roadPart.roadNumber)
-        addressPS.setLong(4, pl.roadPart.partNumber)
-        addressPS.setLong(5, pl.track.value)
-        addressPS.setLong(6, pl.discontinuity.value)
-        addressPS.setLong(7, pl.addrMRange.start)
-        addressPS.setLong(8, pl.addrMRange.end)
-        addressPS.setLong(9, pl.originalAddrMRange.start)
-        addressPS.setLong(10, pl.originalAddrMRange.end)
-        addressPS.setString(11, pl.createdBy.orNull)
-        addressPS.setString(12, pl.createdBy.orNull)
+      val batchParams = projectLinks.map { pl =>
+        Seq(
+          pl.id,
+          pl.projectId,
+          pl.roadPart.roadNumber,
+          pl.roadPart.partNumber,
+          pl.track.value,
+          pl.discontinuity.value,
+          pl.addrMRange.start,
+          pl.addrMRange.end,
+          pl.originalAddrMRange.start,
+          pl.originalAddrMRange.end,
+          pl.createdBy.orNull,
+          pl.createdBy.orNull,
+          pl.startCalibrationPointType.value,
+          pl.endCalibrationPointType.value,
+          pl.originalStartCalibrationPointType.value,
+          pl.originalEndCalibrationPointType.value,
+          pl.status.value,
+          pl.administrativeClass.value,
+          if (pl.roadwayId == 0) null else pl.roadwayId,
+          if (pl.linearLocationId == 0) null else pl.linearLocationId,
+          pl.connectedLinkId.orNull,
+          pl.ely,
+          pl.roadwayNumber, if (pl.reversed) 1 else 0,
+          GeometryDbUtils.createJGeometry(pl.geometry),
+          pl.linkId,
+          pl.sideCode.value,
+          pl.startMValue,
+          pl.endMValue,
+          pl.linkGeometryTimeStamp,
+          pl.linkGeomSource.value,
+          new Date()
 
-        addressPS.setLong(13, pl.startCalibrationPointType.value)
-        addressPS.setLong(14, pl.endCalibrationPointType.value)
-        addressPS.setLong(15, pl.originalStartCalibrationPointType.value)
-        addressPS.setLong(16, pl.originalEndCalibrationPointType.value)
-        addressPS.setLong(17, pl.status.value)
-        addressPS.setLong(18, pl.administrativeClass.value)
-        if (pl.roadwayId == 0)
-          addressPS.setNull(19, Types.BIGINT)
-        else
-          addressPS.setLong(19, pl.roadwayId)
-        if (pl.linearLocationId == 0)
-          addressPS.setNull(20, Types.BIGINT)
-        else
-          addressPS.setLong(20, pl.linearLocationId)
-        if (pl.connectedLinkId.isDefined)
-          addressPS.setString(21, pl.connectedLinkId.get)
-        else
-          addressPS.setNull(21, Types.BIGINT)
-        addressPS.setLong(22, pl.ely)
-        addressPS.setLong(23, pl.roadwayNumber)
-        addressPS.setInt(24, if (pl.reversed) 1 else 0)
-        addressPS.setString(25, PostGISDatabase.createJGeometry(pl.geometry))
-        addressPS.setString(26, pl.linkId)
-        addressPS.setLong(27, pl.sideCode.value)
-        addressPS.setDouble(28, pl.startMValue)
-        addressPS.setDouble(29, pl.endMValue)
-        addressPS.setDouble(30, pl.linkGeometryTimeStamp)
-        addressPS.setInt(31, pl.linkGeomSource.value)
-        addressPS.setDate(32, new java.sql.Date(new Date().getTime))
-        addressPS.addBatch()
+        )
       }
-      addressPS.executeBatch()
-      addressPS.close()
+
+      runBatchUpdateToDb(insertQuery, batchParams)
+
       projectLinks.map(_.id)
     } else
       Seq.empty[Long]
   }
 
+
   def updateProjectLinks(projectLinks: Seq[ProjectLink], modifier: String, addresses: Seq[RoadAddress]): Unit = {
-      time(logger, "Update project links") {
-        val nonUpdatingStatus = Set[RoadAddressChangeType](RoadAddressChangeType.NotHandled)
-        val maxInEachTracks = projectLinks.filter(pl => pl.status == RoadAddressChangeType.Unchanged).groupBy(_.track).map(p => p._2.maxBy(_.addrMRange.end).id).toSeq
-        val links = projectLinks.map { pl =>
-          if (!pl.isSplit && nonUpdatingStatus.contains(pl.status) && addresses.map(_.linearLocationId).contains(pl.linearLocationId) && !maxInEachTracks.contains(pl.id)) {
-            val ra = addresses.find(_.linearLocationId == pl.linearLocationId).get
-            // Discontinuity, administrative class and calibration points may change with Unchanged status
-            pl.copy(roadPart = ra.roadPart, track = ra.track, addrMRange = AddrMRange(ra.addrMRange.start, ra.addrMRange.end), reversed = false)
-          } else
-            pl
-        }
-        val projectLinkPS = dynamicSession.prepareStatement("""
+    time(logger, "Update project links") {
+      val nonUpdatingStatus = Set[RoadAddressChangeType](RoadAddressChangeType.NotHandled)
+      val maxInEachTracks = projectLinks.filter(pl => pl.status == RoadAddressChangeType.Unchanged).groupBy(_.track).map(p => p._2.maxBy(_.addrMRange.end).id).toSeq
+      val links = projectLinks.map { pl =>
+        if (!pl.isSplit && nonUpdatingStatus.contains(pl.status) && addresses.map(_.linearLocationId).contains(pl.linearLocationId) && !maxInEachTracks.contains(pl.id)) {
+          val ra = addresses.find(_.linearLocationId == pl.linearLocationId).get
+          // Discontinuity, administrative class and calibration points may change with Unchanged status
+          pl.copy(roadPart = ra.roadPart, track = ra.track, addrMRange = AddrMRange(ra.addrMRange.start, ra.addrMRange.end), reversed = false)
+        } else
+          pl
+      }
+      val updateQuery =
+        sql"""
           UPDATE project_link
           SET ROAD_NUMBER = ?, ROAD_PART_NUMBER = ?, TRACK = ?, DISCONTINUITY_TYPE = ?, START_ADDR_M = ?, END_ADDR_M = ?,
             ORIGINAL_START_ADDR_M = ?, ORIGINAL_END_ADDR_M = ?, MODIFIED_DATE = CURRENT_TIMESTAMP, MODIFIED_BY = ?, PROJECT_ID = ?,
             START_CALIBRATION_POINT = ?, END_CALIBRATION_POINT = ?, ORIG_START_CALIBRATION_POINT = ?, ORIG_END_CALIBRATION_POINT = ?,
             STATUS = ?, ADMINISTRATIVE_CLASS = ?, REVERSED = ?, GEOMETRY = ST_GeomFromText(?, 3067), SIDE = ?, START_MEASURE = ?, END_MEASURE = ?,  ELY = ?,
             ROADWAY_NUMBER = ?, CONNECTED_LINK_ID = ?
-          WHERE id = ?""")
+          WHERE id = ?
+          """
 
-        for (projectLink <- links) {
-          projectLinkPS.setLong(1, projectLink.roadPart.roadNumber)
-          projectLinkPS.setLong(2, projectLink.roadPart.partNumber)
-          projectLinkPS.setInt(3, projectLink.track.value)
-          projectLinkPS.setInt(4, projectLink.discontinuity.value)
-          projectLinkPS.setLong(5, projectLink.addrMRange.start)
-          projectLinkPS.setLong(6, projectLink.addrMRange.end)
-          projectLinkPS.setLong(7, projectLink.originalAddrMRange.start)
-          projectLinkPS.setLong(8, projectLink.originalAddrMRange.end  )
-          projectLinkPS.setString(9, modifier)
-          projectLinkPS.setLong(10, projectLink.projectId)
-          projectLinkPS.setInt(11, projectLink.startCalibrationPointType.value)
-          projectLinkPS.setInt(12, projectLink.endCalibrationPointType.value)
-          projectLinkPS.setInt(13, projectLink.originalStartCalibrationPointType.value)
-          projectLinkPS.setInt(14, projectLink.originalEndCalibrationPointType.value)
-          projectLinkPS.setInt(15, projectLink.status.value)
-          projectLinkPS.setInt(16, projectLink.administrativeClass.value)
-          projectLinkPS.setInt(17, if (projectLink.reversed) 1 else 0)
-          projectLinkPS.setString(18, PostGISDatabase.createJGeometry(projectLink.geometry))
-          projectLinkPS.setInt(19, projectLink.sideCode.value)
-          projectLinkPS.setDouble(20, projectLink.startMValue)
-          projectLinkPS.setDouble(21, projectLink.endMValue)
-          projectLinkPS.setLong(22, projectLink.ely)
-          projectLinkPS.setLong(23, projectLink.roadwayNumber)
-          if (projectLink.connectedLinkId.isDefined)
-            projectLinkPS.setString(24, projectLink.connectedLinkId.get)
-          else
-            projectLinkPS.setNull(24, Types.BIGINT)
-          projectLinkPS.setLong(25, projectLink.id)
-          projectLinkPS.addBatch()
-        }
-        projectLinkPS.executeBatch()
-        projectLinkPS.close()
+      val batchParams = links.map { pl =>
+        Seq(
+          pl.roadPart.roadNumber,
+          pl.roadPart.partNumber,
+          pl.track.value,
+          pl.discontinuity.value,
+          pl.addrMRange.start,
+          pl.addrMRange.end,
+          pl.originalAddrMRange.start,
+          pl.originalAddrMRange.end,
+          modifier,
+          pl.projectId,
+          pl.startCalibrationPointType.value,
+          pl.endCalibrationPointType.value,
+          pl.originalStartCalibrationPointType.value,
+          pl.originalEndCalibrationPointType.value,
+          pl.status.value,
+          pl.administrativeClass.value,
+          if (pl.reversed) 1 else 0,
+          GeometryDbUtils.createJGeometry(pl.geometry),
+          pl.sideCode.value,
+          pl.startMValue,
+          pl.endMValue,
+          pl.ely,
+          pl.roadwayNumber,
+          pl.connectedLinkId.orNull,
+          pl.id
+        )
       }
+
+      runBatchUpdateToDb(updateQuery, batchParams)
+    }
   }
 
   def updateProjectLinksGeometry(projectLinks: Seq[ProjectLink], modifier: String): Unit = {
     time(logger,
       "Update project links geometry") {
-      val projectLinkPS = dynamicSession.prepareStatement("UPDATE project_link SET  GEOMETRY = ST_GeomFromText(?, 3067), MODIFIED_BY= ?, ADJUSTED_TIMESTAMP = ? WHERE id = ?")
 
-      for (projectLink <- projectLinks) {
-        projectLinkPS.setString(1, PostGISDatabase.createJGeometry(projectLink.geometry))
-        projectLinkPS.setString(2, modifier)
-        projectLinkPS.setLong(3, projectLink.linkGeometryTimeStamp)
-        projectLinkPS.setLong(4, projectLink.id)
-        projectLinkPS.addBatch()
+      val updateQuery = sql"""
+                        UPDATE project_link
+                        SET  GEOMETRY = ST_GeomFromText(?, 3067), MODIFIED_BY= ?, ADJUSTED_TIMESTAMP = ?
+                        WHERE id = ?
+                        """
+
+      val batchParams = projectLinks.map { pl =>
+        Seq(
+          GeometryDbUtils.createJGeometry(pl.geometry),
+          modifier,
+          pl.linkGeometryTimeStamp,
+          pl.id
+        )
       }
-      projectLinkPS.executeBatch()
-      projectLinkPS.close()
+
+      runBatchUpdateToDb(updateQuery, batchParams)
     }
   }
 
@@ -462,38 +610,54 @@ class ProjectLinkDAO extends BaseDAO {
                                         ): Unit = {
     time(logger,
       "Update project link calibrationpoints.") {
-      runUpdateToDb(s"""
-                update project_link
-                set modified_date = current_timestamp,
+      runUpdateToDb(sql"""
+                UPDATE project_link
+                SET modified_date = current_timestamp,
                     start_calibration_point = ${cals._1.value},
                     end_calibration_point = ${cals._2.value}
-                where id = ${projectLink.id}
+                WHERE id = ${projectLink.id}
       """)
     }
   }
 
   def fetchElyFromProjectLinks(projectId:Long): Option[Long]= {
     val query =
-      s"""SELECT ELY FROM PROJECT_LINK WHERE PROJECT_ID=$projectId AND ELY IS NOT NULL LIMIT 1"""
-    Q.queryNA[Long](query).firstOption
+      sql"""
+           SELECT ELY
+           FROM PROJECT_LINK
+           WHERE PROJECT_ID=$projectId
+           AND ELY IS NOT NULL
+           LIMIT 1
+           """
+    runSelectSingleFirstOptionWithType[Long](query)
   }
 
   def fetchProjectLinksHistory(projectId: Long, roadAddressChangeTypeFilter: Option[RoadAddressChangeType] = None): Seq[ProjectLink] = {
     time(logger, "Get project history links") {
-      val filter = if (roadAddressChangeTypeFilter.isEmpty) "" else s"plh.STATUS = ${roadAddressChangeTypeFilter.get.value} AND"
+      val filter = if (roadAddressChangeTypeFilter.isEmpty) sqls"" else sqls"plh.STATUS = ${roadAddressChangeTypeFilter.get.value} AND"
       val query =
-        s"""$projectLinkHistoryQueryBase
-                where $filter plh.PROJECT_ID = $projectId order by plh.ROAD_NUMBER, plh.ROAD_PART_NUMBER, plh.END_ADDR_M """
+        sql"""
+            $projectLinkHistoryQueryBase
+            WHERE $filter plh.PROJECT_ID = $projectId
+            ORDER BY plh.ROAD_NUMBER, plh.ROAD_PART_NUMBER, plh.END_ADDR_M
+            """
       listQuery(query)
     }
   }
 
   def fetchProjectLinks(projectId: Long, roadAddressChangeTypeFilter: Option[RoadAddressChangeType] = None): Seq[ProjectLink] = {
     time(logger, "Get project links") {
-      val filter = if (roadAddressChangeTypeFilter.isEmpty) "" else s"PROJECT_LINK.STATUS = ${roadAddressChangeTypeFilter.get.value} AND"
+      val filter = if (roadAddressChangeTypeFilter.isEmpty) sqls"" else sqls"PROJECT_LINK.STATUS = ${roadAddressChangeTypeFilter.get.value} AND"
       val query =
-        s"""$projectLinkQueryBase
-                where $filter PROJECT_LINK.PROJECT_ID = $projectId order by PROJECT_LINK.ROAD_NUMBER, PROJECT_LINK.ROAD_PART_NUMBER, PROJECT_LINK.END_ADDR_M """
+        sql"""
+              $projectLinkQueryBase
+              WHERE $filter PROJECT_LINK.PROJECT_ID = $projectId
+              ORDER BY PROJECT_LINK.ROAD_NUMBER, PROJECT_LINK.ROAD_PART_NUMBER, PROJECT_LINK.END_ADDR_M
+              """
+       /*Print the SQL query with values
+      logger.warn(s"SQL Query: ${query.statement}")
+      logger.warn(s"SQL Parameters: ${query.parameters}")
+      */
       listQuery(query)
     }
   }
@@ -501,8 +665,11 @@ class ProjectLinkDAO extends BaseDAO {
   def fetchProjectLinksChange(projectId: Long): Seq[ProjectRoadLinkChange] = {
     time(logger, "Get project links changes") {
       val query =
-        s"""$projectLinksChangeQueryBase
-                where PROJECT_LINK.PROJECT_ID = $projectId order by PROJECT_LINK.ROAD_NUMBER, PROJECT_LINK.ROAD_PART_NUMBER, PROJECT_LINK.END_ADDR_M """
+        sql"""
+              $projectLinksChangeQueryBase
+              WHERE PROJECT_LINK.PROJECT_ID = $projectId
+              ORDER BY PROJECT_LINK.ROAD_NUMBER, PROJECT_LINK.ROAD_PART_NUMBER, PROJECT_LINK.END_ADDR_M
+              """
       changesListQuery(query)
     }
   }
@@ -514,8 +681,11 @@ class ProjectLinkDAO extends BaseDAO {
         List()
       else {
         val query =
-          s"""$projectLinkQueryBase
-                where project_link.id in (${ids.mkString(",")}) order by PROJECT_LINK.ROAD_NUMBER, PROJECT_LINK.ROAD_PART_NUMBER, PROJECT_LINK.END_ADDR_M """
+          sql"""
+                $projectLinkQueryBase
+                WHERE project_link.id IN ($ids)
+                ORDER BY PROJECT_LINK.ROAD_NUMBER, PROJECT_LINK.ROAD_PART_NUMBER, PROJECT_LINK.END_ADDR_M
+                """
         listQuery(query)
       }
     }
@@ -527,8 +697,11 @@ class ProjectLinkDAO extends BaseDAO {
         List()
       } else {
         val query =
-          s"""$projectLinkQueryBase
-                where project_link.connected_link_id in (${connectedIds.map(cid => "'" + cid + "'").mkString(",")}) order by PROJECT_LINK.ROAD_NUMBER, PROJECT_LINK.ROAD_PART_NUMBER, PROJECT_LINK.END_ADDR_M """
+          sql"""
+                $projectLinkQueryBase
+                WHERE project_link.connected_link_id IN ($connectedIds)
+                ORDER BY PROJECT_LINK.ROAD_NUMBER, PROJECT_LINK.ROAD_PART_NUMBER, PROJECT_LINK.END_ADDR_M
+                """
         listQuery(query)
       }
     }
@@ -537,8 +710,11 @@ class ProjectLinkDAO extends BaseDAO {
   def getProjectLinksByLinkId(linkId: String): Seq[ProjectLink] = {
     time(logger, "Get project links by link id and project id") {
       val query =
-        s"""$projectLinkQueryBase
-                where PROJECT_LINK.link_id = '$linkId' order by PROJECT_LINK.ROAD_NUMBER, PROJECT_LINK.ROAD_PART_NUMBER, PROJECT_LINK.END_ADDR_M """
+        sql"""
+            $projectLinkQueryBase
+            WHERE PROJECT_LINK.link_id = $linkId
+            ORDER BY PROJECT_LINK.ROAD_NUMBER, PROJECT_LINK.ROAD_PART_NUMBER, PROJECT_LINK.END_ADDR_M
+            """
       listQuery(query)
     }
   }
@@ -546,8 +722,11 @@ class ProjectLinkDAO extends BaseDAO {
   def getOtherProjectLinks(projectId: Long): Seq[ProjectLink] = {
     time(logger, "Get project links all") {
       val query =
-        s"""$projectLinkQueryBase
-                where PROJECT_LINK.project_id <> $projectId order by PROJECT_LINK.ROAD_NUMBER, PROJECT_LINK.ROAD_PART_NUMBER, PROJECT_LINK.END_ADDR_M """
+        sql"""
+            $projectLinkQueryBase
+            WHERE PROJECT_LINK.project_id <> $projectId
+            ORDER BY PROJECT_LINK.ROAD_NUMBER, PROJECT_LINK.ROAD_PART_NUMBER, PROJECT_LINK.END_ADDR_M
+            """
       listQuery(query)
     }
   }
@@ -556,12 +735,14 @@ class ProjectLinkDAO extends BaseDAO {
     if (projectLinkIds.isEmpty && linkIds.isEmpty) {
       List()
     } else {
-      val idsFilter = if (projectLinkIds.nonEmpty) s"AND PROJECT_LINK.ID IN (${projectLinkIds.mkString(",")})" else ""
-      val linkIdsFilter = if (linkIds.nonEmpty) s"AND PROJECT_LINK.LINK_ID IN (${linkIds.map(l => ''' + l + ''').mkString(",")})" else ""
+      val idsFilter = if (projectLinkIds.nonEmpty) sqls"AND PROJECT_LINK.ID IN ($projectLinkIds)" else sqls""
+      val linkIdsFilter = if (linkIds.nonEmpty) sqls"AND PROJECT_LINK.LINK_ID IN ($linkIds)" else sqls""
       val query =
-        s"""$projectLinkQueryBase
-                where PROJECT_LINK.PROJECT_ID = $projectId $idsFilter $linkIdsFilter
-                order by PROJECT_LINK.ROAD_NUMBER, PROJECT_LINK.ROAD_PART_NUMBER, PROJECT_LINK.END_ADDR_M """
+        sql"""
+              $projectLinkQueryBase
+              where PROJECT_LINK.PROJECT_ID = $projectId $idsFilter $linkIdsFilter
+              order by PROJECT_LINK.ROAD_NUMBER, PROJECT_LINK.ROAD_PART_NUMBER, PROJECT_LINK.END_ADDR_M
+              """
       listQuery(query)
     }
   }
@@ -570,31 +751,41 @@ class ProjectLinkDAO extends BaseDAO {
     if (linkIds.isEmpty) {
       List()
     } else {
-      val linkIdsFilter =  s" PROJECT_LINK.LINK_ID IN (${linkIds.map(l => ''' + l + ''').mkString(",")})"
+      val linkIdsFilter =  sqls" PROJECT_LINK.LINK_ID IN ($linkIds)"
       val query =
-        s"""$projectLinkQueryBase
-                where $linkIdsFilter
-                order by PROJECT_LINK.ROAD_NUMBER, PROJECT_LINK.ROAD_PART_NUMBER, PROJECT_LINK.END_ADDR_M """
+        sql"""
+              $projectLinkQueryBase
+              WHERE $linkIdsFilter
+              ORDER BY PROJECT_LINK.ROAD_NUMBER, PROJECT_LINK.ROAD_PART_NUMBER, PROJECT_LINK.END_ADDR_M
+              """
       listQuery(query)
     }
   }
 
   def fetchProjectLinksByProjectRoadPart(roadPart: RoadPart, projectId: Long, roadAddressChangeTypeFilter: Option[RoadAddressChangeType] = None): Seq[ProjectLink] = {
     time(logger, "Get project links by project road part") {
-      val filter = if (roadAddressChangeTypeFilter.isEmpty) "" else s" PROJECT_LINK.STATUS = ${roadAddressChangeTypeFilter.get.value} AND"
+      val filter = if (roadAddressChangeTypeFilter.isEmpty) sqls"" else sqls" PROJECT_LINK.STATUS = ${roadAddressChangeTypeFilter.get.value} AND"
       val query =
-        s"""$projectLinkQueryBase
-                where $filter PROJECT_LINK.ROAD_NUMBER = ${roadPart.roadNumber} and PROJECT_LINK.ROAD_PART_NUMBER = ${roadPart.partNumber} AND PROJECT_LINK.PROJECT_ID = $projectId order by PROJECT_LINK.ROAD_NUMBER, PROJECT_LINK.ROAD_PART_NUMBER, PROJECT_LINK.END_ADDR_M """
+        sql"""
+              $projectLinkQueryBase
+              WHERE $filter PROJECT_LINK.ROAD_NUMBER = ${roadPart.roadNumber}
+              AND PROJECT_LINK.ROAD_PART_NUMBER = ${roadPart.partNumber}
+              AND PROJECT_LINK.PROJECT_ID = $projectId
+              ORDER BY PROJECT_LINK.ROAD_NUMBER, PROJECT_LINK.ROAD_PART_NUMBER, PROJECT_LINK.END_ADDR_M
+              """
       listQuery(query)
     }
   }
 
   def fetchByProjectRoadPart(roadPart: RoadPart, projectId: Long): Seq[ProjectLink] = {
     time(logger, "Fetch project links by project road part") {
-      val filter = s"PROJECT_LINK.ROAD_NUMBER = ${roadPart.roadNumber} AND PROJECT_LINK.ROAD_PART_NUMBER = ${roadPart.partNumber} AND"
+      val filter = sqls"PROJECT_LINK.ROAD_NUMBER = ${roadPart.roadNumber} AND PROJECT_LINK.ROAD_PART_NUMBER = ${roadPart.partNumber} AND"
       val query =
-        s"""$projectLinkQueryBase
-                where $filter (PROJECT_LINK.PROJECT_ID = $projectId ) order by PROJECT_LINK.ROAD_NUMBER, PROJECT_LINK.ROAD_PART_NUMBER, PROJECT_LINK.END_ADDR_M """
+        sql"""
+            $projectLinkQueryBase
+            WHERE $filter (PROJECT_LINK.PROJECT_ID = $projectId )
+            ORDER BY PROJECT_LINK.ROAD_NUMBER, PROJECT_LINK.ROAD_PART_NUMBER, PROJECT_LINK.END_ADDR_M
+            """
       listQuery(query)
     }
   }
@@ -603,33 +794,46 @@ class ProjectLinkDAO extends BaseDAO {
     time(logger, "Fetch project links by project road parts") {
       if (roadParts.isEmpty)
         return Seq()
-      val roadPartsCond = roadParts.map { case (roadPart) => s"(PROJECT_LINK.ROAD_NUMBER = ${roadPart.roadNumber} AND PROJECT_LINK.ROAD_PART_NUMBER = ${roadPart.partNumber})" }
-      val filter = s"${roadPartsCond.mkString("(", " OR ", ")")} AND"
+      // Using sqls interpolation for each condition
+      val roadPartsCond = roadParts.map { roadPart =>
+        sqls"(PROJECT_LINK.ROAD_NUMBER = ${roadPart.roadNumber} AND PROJECT_LINK.ROAD_PART_NUMBER = ${roadPart.partNumber})"
+      }
+      // Combine conditions with OR
+      val roadPartsFilter = sqls.join(roadPartsCond.toSeq, sqls" OR ")
+
       val query =
-        s"""$projectLinkQueryBase
-                where $filter (PROJECT_LINK.PROJECT_ID = $projectId) order by PROJECT_LINK.ROAD_NUMBER, PROJECT_LINK.ROAD_PART_NUMBER, PROJECT_LINK.END_ADDR_M """
+        sql"""
+              $projectLinkQueryBase
+              WHERE $roadPartsFilter
+              AND (PROJECT_LINK.PROJECT_ID = $projectId)
+              ORDER BY PROJECT_LINK.ROAD_NUMBER, PROJECT_LINK.ROAD_PART_NUMBER, PROJECT_LINK.END_ADDR_M
+              """
       listQuery(query)
     }
   }
 
   def fetchByProjectRoad(roadNumber: Long, projectId: Long): Seq[ProjectLink] = {
     time(logger, "Fetch project links by project road part") {
-      val filter = s"PROJECT_LINK.ROAD_NUMBER = $roadNumber AND"
+      val filter = sqls"PROJECT_LINK.ROAD_NUMBER = $roadNumber AND"
       val query =
-        s"""$projectLinkQueryBase
-                where $filter PROJECT_LINK.PROJECT_ID = $projectId order by PROJECT_LINK.ROAD_NUMBER, PROJECT_LINK.ROAD_PART_NUMBER, PROJECT_LINK.END_ADDR_M """
+        sql"""
+              $projectLinkQueryBase
+              WHERE $filter PROJECT_LINK.PROJECT_ID = $projectId
+              ORDER BY PROJECT_LINK.ROAD_NUMBER, PROJECT_LINK.ROAD_PART_NUMBER, PROJECT_LINK.END_ADDR_M """
       listQuery(query)
     }
   }
 
   def updateAddrMValues(projectLink: ProjectLink): Unit = {
-    runUpdateToDb(s"""
-      update project_link
-      set modified_date = current_timestamp, start_addr_m = ${projectLink.addrMRange.start}, end_addr_m = ${projectLink.addrMRange.end},
+    runUpdateToDb(
+      sql"""
+      UPDATE project_link
+      SET modified_date = current_timestamp, start_addr_m = ${projectLink.addrMRange.start}, end_addr_m = ${projectLink.addrMRange.end},
           start_calibration_point = ${projectLink.startCalibrationPointType.value},
           end_calibration_point = ${projectLink.endCalibrationPointType.value}
-      where id = ${projectLink.id}
-    """)
+      WHERE id = ${projectLink.id}
+    """
+    )
   }
 
   /**
@@ -643,10 +847,17 @@ class ProjectLinkDAO extends BaseDAO {
   def updateProjectLinkNumbering(projectId: Long, roadPart: RoadPart, roadAddressChangeType: RoadAddressChangeType, newRoadPart: RoadPart, userName: String, ely: Long ): Unit = {
     time(logger, "Update project link numbering") {
       val user = userName.replaceAll("[^A-Za-z0-9\\-]+", "")
-      val sql = s"UPDATE PROJECT_LINK SET STATUS = ${roadAddressChangeType.value}, MODIFIED_BY='$user', ROAD_NUMBER = ${newRoadPart.roadNumber}, ROAD_PART_NUMBER = ${newRoadPart.partNumber}, ELY = $ely " +
-        s"WHERE PROJECT_ID = $projectId  AND ROAD_NUMBER = ${roadPart.roadNumber} AND ROAD_PART_NUMBER = ${roadPart.partNumber} AND STATUS != ${RoadAddressChangeType.Termination.value}"
-println(sql)
-      runUpdateToDb(sql)
+      val query = sql"""
+                  UPDATE PROJECT_LINK
+                  SET STATUS = ${roadAddressChangeType.value}, MODIFIED_BY=$user, ROAD_NUMBER = ${newRoadPart.roadNumber},
+                    ROAD_PART_NUMBER = ${newRoadPart.partNumber}, ELY = $ely
+                  WHERE PROJECT_ID = $projectId
+                  AND ROAD_NUMBER = ${roadPart.roadNumber}
+                  AND ROAD_PART_NUMBER = ${roadPart.partNumber}
+                  AND STATUS != ${RoadAddressChangeType.Termination.value}
+        """
+println(query)
+      runUpdateToDb(query)
     }
   }
 
@@ -656,14 +867,20 @@ println(sql)
       if (discontinuity.isEmpty) {
         projectLinkIds.grouped(500).foreach {
           grp =>
-            val sql = s"UPDATE PROJECT_LINK SET STATUS = ${roadAddressChangeType.value}, MODIFIED_BY='$user', ADMINISTRATIVE_CLASS= $administrativeClass " +
-              s"WHERE ID IN ${grp.mkString("(", ",", ")")}"
-            runUpdateToDb(sql)
+            val query = sql"""
+                  UPDATE PROJECT_LINK
+                  SET STATUS = ${roadAddressChangeType.value}, MODIFIED_BY=$user, ADMINISTRATIVE_CLASS= $administrativeClass
+                  WHERE ID IN ($grp)
+                  """
+            runUpdateToDb(query)
         }
       } else {
-        val sql = s"UPDATE PROJECT_LINK SET STATUS = ${roadAddressChangeType.value}, MODIFIED_BY='$user', ADMINISTRATIVE_CLASS= $administrativeClass, DISCONTINUITY_TYPE = ${discontinuity.get} " +
-          s"WHERE ID = ${projectLinkIds.head}"
-        runUpdateToDb(sql)
+        val query = sql"""
+                  UPDATE PROJECT_LINK SET STATUS = ${roadAddressChangeType.value}, MODIFIED_BY = $user,
+                    ADMINISTRATIVE_CLASS = $administrativeClass, DISCONTINUITY_TYPE = ${discontinuity.get}
+                  WHERE ID = ${projectLinkIds.head}
+                  """
+        runUpdateToDb(query)
       }
     }
   }
@@ -672,46 +889,54 @@ println(sql)
     val user = userName.replaceAll("[^A-Za-z0-9\\-]+", "")
     ids.grouped(500).foreach {
       grp =>
-        val sql = s"UPDATE PROJECT_LINK SET STATUS = ${roadAddressChangeType.value}, MODIFIED_BY='$user' " +
-          s"WHERE ID IN ${grp.mkString("(", ",", ")")}"
-        runUpdateToDb(sql)
+        val query = sql"""
+                  UPDATE PROJECT_LINK SET STATUS = ${roadAddressChangeType.value}, MODIFIED_BY = $user
+                  WHERE ID IN ($grp)
+                  """
+        runUpdateToDb(query)
     }
   }
 
-  /**
-    * Applies all the values of the road addresses to the project links sharing the project id and road address information.
-    * @param projectId: Long - The id of the project
-    * @param roadAddress: RoadAddress - The road address information
-    * @param updateGeom: Boolean - controls whether we update or not the geometry of the project links
-    */
-  def updateProjectLinkValues(projectId: Long, roadAddress: RoadAddress, updateGeom : Boolean = true, plId: Option[Long] = None): Unit = {
+    /**
+      * Applies all the values of the road addresses to the project links sharing the project id and road address information.
+      * @param projectId: Long - The id of the project
+      * @param roadAddress: RoadAddress - The road address information
+      * @param updateGeom: Boolean - controls whether we update or not the geometry of the project links
+      */
+    def updateProjectLinkValues(projectId: Long, roadAddress: RoadAddress, updateGeom : Boolean = true, plId: Option[Long] = None): Unit = {
 
-    time(logger, "Update project link values") {
-      val lineString: String = PostGISDatabase.createJGeometry(roadAddress.geometry)
-      val geometryQuery = s"ST_GeomFromText('$lineString', 3067)"
-      val updateGeometry = if (updateGeom) s", GEOMETRY = $geometryQuery" else s""
-      val idFilter = plId match {
-        case Some(id) => s"AND ID = $id"
-        case None => s""
+      time(logger, "Update project link values") {
+        val lineString: String = GeometryDbUtils.createJGeometry(roadAddress.geometry)
+        // Create geometry part of the query using sqls
+        val geometryUpdate = if (updateGeom) {
+          sqls", GEOMETRY = ST_GeomFromText($lineString, 3067)"
+        } else {
+          sqls""
+        }
+        val idFilter = plId match {
+          case Some(id) => sqls"AND ID = $id"
+          case None => sqls""
+        }
+
+        val updateProjectLink = sql"""
+          UPDATE PROJECT_LINK
+          SET ROAD_NUMBER = ${roadAddress.roadPart.roadNumber},
+            ROAD_PART_NUMBER = ${roadAddress.roadPart.partNumber}, TRACK = ${roadAddress.track.value},
+            DISCONTINUITY_TYPE = ${roadAddress.discontinuity.value}, ADMINISTRATIVE_CLASS = ${roadAddress.administrativeClass.value},
+            STATUS = ${RoadAddressChangeType.NotHandled.value}, START_ADDR_M = ${roadAddress.addrMRange.start}, END_ADDR_M = ${roadAddress.addrMRange.end},
+            ORIGINAL_START_ADDR_M = ${roadAddress.addrMRange.start}, ORIGINAL_END_ADDR_M = ${roadAddress.addrMRange.end},
+            START_CALIBRATION_POINT = ${roadAddress.startCalibrationPointType.value},
+            END_CALIBRATION_POINT = ${roadAddress.endCalibrationPointType.value},
+            ORIG_START_CALIBRATION_POINT = ${roadAddress.startCalibrationPointType.value},
+            ORIG_END_CALIBRATION_POINT = ${roadAddress.endCalibrationPointType.value},
+            SIDE = ${roadAddress.sideCode.value}, ELY = ${roadAddress.ely},
+            start_measure = ${roadAddress.startMValue}, end_measure = ${roadAddress.endMValue} $geometryUpdate
+          WHERE LINEAR_LOCATION_ID = ${roadAddress.linearLocationId}
+          AND PROJECT_ID = $projectId $idFilter
+        """
+        runUpdateToDb(updateProjectLink)
       }
-
-      val updateProjectLink = s"""
-        UPDATE PROJECT_LINK SET ROAD_NUMBER = ${roadAddress.roadPart.roadNumber},
-          ROAD_PART_NUMBER = ${roadAddress.roadPart.partNumber}, TRACK = ${roadAddress.track.value},
-          DISCONTINUITY_TYPE = ${roadAddress.discontinuity.value}, ADMINISTRATIVE_CLASS = ${roadAddress.administrativeClass.value},
-          STATUS = ${RoadAddressChangeType.NotHandled.value}, START_ADDR_M = ${roadAddress.addrMRange.start}, END_ADDR_M = ${roadAddress.addrMRange.end},
-          ORIGINAL_START_ADDR_M = ${roadAddress.addrMRange.start}, ORIGINAL_END_ADDR_M = ${roadAddress.addrMRange.end},
-          START_CALIBRATION_POINT = ${roadAddress.startCalibrationPointType.value},
-          END_CALIBRATION_POINT = ${roadAddress.endCalibrationPointType.value},
-          ORIG_START_CALIBRATION_POINT = ${roadAddress.startCalibrationPointType.value},
-          ORIG_END_CALIBRATION_POINT = ${roadAddress.endCalibrationPointType.value},
-          SIDE = ${roadAddress.sideCode.value}, ELY = ${roadAddress.ely},
-          start_measure = ${roadAddress.startMValue}, end_measure = ${roadAddress.endMValue} $updateGeometry
-        WHERE LINEAR_LOCATION_ID = ${roadAddress.linearLocationId} AND PROJECT_ID = $projectId $idFilter
-      """
-      runUpdateToDb(updateProjectLink)
     }
-  }
 
   /**
    * Updates a batch of project links to their original road address values when terminating links.
@@ -722,81 +947,79 @@ println(sql)
   def batchUpdateProjectLinksToTerminate(projectLinks: Seq[ProjectLink]): Unit = {
     if (projectLinks.nonEmpty) {
       time(logger, "Batch update project links") {
-        val updatePS = dynamicSession.prepareStatement(
-          """
-        UPDATE project_link
-          SET
-            ROAD_NUMBER = ?,
-            ROAD_PART_NUMBER = ?,
-            TRACK = ?,
-            DISCONTINUITY_TYPE = ?,
-            ADMINISTRATIVE_CLASS = ?,
-            START_ADDR_M = ?,
-            END_ADDR_M = ?,
-            ORIGINAL_START_ADDR_M = ?,
-            ORIGINAL_END_ADDR_M = ?,
-            START_CALIBRATION_POINT = ?,
-            END_CALIBRATION_POINT = ?,
-            ORIG_START_CALIBRATION_POINT = ?,
-            ORIG_END_CALIBRATION_POINT = ?,
-            SIDE = ?,
-            ELY = ?,
-            START_MEASURE = ?,
-            END_MEASURE = ?,
-            STATUS = ?
-          WHERE LINEAR_LOCATION_ID = ? AND PROJECT_ID = ?
-      """)
-
-        try {
-        projectLinks.foreach { pl =>
-          updatePS.setLong(1, pl.roadPart.roadNumber)
-          updatePS.setLong(2, pl.roadPart.partNumber)
-          updatePS.setInt(3, pl.track.value)
-          updatePS.setInt(4, pl.discontinuity.value)
-          updatePS.setInt(5, pl.administrativeClass.value)
-          updatePS.setLong(6, pl.addrMRange.start)
-          updatePS.setLong(7, pl.addrMRange.end)
-          updatePS.setLong(8, pl.originalAddrMRange.start)
-          updatePS.setLong(9, pl.originalAddrMRange.end)
-          updatePS.setInt(10, pl.calibrationPointTypes._1.value)
-          updatePS.setInt(11, pl.calibrationPointTypes._2.value)
-          updatePS.setInt(12, pl.calibrationPointTypes._1.value)
-          updatePS.setInt(13, pl.calibrationPointTypes._2.value)
-          updatePS.setInt(14, pl.sideCode.value)
-          updatePS.setLong(15, pl.ely)
-          updatePS.setDouble(16, pl.startMValue)
-          updatePS.setDouble(17, pl.endMValue)
-          updatePS.setInt(18, RoadAddressChangeType.Termination.value)
-          updatePS.setLong(19, pl.linearLocationId)
-          updatePS.setLong(20, pl.projectId)
-          updatePS.addBatch()
+        val updateQuery =
+          sql"""
+            UPDATE project_link
+            SET
+              ROAD_NUMBER = ?,
+              ROAD_PART_NUMBER = ?,
+              TRACK = ?,
+              DISCONTINUITY_TYPE = ?,
+              ADMINISTRATIVE_CLASS = ?,
+              START_ADDR_M = ?,
+              END_ADDR_M = ?,
+              ORIGINAL_START_ADDR_M = ?,
+              ORIGINAL_END_ADDR_M = ?,
+              START_CALIBRATION_POINT = ?,
+              END_CALIBRATION_POINT = ?,
+              ORIG_START_CALIBRATION_POINT = ?,
+              ORIG_END_CALIBRATION_POINT = ?,
+              SIDE = ?,
+              ELY = ?,
+              START_MEASURE = ?,
+              END_MEASURE = ?,
+              STATUS = ?
+            WHERE LINEAR_LOCATION_ID = ? AND PROJECT_ID = ?
+        """
+        val batchParams = projectLinks.map { pl =>
+          Seq(
+            pl.roadPart.roadNumber,
+            pl.roadPart.partNumber,
+            pl.track.value,
+            pl.discontinuity.value,
+            pl.administrativeClass.value,
+            pl.addrMRange.start,
+            pl.addrMRange.end,
+            pl.originalAddrMRange.start,
+            pl.originalAddrMRange.end,
+            pl.calibrationPointTypes._1.value,
+            pl.calibrationPointTypes._2.value,
+            pl.calibrationPointTypes._1.value,
+            pl.calibrationPointTypes._2.value,
+            pl.sideCode.value,
+            pl.ely,
+            pl.startMValue,
+            pl.endMValue,
+            RoadAddressChangeType.Termination.value,
+            pl.linearLocationId,
+            pl.projectId
+          )
         }
 
-          val updateCounts = updatePS.executeBatch()
-          // Check if any updates were made
-          val updatesMade = updateCounts.exists(count => count > 0)
-          if (!updatesMade) {
-            logger.warn("No rows were updated during the batch update operation.")
-          }
-        } catch {
-          case e: SQLException => logger.error("SQL Exception encountered: ", e)
-        } finally {
-          updatePS.close()
+        val updateCounts = runBatchUpdateToDb(updateQuery, batchParams)
+        // Check if any updates were made
+        val updatesMade = updateCounts.exists(count => count > 0)
+        if (!updatesMade) {
+          logger.warn("No rows were updated during the batch update operation.")
         }
+        updateCounts
       }
     }
   }
 
+
+
+
   def updateProjectLinkGeometry(projectLinkId: Long, geometry: Seq[Point]): Unit = {
-    val geometryString = PostGISDatabase.createJGeometry(geometry)
-    val sql = s"""
-    UPDATE project_link
-    SET modified_date = current_timestamp, geometry = ST_GeomFromText('$geometryString', 3067), connected_link_id = NULL
-    WHERE id = $projectLinkId
-  """
+    val geometryString = GeometryDbUtils.createJGeometry(geometry)
+    val query = sql"""
+                UPDATE project_link
+                SET modified_date = current_timestamp, geometry = ST_GeomFromText('$geometryString', 3067), connected_link_id = NULL
+                WHERE id = $projectLinkId
+                """
 
     try {
-      val updateCount = runUpdateToDb(sql)
+      val updateCount = runUpdateToDb(query)
       if (updateCount == 0) {
         logger.warn(s"No records were updated for projectLinkId: $projectLinkId")
       } else {
@@ -809,6 +1032,7 @@ println(sql)
         logger.error(s"Unexpected exception occurred while updating geometry for projectLinkId: $projectLinkId", e)
     }
   }
+
   /**
     * Reverses the given road part in project. Switches side codes 2 <-> 3, updates calibration points start <-> end,
     * updates track codes 1 <-> 2
@@ -818,21 +1042,27 @@ println(sql)
     */
   def reverseRoadPartDirection(projectId: Long, roadPart: RoadPart): Unit = {
     time(logger, "Reverse road part direction") {
-      val roadPartMaxAddr =
-        sql"""SELECT MAX(END_ADDR_M) FROM PROJECT_LINK
-         where project_link.project_id = $projectId and project_link.road_number = ${roadPart.roadNumber} and project_link.road_part_number = ${roadPart.partNumber}
-         and project_link.status != ${RoadAddressChangeType.Termination.value}
-         """.as[Long].firstOption.getOrElse(0L)
-      val updateProjectLink = s"""
-        update project_link
-        set start_calibration_point = end_calibration_point, end_calibration_point = start_calibration_point,
-          orig_start_calibration_point = orig_end_calibration_point, orig_end_calibration_point = orig_start_calibration_point,
-          (start_addr_m, end_addr_m) = (SELECT $roadPartMaxAddr - pl2.end_addr_m, $roadPartMaxAddr - pl2.start_addr_m FROM PROJECT_LINK pl2 WHERE pl2.id = project_link.id),
-          TRACK = (CASE TRACK WHEN ${Track.Combined.value} THEN ${Track.Combined.value} WHEN ${Track.RightSide.value} THEN ${Track.LeftSide.value} WHEN ${Track.LeftSide.value} THEN ${Track.RightSide.value} ELSE ${Track.Unknown.value} END),
-          SIDE = (CASE SIDE WHEN ${SideCode.TowardsDigitizing.value} THEN ${SideCode.AgainstDigitizing.value} ELSE ${SideCode.TowardsDigitizing.value} END),
-          reversed = (CASE WHEN reversed = 0 AND status != ${RoadAddressChangeType.New.value} THEN 1 WHEN reversed = 1 AND status != ${RoadAddressChangeType.New.value} THEN 0 ELSE 0 END)
-        where project_link.project_id = $projectId and project_link.road_number = ${roadPart.roadNumber} and project_link.road_part_number = ${roadPart.partNumber}
-          and project_link.status != ${RoadAddressChangeType.Termination.value}"""
+      val maxAddrQuery =
+        sql"""
+              SELECT MAX(END_ADDR_M) FROM PROJECT_LINK
+              where project_link.project_id = $projectId and project_link.road_number = ${roadPart.roadNumber} and project_link.road_part_number = ${roadPart.partNumber}
+              and project_link.status != ${RoadAddressChangeType.Termination.value}
+              """
+
+      val roadPartMaxAddr = runSelectSingleFirstOptionWithType[Long](maxAddrQuery).getOrElse(0L)
+
+      val updateProjectLink =
+        sql"""
+          UPDATE project_link
+          SET start_calibration_point = end_calibration_point, end_calibration_point = start_calibration_point,
+            orig_start_calibration_point = orig_end_calibration_point, orig_end_calibration_point = orig_start_calibration_point,
+            (start_addr_m, end_addr_m) = (SELECT $roadPartMaxAddr - pl2.end_addr_m, $roadPartMaxAddr - pl2.start_addr_m FROM PROJECT_LINK pl2 WHERE pl2.id = project_link.id),
+            TRACK = (CASE TRACK WHEN ${Track.Combined.value} THEN ${Track.Combined.value} WHEN ${Track.RightSide.value} THEN ${Track.LeftSide.value} WHEN ${Track.LeftSide.value} THEN ${Track.RightSide.value} ELSE ${Track.Unknown.value} END),
+            SIDE = (CASE SIDE WHEN ${SideCode.TowardsDigitizing.value} THEN ${SideCode.AgainstDigitizing.value} ELSE ${SideCode.TowardsDigitizing.value} END),
+            reversed = (CASE WHEN reversed = 0 AND status != ${RoadAddressChangeType.New.value} THEN 1 WHEN reversed = 1 AND status != ${RoadAddressChangeType.New.value} THEN 0 ELSE 0 END)
+          WHERE project_link.project_id = $projectId and project_link.road_number = ${roadPart.roadNumber} and project_link.road_part_number = ${roadPart.partNumber}
+          AND project_link.status != ${RoadAddressChangeType.Termination.value}
+          """
       runUpdateToDb(updateProjectLink)
     }
   }
@@ -845,32 +1075,48 @@ println(sql)
     * @return
     */
   def countLinksByStatus(projectId: Long, roadPart: RoadPart, roadAddressChangeTypes: Set[Long]): Long = {
-    val filterByStatus = if(roadAddressChangeTypes.nonEmpty) s" AND Status IN (${roadAddressChangeTypes.mkString(",")})" else ""
+    val filterByStatus = if(roadAddressChangeTypes.nonEmpty) sqls" AND Status IN ($roadAddressChangeTypes)" else sqls""
     val query =
-      s"""select count(id) from project_link
-          WHERE project_id = $projectId and road_number = ${roadPart.roadNumber} and road_part_number = ${roadPart.partNumber} $filterByStatus"""
-    Q.queryNA[Long](query).first
+      sql"""
+          SELECT count(id)
+          FROM project_link
+          WHERE project_id = $projectId
+          AND road_number = ${roadPart.roadNumber}
+          AND road_part_number = ${roadPart.partNumber} $filterByStatus
+          """
+    runSelectSingleFirstOptionWithType[Long](query).getOrElse(
+      throw new NoSuchElementException(s"No project links found for project $projectId, road number ${roadPart.roadNumber} and road part number ${roadPart.partNumber}")
+    )
   }
 
   def getProjectLinksContinuityCodes(projectId: Long, roadPart: RoadPart): Map[Long, Discontinuity] = {
-    sql""" SELECT END_ADDR_M, DISCONTINUITY_TYPE FROM PROJECT_LINK WHERE PROJECT_ID = $projectId AND
-         ROAD_NUMBER = ${roadPart.roadNumber} AND ROAD_PART_NUMBER = ${roadPart.partNumber} AND STATUS != ${RoadAddressChangeType.Termination.value}
-         AND (DISCONTINUITY_TYPE != ${Discontinuity.Continuous.value} OR END_ADDR_M =
-         (SELECT MAX(END_ADDR_M) FROM PROJECT_LINK WHERE PROJECT_ID = $projectId AND
+    val query =
+      sql"""
+          SELECT END_ADDR_M, DISCONTINUITY_TYPE FROM PROJECT_LINK WHERE PROJECT_ID = $projectId AND
+          ROAD_NUMBER = ${roadPart.roadNumber} AND ROAD_PART_NUMBER = ${roadPart.partNumber} AND STATUS != ${RoadAddressChangeType.Termination.value}
+          AND (DISCONTINUITY_TYPE != ${Discontinuity.Continuous.value} OR END_ADDR_M =
+          (SELECT MAX(END_ADDR_M) FROM PROJECT_LINK WHERE PROJECT_ID = $projectId AND
            ROAD_NUMBER = ${roadPart.roadNumber} AND ROAD_PART_NUMBER = ${roadPart.partNumber} AND STATUS != ${RoadAddressChangeType.Termination.value}))
-       """.as[(Long, Int)].list.map(x => x._1 -> Discontinuity.apply(x._2)).toMap
+       """
+    runSelectQuery(query.map(rs => (rs.long("END_ADDR_M"), rs.int("DISCONTINUITY_TYPE"))))
+      .map(x => x._1 -> Discontinuity.apply(x._2))
+      .toMap
   }
 
   def fetchFirstLink(projectId: Long, roadPart: RoadPart): Option[ProjectLink] = {
-    val query = s"""$projectLinkQueryBase
-    where PROJECT_LINK.ROAD_PART_NUMBER=${roadPart.partNumber} AND PROJECT_LINK.ROAD_NUMBER=${roadPart.roadNumber} AND
-    PROJECT_LINK.START_ADDR_M = (SELECT MIN(PROJECT_LINK.START_ADDR_M) FROM PROJECT_LINK
-      LEFT JOIN
-      ROADWAY ON ((ROADWAY.road_number = PROJECT_LINK.road_number AND ROADWAY.road_part_number = PROJECT_LINK.road_part_number) OR ROADWAY.id = PROJECT_LINK.ROADWAY_ID)
-      LEFT JOIN
-      Linear_Location ON (Linear_Location.id = Project_Link.Linear_Location_Id)
-      WHERE PROJECT_LINK.PROJECT_ID = $projectId AND ((PROJECT_LINK.ROAD_PART_NUMBER=${roadPart.partNumber} AND PROJECT_LINK.ROAD_NUMBER=${roadPart.roadNumber}) OR PROJECT_LINK.ROADWAY_ID = ROADWAY.ID))
-    order by PROJECT_LINK.ROAD_NUMBER, PROJECT_LINK.ROAD_PART_NUMBER, PROJECT_LINK.START_ADDR_M, PROJECT_LINK.TRACK """
+    val query =
+      sql"""
+          $projectLinkQueryBase
+          WHERE PROJECT_LINK.ROAD_PART_NUMBER=${roadPart.partNumber}
+          AND PROJECT_LINK.ROAD_NUMBER=${roadPart.roadNumber}
+          AND PROJECT_LINK.START_ADDR_M = (SELECT MIN(PROJECT_LINK.START_ADDR_M) FROM PROJECT_LINK
+          LEFT JOIN
+          ROADWAY ON ((ROADWAY.road_number = PROJECT_LINK.road_number AND ROADWAY.road_part_number = PROJECT_LINK.road_part_number) OR ROADWAY.id = PROJECT_LINK.ROADWAY_ID)
+          LEFT JOIN
+          Linear_Location ON (Linear_Location.id = Project_Link.Linear_Location_Id)
+          WHERE PROJECT_LINK.PROJECT_ID = $projectId AND ((PROJECT_LINK.ROAD_PART_NUMBER=${roadPart.partNumber} AND PROJECT_LINK.ROAD_NUMBER=${roadPart.roadNumber}) OR PROJECT_LINK.ROADWAY_ID = ROADWAY.ID))
+          ORDER BY PROJECT_LINK.ROAD_NUMBER, PROJECT_LINK.ROAD_PART_NUMBER, PROJECT_LINK.START_ADDR_M, PROJECT_LINK.TRACK
+          """
     listQuery(query).headOption
   }
 
@@ -879,8 +1125,9 @@ println(sql)
       ids.grouped(900).map(deleteProjectLinks).sum
     else {
       val deleteLinks =
-        s"""
-         DELETE FROM PROJECT_LINK WHERE id IN (${ids.mkString(",")})
+        sql"""
+         DELETE FROM PROJECT_LINK
+         WHERE id IN ($ids)
        """
       val count = runUpdateToDb(deleteLinks)
       count
@@ -903,19 +1150,38 @@ println(sql)
   }
 
   private def removeProjectLinks(projectId: Long, roadPart: Option[RoadPart], linkIds: Set[String] = Set()) = {
-    val roadPartFilter = roadPart.map(l => s"AND road_number = ${l.roadNumber} AND road_part_number = ${l.partNumber}").getOrElse("")
+    val roadPartFilter = roadPart.map(l =>
+      sqls"AND road_number = ${l.roadNumber} AND road_part_number = ${l.partNumber}"
+    ).getOrElse(sqls"")
+
     val linkIdFilter = if (linkIds.isEmpty) {
-      ""
+      sqls""
     } else {
-      s"AND LINK_ID IN (${linkIds.map(l => ''' + l + ''').mkString(",")})"
+      sqls"AND LINK_ID IN ($linkIds)"
     }
-    val query =
-      s"""SELECT pl.id FROM PROJECT_LINK pl WHERE
-        project_id = $projectId $roadPartFilter $linkIdFilter"""
-    val ids = Q.queryNA[Long](query).iterator.toSet
+
+    val query = sql"""
+            SELECT pl.id
+            FROM PROJECT_LINK pl
+            WHERE project_id = $projectId
+            $roadPartFilter
+            $linkIdFilter
+            """
+    val ids = runSelectQuery(query.map(rs => rs.long("id"))).toSet
+
     if (ids.nonEmpty) {
-      runUpdateToDb(s"""DELETE FROM ROADWAY_CHANGES_LINK WHERE PROJECT_ID = $projectId""")
-      runUpdateToDb(s"""DELETE FROM ROADWAY_CHANGES WHERE PROJECT_ID = $projectId""")
+      runUpdateToDb(
+        sql"""
+             DELETE FROM ROADWAY_CHANGES_LINK
+             WHERE PROJECT_ID = $projectId
+             """
+      )
+      runUpdateToDb(
+        sql"""
+             DELETE FROM ROADWAY_CHANGES
+             WHERE PROJECT_ID = $projectId
+             """
+      )
       deleteProjectLinks(ids)
     }
     else
@@ -923,14 +1189,14 @@ println(sql)
   }
 
   def removeConnectedLinkId(originalLink: ProjectLink): Unit = {
-    val sql = s"""
+    val query = sql"""
       UPDATE project_link
       SET connected_link_id = NULL
       WHERE id = ${originalLink.id}
     """
 
     try {
-      runUpdateToDb(sql)
+      runUpdateToDb(query)
       logger.info(s"Removed connected_link_id for projectLinkId: ${originalLink.id}")
     } catch {
       case e: SQLException =>
@@ -964,7 +1230,7 @@ println(sql)
   }
 
   def moveProjectLinksToHistory(projectId: Long): Unit = {
-    runUpdateToDb(s"""
+    runUpdateToDb(sql"""
       INSERT INTO PROJECT_LINK_HISTORY (ID, PROJECT_ID, TRACK, DISCONTINUITY_TYPE,
         ROAD_NUMBER, ROAD_PART_NUMBER, START_ADDR_M, END_ADDR_M, CREATED_BY, MODIFIED_BY, CREATED_DATE,
         MODIFIED_DATE, STATUS, START_CALIBRATION_POINT, END_CALIBRATION_POINT,
@@ -977,11 +1243,27 @@ println(sql)
           ORIG_START_CALIBRATION_POINT, ORIG_END_CALIBRATION_POINT, ADMINISTRATIVE_CLASS, ROADWAY_ID, LINEAR_LOCATION_ID,
           CONNECTED_LINK_ID, ELY, REVERSED, SIDE, START_MEASURE, END_MEASURE, LINK_ID, ADJUSTED_TIMESTAMP,
           LINK_SOURCE, GEOMETRY, ORIGINAL_START_ADDR_M, ORIGINAL_END_ADDR_M, ROADWAY_NUMBER
-        FROM PROJECT_LINK WHERE PROJECT_ID = $projectId)
+        FROM PROJECT_LINK
+        WHERE PROJECT_ID = $projectId)
     """)
-    runUpdateToDb(s"""DELETE FROM ROADWAY_CHANGES_LINK WHERE PROJECT_ID = $projectId""")
-    runUpdateToDb(s"""DELETE FROM PROJECT_LINK WHERE PROJECT_ID = $projectId""")
-    runUpdateToDb(s"""DELETE FROM PROJECT_RESERVED_ROAD_PART WHERE PROJECT_ID = $projectId""")
+    runUpdateToDb(
+      sql"""
+           DELETE FROM ROADWAY_CHANGES_LINK
+           WHERE PROJECT_ID = $projectId
+           """
+    )
+    runUpdateToDb(
+      sql"""
+           DELETE FROM PROJECT_LINK
+           WHERE PROJECT_ID = $projectId
+           """
+    )
+    runUpdateToDb(
+      sql"""
+           DELETE FROM PROJECT_RESERVED_ROAD_PART
+           WHERE PROJECT_ID = $projectId
+           """
+    )
   }
 
   //TODO used only from Spec
@@ -1002,23 +1284,25 @@ println(sql)
 
   def fetchSplitLinks(projectId: Long, linkId: String): Seq[ProjectLink] = {
     val query =
-      s"""$projectLinkQueryBase
-                where PROJECT_LINK.PROJECT_ID = $projectId AND (PROJECT_LINK.LINK_ID = '$linkId' OR PROJECT_LINK.CONNECTED_LINK_ID = '$linkId')"""
+      sql"""
+            $projectLinkQueryBase
+            WHERE PROJECT_LINK.PROJECT_ID = $projectId
+            AND (PROJECT_LINK.LINK_ID = $linkId
+            OR PROJECT_LINK.CONNECTED_LINK_ID = $linkId)
+            """
     listQuery(query)
   }
 
   def fetchProjectLinkElys(projectId: Long): Seq[Long] = {
     time(logger, "Get elys from project links.") {
       val query =
-        s"""SELECT DISTINCT ELY FROM PROJECT_LINK
-                where PROJECT_ID = $projectId """
-      Q.queryNA[Long](query).list.sorted
+        sql"""
+              SELECT DISTINCT ELY
+              FROM PROJECT_LINK
+              WHERE PROJECT_ID = $projectId
+              """
+      runSelectQuery(query.map(rs => rs.long("ELY"))).sorted
     }
   }
 
-  implicit val getDiscontinuity: GetResult[Option[Discontinuity]] = new GetResult[Option[Discontinuity]] {
-    def apply(r: PositionedResult): Option[Discontinuity] = {
-      r.nextLongOption().map(l => Discontinuity.apply(l))
-    }
-  }
 }

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/ProjectLinkNameDAOSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/ProjectLinkNameDAOSpec.scala
@@ -47,40 +47,45 @@ class ProjectLinkNameDAOSpec extends AnyFunSuite with Matchers with BeforeAndAft
   val mockLinearLocationDAO = MockitoSugar.mock[LinearLocationDAO]
   val mockRoadwayChangesDAO = MockitoSugar.mock[RoadwayChangesDAO]
 
-  val roadAddressServiceRealRoadwayAddressMapper = new RoadAddressService(mockRoadLinkService,
-                                                                          roadwayDAO,
-                                                                          linearLocationDAO,
-                                                                          roadNetworkDAO,
-                                                                          roadwayPointDAO,
-                                                                          nodePointDAO,
-                                                                          junctionPointDAO,
-                                                                          roadwayAddressMapper,
-                                                                          mockEventBus,
-                                                                          frozenKGV = false) {
-
+  val roadAddressServiceRealRoadwayAddressMapper = new RoadAddressService(
+    mockRoadLinkService,
+    roadwayDAO,
+    linearLocationDAO,
+    roadNetworkDAO,
+    roadwayPointDAO,
+    nodePointDAO,
+    junctionPointDAO,
+    roadwayAddressMapper,
+    mockEventBus,
+    frozenKGV = false
+  ) {
     override def runWithReadOnlySession[T](f: => T): T = f
+
     override def runWithTransaction[T](f: => T): T = f
   }
 
-  val projectService = new ProjectService(roadAddressServiceRealRoadwayAddressMapper,
-                                          mockRoadLinkService,
-                                          mockNodesAndJunctionsService,
-                                          roadwayDAO,
-                                          roadwayPointDAO,
-                                          linearLocationDAO,
-                                          projectDAO,
-                                          projectLinkDAO,
-                                          nodeDAO,
-                                          nodePointDAO,
-                                          junctionPointDAO,
-                                          projectReservedPartDAO,
-                                          roadwayChangesDAO,
-                                          roadwayAddressMapper,
-                                          mockEventBus) {
-                                            override def runWithReadOnlySession[T](f: => T): T = f
-                                            override def runWithTransaction[T](f: => T): T = f
-                                            override def runWithFutureTransaction[T](f: => T): Future[T] = Future.successful(f)
-                                          }
+  val projectService = new ProjectService(
+    roadAddressServiceRealRoadwayAddressMapper,
+    mockRoadLinkService,
+    mockNodesAndJunctionsService,
+    roadwayDAO,
+    roadwayPointDAO,
+    linearLocationDAO,
+    projectDAO,
+    projectLinkDAO,
+    nodeDAO,
+    nodePointDAO,
+    junctionPointDAO,
+    projectReservedPartDAO,
+    roadwayChangesDAO,
+    roadwayAddressMapper,
+    mockEventBus) {
+    override def runWithReadOnlySession[T](f: => T): T = f
+
+    override def runWithTransaction[T](f: => T): T = f
+
+    override def runWithFutureTransaction[T](f: => T): Future[T] = Future.successful(f)
+  }
 
   test("Test setProjectRoadName When there is no road/projectlink name and given one new road name Then save should be successful") {
     runWithRollback {

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/CalibrationPointDAOSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/CalibrationPointDAOSpec.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.viite.dao
 
 import fi.liikennevirasto.viite.NewIdValue
 import fi.vaylavirasto.viite.model.{CalibrationPoint, CalibrationPointLocation, CalibrationPointType}
-import fi.vaylavirasto.viite.postgis.PostGISDatabase.runWithRollback
+import fi.vaylavirasto.viite.postgis.PostGISDatabaseScalikeJDBC.runWithRollback
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/ProjectLinkDAOSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/dao/ProjectLinkDAOSpec.scala
@@ -6,8 +6,8 @@ import fi.liikennevirasto.viite.NewIdValue
 import fi.vaylavirasto.viite.dao.Sequences
 import fi.vaylavirasto.viite.geometry.{GeometryUtils, Point, Vector3d}
 import fi.vaylavirasto.viite.model.CalibrationPointType.{NoCP, RoadAddressCP}
-import fi.vaylavirasto.viite.model.{AddrMRange, AdministrativeClass, Discontinuity, LinkGeomSource, RoadAddressChangeType, RoadPart, SideCode, Track}
-import fi.vaylavirasto.viite.postgis.PostGISDatabase.runWithRollback
+import fi.vaylavirasto.viite.model.{AddrMRange, AdministrativeClass, CalibrationPointType, Discontinuity, LinkGeomSource, RoadAddressChangeType, RoadPart, SideCode, Track}
+import fi.vaylavirasto.viite.postgis.PostGISDatabaseScalikeJDBC.runWithRollback
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers.contains
 import org.mockito.Mockito.verify


### PR DESCRIPTION
- Modified PingAPI and -DAO to use ScalikeJDBC, added test to test the ping
- Modified ComplementaryLinkDAO, MunicipalityDAO, LinkDAO, ProjectLinkDAO and their Spec files to use ScalikeJDBC
- Modified getUser in PostGISUserProvider to return Option as it should
- Modified PostGISUserProviderSpec to use ScalikeJDBC
- RoadLinkService and -Spec to use ScalikeJDBC and removed all methods without use

BaseDAO: 
- Added Select method to return first result
- Added implicit val dateTimeMapper

