### PR TITLE
VIITE-3094/VIITE-3330 data fixture scalike jdbc migration

### DIFF
--- a/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/dao/MunicipalityDAO.scala
+++ b/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/dao/MunicipalityDAO.scala
@@ -7,6 +7,16 @@ import scalikejdbc._
   */
 object MunicipalityDAO extends BaseDAO {
 
+  def fetchMunicipalityIds: Seq[Int] = {
+    sql"""
+         SELECT id
+         FROM municipality
+         """
+      .map(_.int(1))
+      .list()
+      .apply()
+  }
+
   /** Digiroad's municipality to ELY code mapping.
    * Database ely_nro field naming is from the era when Viite was still part of the Digiroad codebase.
    * For Viite ELY codes, see @getViiteMunicipalityToElyMapping

--- a/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/dao/queries.scala
+++ b/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/dao/queries.scala
@@ -73,8 +73,4 @@ object Queries {
     sql"""SELECT nextval('linear_location_seq') FROM generate_series(1, $len)""".map(_.long(1))
   }
 
-  def fetchMunicipalityIds: SQL[Int, HasExtractor] = {
-    sql"SELECT id FROM municipality".map(_.int(1))
-  }
-
 }


### PR DESCRIPTION
DataFixture migration:
- DataFixture now uses ScalikeJDBC
- runUpdateToDbSlick is now defined in DataImporter as it is the only part of the app that uses the Slick version
- Municipality ids are now fetched from MunicipalityDAO instead of queries.scala as they are not new sequences

NodeDAO cleanup:
- Removed unused table alias
- expireById return type changed to Int instead of Unit
- Removed unused fetchId method