### PR TITLE
VIITE-3094/VIITE-3337: Update Scalike to use BoneCp properties

### DIFF
--- a/viite-backend/conf/env.properties
+++ b/viite-backend/conf/env.properties
@@ -26,8 +26,3 @@ awsConnectionEnabled=false
 apiS3ObjectTTLSeconds=300
 kgvEndpoint=https://api.vaylapilvi.fi/paikkatiedot/ogc/features/v1/collections
 kgvApiKey=
-
-# ScalikeJDBC Configuration
-scalikejdbc.jdbc.url=jdbc:postgresql://localhost:5432/viite
-scalikejdbc.jdbc.user=viite
-scalikejdbc.jdbc.password=viite

--- a/viite-backend/database/src/main/scala/fi/liikennevirasto/digiroad2/util/ViiteProperties.scala
+++ b/viite-backend/database/src/main/scala/fi/liikennevirasto/digiroad2/util/ViiteProperties.scala
@@ -36,11 +36,6 @@ trait ViiteProperties {
 
   def getAuthenticationBasicUsername(baseAuth: String = ""): String
   def getAuthenticationBasicPassword(baseAuth: String = ""): String
-
-  // ScalikeJDBC properties
-  val scalikeJdbcUrl: String
-  val scalikeJdbcUser: String
-  val scalikeJdbcPassword: String
 }
 
 class ViitePropertiesFromEnv extends ViiteProperties {
@@ -82,10 +77,6 @@ class ViitePropertiesFromEnv extends ViiteProperties {
   val dynamicLinkNetworkS3BucketName: String = scala.util.Properties.envOrElse("dynamicLinkNetworkS3BucketName", null)
   val awsConnectionEnabled: Boolean = scala.util.Properties.envOrElse("awsConnectionEnabled", "true").toBoolean
   val apiS3ObjectTTLSeconds: String = scala.util.Properties.envOrElse("apiS3ObjectTTLSeconds", null)
-  // ScalikeJDBC property implementations
-  val scalikeJdbcUrl: String = scala.util.Properties.envOrElse("scalikejdbc.jdbc.url", null)
-  val scalikeJdbcUser: String = scala.util.Properties.envOrElse("scalikejdbc.jdbc.user", null)
-  val scalikeJdbcPassword: String = scala.util.Properties.envOrElse("scalikejdbc.jdbc.password", null)
 
   lazy val bonecpProperties: Properties = {
     val props = new Properties()
@@ -163,10 +154,6 @@ class ViitePropertiesFromFile extends ViiteProperties {
   override val dynamicLinkNetworkS3BucketName: String = scala.util.Properties.envOrElse("dynamicLinkNetworkS3BucketName", envProps.getProperty("dynamicLinkNetworkS3BucketName"))
   override val awsConnectionEnabled: Boolean = envProps.getProperty("awsConnectionEnabled", "true").toBoolean
   override val apiS3ObjectTTLSeconds: String = scala.util.Properties.envOrElse("apiS3ObjectTTLSeconds", envProps.getProperty("apiS3ObjectTTLSeconds"))
-  // ScalikeJDBC
-  override val scalikeJdbcUrl: String = scala.util.Properties.envOrElse("scalikeJdbcUrl", envProps.getProperty("scalikejdbc.jdbc.url"))
-  override val scalikeJdbcUser: String = scala.util.Properties.envOrElse("scalikeJdbcUser", envProps.getProperty("scalikejdbc.jdbc.user"))
-  override val scalikeJdbcPassword: String = scala.util.Properties.envOrElse("scalikeJdbcPassword", envProps.getProperty("scalikejdbc.jdbc.password"))
 
   override lazy val bonecpProperties: Properties = {
     val props = new Properties()
@@ -243,12 +230,6 @@ object ViiteProperties {
   lazy val dynamicLinkNetworkS3BucketName: String = properties.dynamicLinkNetworkS3BucketName
   lazy val awsConnectionEnabled: Boolean = properties.awsConnectionEnabled
   lazy val apiS3ObjectTTLSeconds: String = properties.apiS3ObjectTTLSeconds
-
-  // Scalike properties
-  lazy val scalikeJdbcUrl: String = properties.scalikeJdbcUrl
-  lazy val scalikeJdbcUser: String = properties.scalikeJdbcUser
-  lazy val scalikeJdbcPassword: String = properties.scalikeJdbcPassword
-
 
   def getAuthenticationBasicUsername(baseAuth: String = ""): String = properties.getAuthenticationBasicUsername(baseAuth)
   def getAuthenticationBasicPassword(baseAuth: String = ""): String = properties.getAuthenticationBasicPassword(baseAuth)

--- a/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/postgis/PostGISDatabaseScalikeJDBC.scala
+++ b/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/postgis/PostGISDatabaseScalikeJDBC.scala
@@ -11,9 +11,9 @@ object PostGISDatabaseScalikeJDBC {
 
   // Initialize the connection pool with default settings
   ConnectionPool.singleton(
-    url = ViiteProperties.scalikeJdbcUrl,
-    user = ViiteProperties.scalikeJdbcUser,
-    password = ViiteProperties.scalikeJdbcPassword
+    url = ViiteProperties.bonecpJdbcUrl,
+    user = ViiteProperties.bonecpUsername,
+    password = ViiteProperties.bonecpPassword
   )
 
   // Logging for queries


### PR DESCRIPTION
Update Scalike to use BoneCp properties so it can be published to Postgis 