### PR TITLE
VIITE-3346: fix to load nodes and junctions to map correctly

### DIFF
--- a/viite-UI/src/view/NodeSearchForm.js
+++ b/viite-UI/src/view/NodeSearchForm.js
@@ -206,9 +206,11 @@
         });
 
         rootElement.on('click', '.junction-template-link', function (event) {
-          // Using window.location.hash with preventDefault instead of eventbus.trigger
-          // to Prevent double event triggering from both click and URL change
+          // Prevent default link behavior to avoid page reload
           event.preventDefault();
+          // Trigger event to handle junction template click
+          eventbus.trigger('nodeSearchTool:clickJunctionTemplate', event.currentTarget.id);
+          // Update url hash to match clicked template
           window.location.hash = `node/junctionTemplate/${event.currentTarget.id}`;
         });
       });


### PR DESCRIPTION
- node:fetched event handler is added back to its own event listener to handle the fetched node data separately. 
- The moveToLocation function now waits for the node:fetched event to be triggered and resolves the promise with the fetched data. 
- This ensures that node:fetched triggers correctly  also with fetchedNodes function to load all nodes and junctions, not just the selected ones