### PR TITLE
VIITE-3346 nodes and junction wont update when map is moved fix to nextRelease

### DIFF
--- a/viite-UI/src/model/NodeCollection.js
+++ b/viite-UI/src/model/NodeCollection.js
@@ -96,55 +96,62 @@
         });
 
         // Fetch node data for the selected location
-        await new Promise((resolve) => {
-          eventbus.once('node:fetched', (fetchedNodesAndJunctions) => {
-            // Handle fetched node data once received
-            if (fetchedNodesAndJunctions && (fetchedNodesAndJunctions.junctionTemplates || fetchedNodesAndJunctions.nodePointTemplates)) {
-              const referencePoint = {
-                // Calculate reference point for template filtering
-                x: parseFloat(result.lon.toFixed(3)),
-                y: parseFloat(result.lat.toFixed(3))
-              };
-
-              const templates = {
-                nodePoints: fetchedNodesAndJunctions.nodePointTemplates,
-                junctions: fetchedNodesAndJunctions.junctionTemplates
-              };
-
-              // Update data in nodeCollection
-              me.setNodes(fetchedNodesAndJunctions.nodes);
-              me.setMapTemplates(templates);
-
-              // Open template form with filtered data matching reference point
-              eventbus.trigger('selectedNodesAndJunctions:openTemplates', {
-                nodePoints: _.filter(templates.nodePoints, function (nodePoint) {
-                  return _.isEqual(nodePoint.coordinates, referencePoint);
-                }),
-                junctions: _.filter(templates.junctions, function (junction) {
-                  return _.some(junction.junctionPoints, function (junctionPoint) {
-                    return _.isEqual(junctionPoint.coordinates, referencePoint);
-                  });
-                })
-              });
-
-              // Update map with new node data
-              eventbus.trigger('node:addNodesToMap', fetchedNodesAndJunctions.nodes, {
-                nodePoints: fetchedNodesAndJunctions.nodePointTemplates,
-                junctions: fetchedNodesAndJunctions.junctionTemplates
-              }, zoomlevels.minZoomForJunctions);
-            }
-            resolve(fetchedNodesAndJunctions);
-          });
-          // Trigger node data fetch for the selected location
-          eventbus.trigger('nodeLayer:fetch');
+        const fetchedNodesAndJunctions = await new Promise((resolve) => {
+          eventbus.trigger('nodeLayer:fetch', resolve);
         });
+
+        if (fetchedNodesAndJunctions && (fetchedNodesAndJunctions.junctionTemplates || fetchedNodesAndJunctions.nodePointTemplates)) {
+          const referencePoint = {
+            // Calculate reference point for template filtering
+            x: parseFloat(result.lon.toFixed(3)),
+            y: parseFloat(result.lat.toFixed(3))
+          };
+
+          const templates = {
+            nodePoints: fetchedNodesAndJunctions.nodePointTemplates,
+            junctions: fetchedNodesAndJunctions.junctionTemplates
+          };
+
+          // Update data in nodeCollection
+          me.setNodes(fetchedNodesAndJunctions.nodes);
+          me.setMapTemplates(templates);
+
+          // Open template form with filtered data matching reference point
+          eventbus.trigger('selectedNodesAndJunctions:openTemplates', {
+            nodePoints: _.filter(templates.nodePoints, function (nodePoint) {
+              return _.isEqual(nodePoint.coordinates, referencePoint);
+            }),
+            junctions: _.filter(templates.junctions, function (junction) {
+              return _.some(junction.junctionPoints, function (junctionPoint) {
+                return _.isEqual(junctionPoint.coordinates, referencePoint);
+              });
+            })
+          });
+
+          // Update map with new node/junction template information
+          eventbus.trigger('node:addNodesToMap', fetchedNodesAndJunctions.nodes, templates, zoomlevels.minZoomForJunctions);
+        }
       } catch (error) {
-        console.error('Operation failed:', error);
+        console.error('Error in moveToLocation:', error);
       } finally {
         // Ensure spinner is always removed
         applicationModel.removeSpinner('moveToLocation');
       }
     };
+
+    // Update map with the nodes and junctions of the fetched location
+    eventbus.on('node:fetched', function (fetchResult, zoom) {
+      var resultNodes = fetchResult.nodes;
+      var templates = {
+        nodePoints: fetchResult.nodePointTemplates,
+        junctions: fetchResult.junctionTemplates
+      };
+
+      me.setNodes(resultNodes);
+      me.setMapTemplates(templates);
+
+      eventbus.trigger('node:addNodesToMap', resultNodes, templates, zoom);
+    });
 
     eventbus.on('node:save', function (node) {
       var fail = function (message) {
@@ -157,7 +164,6 @@
           backend.updateNodeInfo(node, function (result) {
             if (result.success) {
               applicationModel.removeSpinner(saving);
-              applicationModel.addSpinner(fetching);
               eventbus.trigger('node:saveSuccess');
             } else {
               fail(result);
@@ -167,7 +173,6 @@
           backend.createNodeInfo(node, function (result) {
             if (result.success) {
               applicationModel.removeSpinner(saving);
-              applicationModel.addSpinner(fetching);
               eventbus.trigger('node:saveSuccess');
             } else {
               fail(result);

--- a/viite-UI/src/view/NodeSearchForm.js
+++ b/viite-UI/src/view/NodeSearchForm.js
@@ -206,9 +206,9 @@
         });
 
         rootElement.on('click', '.junction-template-link', function (event) {
-          // Using window.location.hash with preventDefault instead of eventbus.trigger
-          // to Prevent double event triggering from both click and URL change
-          event.preventDefault();
+          // Trigger event to handle junction template click
+          eventbus.trigger('nodeSearchTool:clickJunctionTemplate', event.currentTarget.id);
+          // Update url hash to match clicked template
           window.location.hash = `node/junctionTemplate/${event.currentTarget.id}`;
         });
       });


### PR DESCRIPTION
Hot fix to nextRealease:

Nodes and Junctions now appear on the map correctly when the form is opened or map moved. 

- node:fetched event handler is added back to its own event listener to handle the fetched node data separately.
- The moveToLocation function now waits for the node:fetched event to be triggered and resolves the promise with the fetched data.
- This ensures that node:fetched triggers correctly also with fetchedNodes function to load all nodes and junctions, not just the selected ones
- Removed unnecessary spinnerEvent(fetching) as only closing the form happens after its triggered