### PR TITLE
VIITE-3304/VIITE-3342/VIITE-3341 scalike jdbc migration of data importer and road address importer files

### DIFF
--- a/viite-backend/database/src/main/scala/fi/liikennevirasto/digiroad2/util/DatabaseMigration.scala
+++ b/viite-backend/database/src/main/scala/fi/liikennevirasto/digiroad2/util/DatabaseMigration.scala
@@ -1,8 +1,8 @@
 package fi.liikennevirasto.digiroad2.util
 
 import org.flywaydb.core.Flyway
-import fi.vaylavirasto.viite.postgis.PostGISDatabase._
 import org.flywaydb.core.api.configuration.FluentConfiguration
+import scalikejdbc.ConnectionPool
 
 object DatabaseMigration {
 
@@ -13,7 +13,7 @@ object DatabaseMigration {
   def migrate(outOfOrder: Boolean = false): Unit = {
 
     val flywayConf: FluentConfiguration = Flyway.configure
-    flywayConf.dataSource(ds)
+    flywayConf.dataSource(ConnectionPool.get().dataSource)
     flywayConf.locations("db/migration")
     flywayConf.outOfOrder(outOfOrder)
 
@@ -24,7 +24,7 @@ object DatabaseMigration {
   def flywayInit(): Unit = {
 
     val flywayConf: FluentConfiguration = Flyway.configure
-    flywayConf.dataSource(ds)
+    flywayConf.dataSource(ConnectionPool.get().dataSource)
     flywayConf.baselineVersion("-1")
     flywayConf.baselineOnMigrate(true)
     flywayConf.locations("db/migration")

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/util/RoadAddressImporter.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/util/RoadAddressImporter.scala
@@ -581,10 +581,12 @@ class RoadAddressImporter(KGVClient: KgvRoadLink, importOptions: ImportOptions) 
             x2, y2, roadwayNumber, SideCode.TowardsDigitizing,
             getCalibrationCode(startCalibrationPoint, endCalibrationPoint, addrMRange), directionFlag)
         } else {
-          new ConversionAddress(roadPart, trackCode, discontinuity, addrMRange, startM, endM, startDate, endDate,
+          new ConversionAddress(
+            roadPart, trackCode, discontinuity, addrMRange, startM, endM, startDate, endDate,
             validFrom, expirationDate, ely, administrativeClass, 0, linkId, userId, x1, y1,
             x2, y2, roadwayNumber, SideCode.AgainstDigitizing,
-            getCalibrationCode(startCalibrationPoint, endCalibrationPoint, addrMRange), directionFlag)
+            getCalibrationCode(startCalibrationPoint, endCalibrationPoint, addrMRange), directionFlag
+          )
         }
       }
     }

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/util/RoadAddressImporter.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/util/RoadAddressImporter.scala
@@ -1,25 +1,23 @@
 package fi.liikennevirasto.viite.util
 
-import java.sql.{PreparedStatement, Timestamp}
-import slick.driver.JdbcDriver.backend.{Database, DatabaseDef}
-import Database.dynamicSession
 import fi.liikennevirasto.digiroad2.client.kgv.{HistoryRoadLink, KgvRoadLink}
 import fi.liikennevirasto.viite._
 import fi.liikennevirasto.viite.dao.{CalibrationCode, RoadwayPoint, TerminationCode, _}
 import fi.liikennevirasto.viite.dao.CalibrationCode.{AtBeginning, AtBoth, AtEnd}
 import fi.liikennevirasto.viite.dao.TerminationCode.{NoTermination, Subsequent, Termination}
+import fi.liikennevirasto.viite.util.DataImporter.Conversion.runWithConversionDbReadOnlySession
 import fi.vaylavirasto.viite.dao.{BaseDAO, LinkDAO, Sequences}
 import fi.vaylavirasto.viite.geometry.GeometryUtils
 import fi.vaylavirasto.viite.model.{AddrMRange, CalibrationPoint, CalibrationPointLocation, CalibrationPointType, LinkGeomSource, RoadLinkLike, RoadPart, SideCode}
-import fi.vaylavirasto.viite.util.DateTimeFormatters.basicDateFormatter
 import org.joda.time.DateTime
-import slick.jdbc._
-import slick.jdbc.StaticQuery.interpolation
+import scalikejdbc._
+import scalikejdbc.jodatime.JodaWrappedResultSet.fromWrappedResultSetToJodaWrappedResultSet
+
 
 
 case class ConversionAddress(roadPart: RoadPart, trackCode: Long, discontinuity: Long, addrMRange: AddrMRange, startM: Double, endM: Double, startDate: Option[DateTime], endDate: Option[DateTime], validFrom: Option[DateTime], expirationDate: Option[DateTime], ely: Long, administrativeClass: Long, terminated: Long, linkId: String, userId: String, x1: Option[Double], y1: Option[Double], x2: Option[Double], y2: Option[Double], roadwayNumber: Long, sideCode: SideCode, calibrationCode: CalibrationCode = CalibrationCode.No, directionFlag: Long = 0)
 
-class RoadAddressImporter(conversionDatabase: DatabaseDef, KGVClient: KgvRoadLink, importOptions: ImportOptions)  extends BaseDAO {
+class RoadAddressImporter(KGVClient: KgvRoadLink, importOptions: ImportOptions)  extends BaseDAO {
 
   case class IncomingRoadway(roadwayNumber: Long, roadPart: RoadPart, trackCode: Long, addrMRange: AddrMRange, reversed: Long, startDate: Option[DateTime], endDate: Option[DateTime], createdBy: String, administrativeClass: Long, ely: Long, validFrom: Option[DateTime], validTo: Option[DateTime], discontinuity: Long, terminated: Long)
 
@@ -27,128 +25,114 @@ class RoadAddressImporter(conversionDatabase: DatabaseDef, KGVClient: KgvRoadLin
 
   val roadwayPointDAO = new RoadwayPointDAO
 
-  private def roadwayStatement(): PreparedStatement =
-    dynamicSession.prepareStatement(sql = "insert into ROADWAY (id, ROADWAY_NUMBER, road_number, road_part_number, TRACK, start_addr_m, end_addr_m, reversed, start_date, end_date, created_by, ADMINISTRATIVE_CLASS, ely, valid_from, valid_to, discontinuity, terminated) " +
-                                          "values (nextval('ROADWAY_SEQ'), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+  private def batchUpdateRoadways(params: Seq[Seq[Any]]): List[Int] = {
+    val insertQuery =
+      sql"""
+        INSERT INTO roadway (id, roadway_number, road_number, road_part_number, track, start_addr_m,
+          end_addr_m, reversed, start_date, end_date, created_by, administrative_class, ely,
+          valid_from, valid_to, discontinuity, terminated)
+        VALUES (nextval('ROADWAY_SEQ'), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """
 
-  private def linearLocationStatement(): PreparedStatement =
-    dynamicSession.prepareStatement(sql = s"""
-        insert into LINEAR_LOCATION (id, ROADWAY_NUMBER, order_number, link_id, start_measure, end_measure, SIDE, geometry, created_by, valid_from, valid_to)
-        values (nextval('LINEAR_LOCATION_SEQ'), ?, ?, ?, ?, ?, ?, ST_GeomFromText('LINESTRING('||?||' '||?||' 0.0 0.0, '||?||' '||?||' 0.0 '||?||')', 3067), ?, ?, ?)
-                                           """)
-
-  private def roadwayPointStatement(): PreparedStatement = {
-    dynamicSession.prepareStatement(sql = "Insert Into ROADWAY_POINT (ID, ROADWAY_NUMBER, ADDR_M, CREATED_BY, MODIFIED_BY) " +
-                                          " values (?, ?, ?, ?, ?)")
+    runBatchUpdateToDb(insertQuery, params)
   }
 
-  private def calibrationPointStatement(): PreparedStatement = {
-    dynamicSession.prepareStatement(sql = "Insert Into CALIBRATION_POINT (ID, ROADWAY_POINT_ID, LINK_ID, START_END, TYPE, CREATED_BY) " +
-                                          " values (nextval('CALIBRATION_POINT_SEQ'), ?, ?, ?, ?, ?)")
+  private def createRoadwayParams(roadway: IncomingRoadway): Seq[Any] = {
+    // return the parameters for the batch update
+    Seq(
+      roadway.roadwayNumber,
+      roadway.roadPart.roadNumber,
+      roadway.roadPart.partNumber,
+      roadway.trackCode,
+      roadway.addrMRange.start,
+      roadway.addrMRange.end,
+      roadway.reversed,
+      roadway.startDate.orNull,
+      roadway.endDate.orNull,
+      roadway.createdBy,
+      roadway.administrativeClass,
+      roadway.ely,
+      roadway.validFrom.orNull,
+      roadway.validTo.map(d => new java.sql.Timestamp(d.getMillis)).orNull,
+      roadway.discontinuity,
+      roadway.terminated
+    )
   }
 
-  private def linkStatement(): PreparedStatement = {
-    dynamicSession.prepareStatement(sql = "Insert into LINK (ID, SOURCE, ADJUSTED_TIMESTAMP) values(?, ?, ?)")
+  private def batchUpdateLinearLocations(params: Seq[Seq[Any]]): List[Int] = {
+    val linearLocationBatchSql =
+      sql"""
+        INSERT INTO linear_location (id, roadway_number, order_number, link_id, start_measure, end_measure, side,
+          geometry, created_by, valid_from, valid_to)
+        VALUES (nextval('LINEAR_LOCATION_SEQ'), ?, ?, ?, ?, ?, ?, ST_GeomFromText('LINESTRING('||?||' '||?||' 0.0 0.0, '||?||' '||?||' 0.0 '||?||')', 3067), ?, ?, ?)
+        """
+
+    runBatchUpdateToDb(linearLocationBatchSql, params)
   }
 
-  def datePrinter(date: Option[DateTime]): String = {
-    date match {
-      case Some(dt) => basicDateFormatter.print(dt)
-      case None => ""
-    }
+  private def createLinearLocationParams(linearLocation: IncomingLinearLocation): Seq[Any] = {
+    // return the parameters for the batch update
+    Seq(Seq(
+      linearLocation.roadwayNumber,
+      linearLocation.orderNumber,
+      linearLocation.linkId,
+      linearLocation.startMeasure,
+      linearLocation.endMeasure,
+      linearLocation.sideCode.value,
+      linearLocation.x1.get,
+      linearLocation.y1.get,
+      linearLocation.x2.get,
+      linearLocation.y2.get,
+      linearLocation.endMeasure,
+      linearLocation.createdBy,
+      linearLocation.validFrom.orNull,
+      linearLocation.validTo.orNull
+    ))
   }
 
-  private def insertRoadway(roadwayStatement: PreparedStatement, roadway: IncomingRoadway): Unit = {
-    roadwayStatement.setLong(1, roadway.roadwayNumber)
-    roadwayStatement.setLong(2, roadway.roadPart.roadNumber)
-    roadwayStatement.setLong(3, roadway.roadPart.partNumber)
-    roadwayStatement.setLong(4, roadway.trackCode)
-    roadwayStatement.setLong(5, roadway.addrMRange.start)
-    roadwayStatement.setLong(6, roadway.addrMRange.end)
-    roadwayStatement.setLong(7, roadway.reversed)
-    if (roadway.startDate.isDefined) {
-      roadwayStatement.setDate(8, new java.sql.Date(roadway.startDate.get.getMillis))
-    } else {
-      roadwayStatement.setNull(8, java.sql.Types.DATE)
-    }
-    if (roadway.endDate.isDefined) {
-      roadwayStatement.setDate(9, new java.sql.Date(roadway.endDate.get.getMillis))
-    } else {
-      roadwayStatement.setNull(9, java.sql.Types.DATE)
-    }
-    roadwayStatement.setString(10, roadway.createdBy)
-    roadwayStatement.setLong(11, roadway.administrativeClass)
-    roadwayStatement.setLong(12, roadway.ely)
-    if (roadway.validFrom.isDefined) {
-      roadwayStatement.setTimestamp(13, new Timestamp(roadway.validFrom.get.getMillis))
-    } else {
-      roadwayStatement.setNull(13, java.sql.Types.TIMESTAMP)
-    }
-    if (roadway.validTo.isDefined) {
-      roadwayStatement.setTimestamp(14, new Timestamp(roadway.validTo.get.getMillis))
-    } else {
-      roadwayStatement.setNull(14, java.sql.Types.TIMESTAMP)
-    }
-    roadwayStatement.setLong(15, roadway.discontinuity)
-    roadwayStatement.setLong(16, roadway.terminated)
-    roadwayStatement.addBatch()
+  private def insertRoadwayPointToDb(roadwayPoint: RoadwayPoint): Long = {
+    val roadwayPointId = Sequences.nextRoadwayPointId
+    val roadwayPointSql =
+      sql"""
+      INSERT INTO roadway_point (id, roadway_number, addr_m, created_by, modified_by)
+      VALUES ($roadwayPointId, ${roadwayPoint.roadwayNumber}, ${roadwayPoint.addrMValue},
+             ${roadwayPoint.createdBy}, ${roadwayPoint.createdBy})
+      """
+
+    val inserted = runUpdateToDb(roadwayPointSql)
+    if (inserted == 1) roadwayPointId // Check that the insert was successful and return the id
+    else throw new Exception(s"Failed to insert roadway point, rows affected: $inserted")
+
   }
 
-  private def insertLinearLocation(linearLocationStatement: PreparedStatement, linearLocation: IncomingLinearLocation): Unit = {
-    linearLocationStatement.setLong(1, linearLocation.roadwayNumber)
-    linearLocationStatement.setLong(2, linearLocation.orderNumber)
-    linearLocationStatement.setString(3, linearLocation.linkId)
-    linearLocationStatement.setDouble(4, linearLocation.startMeasure)
-    linearLocationStatement.setDouble(5, linearLocation.endMeasure)
-    linearLocationStatement.setLong(6, linearLocation.sideCode.value)
-    linearLocationStatement.setDouble(7, linearLocation.x1.get)
-    linearLocationStatement.setDouble(8, linearLocation.y1.get)
-    linearLocationStatement.setDouble(9, linearLocation.x2.get)
-    linearLocationStatement.setDouble(10, linearLocation.y2.get)
-    linearLocationStatement.setDouble(11, linearLocation.endMeasure)
-    linearLocationStatement.setString(12, linearLocation.createdBy)
-    if (linearLocation.validFrom.isDefined) {
-      linearLocationStatement.setTimestamp(13, new java.sql.Timestamp(linearLocation.validFrom.get.getMillis))
-    } else {
-      linearLocationStatement.setNull(13, java.sql.Types.TIMESTAMP)
-    }
-    if (linearLocation.validTo.isDefined) {
-      linearLocationStatement.setTimestamp(14, new Timestamp(linearLocation.validTo.get.getMillis))
-    } else {
-      linearLocationStatement.setNull(14, java.sql.Types.TIMESTAMP)
-    }
-    linearLocationStatement.addBatch()
+  private def createCalibrationPointParams(calibrationPoint: CalibrationPoint): Seq[Any] = {
+    // return the parameters for the batch update
+    Seq(
+      calibrationPoint.roadwayPointId,
+      calibrationPoint.linkId,
+      calibrationPoint.startOrEnd.value,
+      calibrationPoint.typeCode.value,
+      calibrationPoint.createdBy
+    )
   }
 
-  private def insertRoadwayPoint(roadwayPointStatement: PreparedStatement, roadwayPoint: RoadwayPoint): Long = {
-    val id = Sequences.nextRoadwayPointId
-    roadwayPointStatement.setLong(1, id)
-    roadwayPointStatement.setLong(2, roadwayPoint.roadwayNumber)
-    roadwayPointStatement.setLong(3, roadwayPoint.addrMValue)
-    roadwayPointStatement.setString(4, roadwayPoint.createdBy)
-    roadwayPointStatement.setString(5, roadwayPoint.createdBy)
-    roadwayPointStatement.addBatch()
-    roadwayPointStatement.executeBatch()
-    id
+  private def batchUpdateCalibrationPoints(params: Seq[Seq[Any]]): List[Int] = {
+    val insertQuery =
+      sql"""
+        INSERT INTO calibration_point (id, roadway_point_id, link_id, start_end, type, created_by)
+        VALUES (nextval('CALIBRATION_POINT_SEQ'), ?, ?, ?, ?, ?)
+        """
+    runBatchUpdateToDb(insertQuery, params)
   }
 
-  private def insertCalibrationPoint(calibrationPointStatement: PreparedStatement, calibrationPoint: CalibrationPoint): Unit = {
-    calibrationPointStatement.setLong(1, calibrationPoint.roadwayPointId)
-    calibrationPointStatement.setString(2, calibrationPoint.linkId)
-    calibrationPointStatement.setLong(3, calibrationPoint.startOrEnd.value)
-    calibrationPointStatement.setLong(4, calibrationPoint.typeCode.value)
-    calibrationPointStatement.setString(5, calibrationPoint.createdBy)
-    calibrationPointStatement.addBatch()
-  }
-
-  private def fetchRoadLinksFromVVH(linkIds: Set[String]): Map[String, RoadLinkLike] = {
+  private def fetchRoadLinksFromKGV(linkIds: Set[String]): Map[String, RoadLinkLike] = {
     val KGVRoadLinkClient = if (importOptions.useFrozenLinkService) KGVClient.frozenTimeRoadLinkData else KGVClient.roadLinkData
     linkIds.grouped(4000).flatMap(group =>
       KGVRoadLinkClient.fetchByLinkIds(group) ++ KGVClient.complementaryData.fetchByLinkIds(group)
     ).toSeq.groupBy(_.linkId).mapValues(_.head)
   }
 
-  private def fetchHistoryRoadLinksFromVVH(linkIds: Set[String]): Map[String, HistoryRoadLink] =
+  private def fetchHistoryRoadLinksFromKGV(linkIds: Set[String]): Map[String, HistoryRoadLink] =
     Map[String, HistoryRoadLink]()
 
   private def adjustLinearLocation(linearLocation: IncomingLinearLocation, coefficient: Double): IncomingLinearLocation = {
@@ -156,10 +140,12 @@ class RoadAddressImporter(conversionDatabase: DatabaseDef, KGVClient: KgvRoadLin
   }
 
   /* Added road type to administrative class value conversion */
-  protected def fetchValidAddressesFromConversionTable(minRoadwayNumber: Long, maxRoadwayNumber: Long): Seq[ConversionAddress] = {
-    conversionDatabase.withDynSession {
+  def fetchValidAddressesFromConversionTable(minRoadwayNumber: Long, maxRoadwayNumber: Long): Seq[ConversionAddress] = {
+    runWithConversionDbReadOnlySession {
       val tableName = importOptions.conversionTable
-      sql"""select tie, aosa, ajr, jatkuu, aet, let, alku, loppu,
+      val query =
+        sql"""
+           SELECT tie, aosa, ajr, jatkuu, aet, let, alku, loppu,
            TO_CHAR(alkupvm, 'YYYY-MM-DD hh:mm:ss'),   TO_CHAR(loppupvm, 'YYYY-MM-DD hh:mm:ss'),
            TO_CHAR(muutospvm, 'YYYY-MM-DD hh:mm:ss'), TO_CHAR(lakkautuspvm, 'YYYY-MM-DD hh:mm:ss'),  ely,
            CASE tietyyppi
@@ -177,16 +163,22 @@ class RoadAddressImporter(conversionDatabase: DatabaseDef, KGVClient: KgvRoadLin
              AND linkid IN (
                  SELECT linkid FROM  #$tableName
                   WHERE ajorataid > $minRoadwayNumber AND ajorataid <= $maxRoadwayNumber
-                    AND aet >= 0 AND let >= 0) """
-        .as[ConversionAddress].list
+                    AND aet >= 0 AND let >= 0)
+          """
+      runSelectQuery(query.map(ConversionAddress.apply))
     }
   }
 
-  /* Added road type to administrative class value conversion */
-  protected def fetchAllTerminatedAddressesFromConversionTable(): Seq[ConversionAddress] = {
-    conversionDatabase.withDynSession {
+  /**
+   * Fetches all addresses from the conversion table that have been terminated.
+   * Added road type to administrative class value conversion
+   */
+  def fetchAllTerminatedAddressesFromConversionTable(): Seq[ConversionAddress] = {
+    runWithConversionDbReadOnlySession {
       val tableName = importOptions.conversionTable
-      sql"""select tie, aosa, ajr, jatkuu, aet, let, alku, loppu, TO_CHAR(alkupvm, 'YYYY-MM-DD hh:mm:ss') as alkupvm, TO_CHAR(loppupvm, 'YYYY-MM-DD hh:mm:ss') as loppupvm,
+      val query =
+        sql"""
+           SELECT tie, aosa, ajr, jatkuu, aet, let, alku, loppu, TO_CHAR(alkupvm, 'YYYY-MM-DD hh:mm:ss') as alkupvm, TO_CHAR(loppupvm, 'YYYY-MM-DD hh:mm:ss') as loppupvm,
            TO_CHAR(muutospvm, 'YYYY-MM-DD hh:mm:ss') as muutospvm, null as lakkautuspvm, ely,
            CASE tietyyppi
              WHEN 1 THEN 1
@@ -199,11 +191,13 @@ class RoadAddressImporter(conversionDatabase: DatabaseDef, KGVClient: KgvRoadLin
            END AS tietyyppi,
            linkid, kayttaja, alkux, alkuy, loppux,
            loppuy, ajorataid, kaannetty, alku_kalibrointipiste, loppu_kalibrointipiste from #$tableName
-           WHERE aet >= 0 AND let >= 0 AND linkid is null AND lakkautuspvm is null"""
-        .as[ConversionAddress].list
+           WHERE aet >= 0 AND let >= 0 AND linkid is null AND lakkautuspvm is null
+           """
+      runSelectQuery(query.map(ConversionAddress.apply))
     }
   }
 
+  // Generate chunks of roadway numbers to process in batches
   private def generateChunks(roadwayNumbers: Seq[Long], chunkNumber: Long): Seq[(Long, Long)] = {
     val (chunks, _) = roadwayNumbers.foldLeft((Seq[Long](0), 0)) {
       case ((fchunks, index), roadwayNumber) =>
@@ -222,15 +216,29 @@ class RoadAddressImporter(conversionDatabase: DatabaseDef, KGVClient: KgvRoadLin
     result.zip(result.tail)
   }
 
-  protected def fetchChunkRoadwayNumbersFromConversionTable(): Seq[(Long, Long)] = {
+  // Fetch roadway numbers from conversion table to process in chunks
+  private def fetchChunkRoadwayNumbersFromConversionTable(): Seq[(Long, Long)] = {
     //TODO Try to do the group in the query
-    conversionDatabase.withDynSession {
+    runWithConversionDbReadOnlySession {
       val tableName = importOptions.conversionTable
-      val roadwayNumbers = sql"""select distinct ajorataid from #$tableName where ajorataid is not null order by ajorataid""".as[Long].list
+      val query =
+        sql"""
+             SELECT DISTINCT ajorataid
+             FROM #$tableName
+             WHERE ajorataid IS NOT NULL
+             ORDER BY ajorataid
+             """
+      val roadwayNumbers = runSelectQuery(query.map(_.long(1)))
       generateChunks(roadwayNumbers, 1000)
     }
   }
 
+  /** Main import process for road addresses.
+   * The process includes:
+   * 1. Fetching and mapping road links from KGV (both current and historical)
+   * 2. Updating links to main database
+   *
+   */
   def importRoadAddress(): Unit = {
     val chunks = fetchChunkRoadwayNumbersFromConversionTable()
     chunks.foreach {
@@ -249,23 +257,58 @@ class RoadAddressImporter(conversionDatabase: DatabaseDef, KGVClient: KgvRoadLin
     importTerminatedAddresses(terminatedAddresses)
   }
 
+  /** Imports road addresses from conversion database to the main database.
+   *
+   * The process includes:
+   * 1. Fetching and mapping road links from KGV (both current and historical)
+   * 2. Updating links to main database
+   * 3. Processing conversion addresses:
+   *    - Filtering out suppressed road links
+   *    - Calculating scaling coefficients for link lengths
+   *    - Splitting addresses into current and historical
+   * 4. Collecting parameters for batch updates:
+   *    - Linear locations with adjusted measurements
+   *    - Calibration points with associated roadway points
+   *    - Roadways from both current and historical addresses
+   * 5. Executing batch updates:
+   *    - Calibration points (includes immediate roadway point inserts)
+   *    - Linear locations
+   *    - Roadways
+   *
+   * @param validConversionAddressesInChunk Addresses to be processed from the current chunk
+   * @param allConversionAddresses          All addresses needed for coefficient calculations
+   */
   private def importAddresses(validConversionAddressesInChunk: Seq[ConversionAddress], allConversionAddresses: Seq[ConversionAddress]): Unit = {
 
+    // get link ids from conversion table
     val linkIds = validConversionAddressesInChunk.map(_.linkId).toSet
     print(s"${DateTime.now()} - ")
     println("Total of %d link ids".format(linkIds.size))
-    val mappedRoadLinks = fetchRoadLinksFromVVH(linkIds)
+
+    // fetch road links from KGV TODO change name of the method
+    val mappedRoadLinks = fetchRoadLinksFromKGV(linkIds)
     print(s"${DateTime.now()} - ")
     println("Read %d road links from vvh".format(mappedRoadLinks.size))
-    val mappedHistoryRoadLinks = fetchHistoryRoadLinksFromVVH(linkIds.filterNot(linkId => mappedRoadLinks.contains(linkId)))
+
+    // fetch history road links from KGV and filter out the ones that are already in the mappedRoadLinks
+    val mappedHistoryRoadLinks = fetchHistoryRoadLinksFromKGV(
+      linkIds.filterNot(linkId => mappedRoadLinks.contains(linkId))
+    )
     print(s"${DateTime.now()} - ")
     println("Read %d road links history from vvh".format(mappedHistoryRoadLinks.size))
 
+    // Batch update links to the main database
+    batchUpdateLinksToDb(mappedRoadLinks.values ++ mappedHistoryRoadLinks.values)
+
+    // Find addresses where:
+    // - linkId is 0
+    // - or the linkId doesn't exist in current (mappedRoadLinks) or historical (mappedHistoryRoadLinks) road links
     val suppressedRoadLinks = validConversionAddressesInChunk.filter(ra => ra.linkId == 0 || (mappedRoadLinks.get(ra.linkId).isEmpty && mappedHistoryRoadLinks.get(ra.linkId).isEmpty))
     suppressedRoadLinks.map(_.roadwayNumber).distinct.foreach {
       roadwayNumber => println(s"Suppressed ROADWAY_NUMBER $roadwayNumber because it contains NULL LINKID values ")
     }
 
+    // Calculate scaling coefficient between measured length and actual geometry length for each link
     val groupedLinkCoeffs = allConversionAddresses.filter(_.expirationDate.isEmpty).groupBy(_.linkId).mapValues {
       addresses =>
         val minM = addresses.map(_.startM).min
@@ -273,220 +316,277 @@ class RoadAddressImporter(conversionDatabase: DatabaseDef, KGVClient: KgvRoadLin
         val roadLink = mappedRoadLinks.getOrElse(addresses.head.linkId, mappedHistoryRoadLinks(addresses.head.linkId))
         GeometryUtils.geometryLength(roadLink.geometry) / (maxM - minM)
     }
-    val (currentConversionAddresses, historyConversionAddresses) = validConversionAddressesInChunk.filterNot(ca => suppressedRoadLinks.map(_.roadwayNumber).distinct.contains(ca.roadwayNumber)).partition(_.endDate.isEmpty)
+
+    // Split addresses into current and history, excluding suppressed roadways.
+    // Then group both by (roadway number, part, track, dates)
+    val (currentConversionAddresses, historyConversionAddresses) = validConversionAddressesInChunk
+      .filterNot(ca => suppressedRoadLinks.map(_.roadwayNumber).distinct.contains(ca.roadwayNumber))
+      .partition(_.endDate.isEmpty)
     val currentMappedConversionAddresses = currentConversionAddresses.groupBy(ra => (ra.roadwayNumber, ra.roadPart, ra.trackCode, ra.startDate, ra.endDate))
     val historyMappedConversionAddresses = historyConversionAddresses.groupBy(ra => (ra.roadwayNumber, ra.roadPart, ra.trackCode, ra.startDate, ra.endDate))
-    val roadwayPs = roadwayStatement()
-    val linearLocationPs = linearLocationStatement()
-    val roadwayPointPs = roadwayPointStatement()
-    val calibrationPointPs = calibrationPointStatement()
-    val linkPs = linkStatement()
-    insertLinks(linkPs, mappedRoadLinks.values ++ mappedHistoryRoadLinks.values)
-    currentMappedConversionAddresses.mapValues {
-      case address =>
-        address.sortBy(_.addrMRange.start).zip(1 to address.size)
-    }.foreach {
-      case (_/*key*/, addresses) =>
-        addresses.foreach {
-          //add current linear locations
-          add =>
-            val converted = add._1
-            val roadLink = mappedRoadLinks.getOrElse(converted.linkId, mappedHistoryRoadLinks(converted.linkId))
-            val startCalibrationPoint = getStartCalibrationPoint(converted)
-            val endCalibrationPoint = getEndCalibrationPoint(converted)
-            handlePoints(roadwayPointPs, calibrationPointPs, startCalibrationPoint, endCalibrationPoint)
 
-            val linearLocation = adjustLinearLocation(IncomingLinearLocation(converted.roadwayNumber, add._2, converted.linkId, converted.startM, converted.endM, converted.sideCode, roadLink.linkSource, createdBy = "import",
-              converted.x1, converted.y1, converted.x2, converted.y2, converted.validFrom, None), groupedLinkCoeffs(converted.linkId))
-            if (add._1.directionFlag == 1) {
-              val revertedDirectionLinearLocation = linearLocation.copy(sideCode = SideCode.switch(linearLocation.sideCode))
-              insertLinearLocation(linearLocationPs, revertedDirectionLinearLocation)
-            } else {
-              insertLinearLocation(linearLocationPs, linearLocation)
-            }
+    // First collect all parameters from current addresses by mapping each group to linear locations, roadways and calibration points
+    val (currentLinearLocationParams, currentRoadwayParams, currentCalibrationPointParams) =
+      currentMappedConversionAddresses.map { case (_, addresses) =>
+        // Sort addresses by start measure
+        val sortedAddresses = addresses.sortBy(_.addrMRange.start).zip(1 to addresses.size)
+
+        // Collect all linear locations first
+        val linearLocationParams = sortedAddresses.flatMap { case (converted, index) =>
+          val roadLink = mappedRoadLinks.getOrElse(converted.linkId, mappedHistoryRoadLinks(converted.linkId))
+          val linearLocation = adjustLinearLocation(
+            IncomingLinearLocation(
+              converted.roadwayNumber, index, converted.linkId, converted.startM, converted.endM, converted.sideCode, roadLink.linkSource, createdBy = "import",
+              converted.x1, converted.y1, converted.x2, converted.y2, converted.validFrom, None
+            ),
+            groupedLinkCoeffs(converted.linkId))
+
+          // If the direction flag is 1, reverse the side code
+          if (converted.directionFlag == 1) {
+            val revertedDirectionLinearLocation = linearLocation.copy(sideCode = SideCode.switch(linearLocation.sideCode))
+            Seq(createLinearLocationParams(revertedDirectionLinearLocation))
+          } else {
+            Seq(createLinearLocationParams(linearLocation))
+          }
         }
 
-        val minAddress = addresses.head._1
-        val maxAddress = addresses.last._1
-        val addrRange = AddrMRange(minAddress.addrMRange.start, maxAddress.addrMRange.end)
-        val roadAddress = IncomingRoadway(minAddress.roadwayNumber, minAddress.roadPart, minAddress.trackCode, addrRange, reversed = 0, minAddress.startDate,
-          None, "import", minAddress.administrativeClass, minAddress.ely, minAddress.validFrom, None, maxAddress.discontinuity, terminated = NoTermination.value)
-
-        insertRoadway(roadwayPs, roadAddress)
-    }
-
-    historyMappedConversionAddresses.mapValues {
-      case address =>
-        address.sortBy(_.addrMRange.start).zip(1 to address.size)
-    }.foreach {
-      case (_/*key*/, addresses) =>
-        val minAddress = addresses.head._1
-        val maxAddress = addresses.last._1
-        val addrRange = AddrMRange(minAddress.addrMRange.start, maxAddress.addrMRange.end)
-        val roadAddress = IncomingRoadway(minAddress.roadwayNumber, minAddress.roadPart, minAddress.trackCode, addrRange, minAddress.directionFlag, minAddress.startDate, minAddress.endDate, "import", minAddress.administrativeClass, minAddress.ely, minAddress.validFrom, None, maxAddress.discontinuity, terminated = NoTermination.value)
-
-        insertRoadway(roadwayPs, roadAddress)
-    }
-    calibrationPointPs.executeBatch()
-    linearLocationPs.executeBatch()
-    roadwayPs.executeBatch()
-    println(s"${DateTime.now()} - Roadways saved")
-    calibrationPointPs.close()
-    linkPs.close()
-    linearLocationPs.close()
-    roadwayPs.close()
-  }
-
-  private def handlePoints(roadwayPointPs: PreparedStatement, calibrationPointPs: PreparedStatement, startCalibrationPoint: Option[(RoadwayPoint, CalibrationPoint)], endCalibrationPoint: Option[(RoadwayPoint, CalibrationPoint)]): Unit = {
-    if (startCalibrationPoint.isDefined && startCalibrationPoint.get._1.isNew) {
-      val roadwayPointId = insertRoadwayPoint(roadwayPointPs, startCalibrationPoint.get._1)
-      insertCalibrationPoint(calibrationPointPs, startCalibrationPoint.get._2.copy(roadwayPointId = roadwayPointId))
-    }
-    else if (startCalibrationPoint.isDefined && startCalibrationPoint.get._1.isNotNew && startCalibrationPoint.get._2.id == NewIdValue) {
-      insertCalibrationPoint(calibrationPointPs, startCalibrationPoint.get._2)
-    }
-    if (endCalibrationPoint.isDefined && endCalibrationPoint.get._1.isNew) {
-      val roadwayPointId = insertRoadwayPoint(roadwayPointPs, endCalibrationPoint.get._1)
-      insertCalibrationPoint(calibrationPointPs, endCalibrationPoint.get._2.copy(roadwayPointId = roadwayPointId))
-    }
-    else if (endCalibrationPoint.isDefined && endCalibrationPoint.get._1.isNotNew && endCalibrationPoint.get._2.id == NewIdValue) {
-      insertCalibrationPoint(calibrationPointPs, endCalibrationPoint.get._2)
-    }
-  }
-
-  private def insertLinks(statement: PreparedStatement, links: Iterable[RoadLinkLike]): Unit = {
-    links.foreach {
-      link =>
-        if (LinkDAO.fetch(link.linkId).isEmpty) {
-          statement.setString(1, link.linkId)
-          statement.setLong(2, link.linkSource.value)
-          statement.setLong(3, link.roadLinkTimeStamp)
-          statement.addBatch()
+        // Collect calibration point params and insert roadway points
+        val calibrationPointParams = sortedAddresses.flatMap { case (converted, _) =>
+          val startCalibrationPoint = getStartCalibrationPoint(converted)
+          val endCalibrationPoint = getEndCalibrationPoint(converted)
+          prepareCalibrationPointInsertsAndUpdateRoadwayPoints(startCalibrationPoint, endCalibrationPoint)
         }
+
+
+        // Create roadway params
+        val minAddress = sortedAddresses.head._1
+        val maxAddress = sortedAddresses.last._1
+        val addrMRange = AddrMRange(minAddress.addrMRange.start, maxAddress.addrMRange.end)
+        val roadAddress = IncomingRoadway(
+          minAddress.roadwayNumber, minAddress.roadPart, minAddress.trackCode, addrMRange, reversed = 0, minAddress.startDate,
+          None, "import", minAddress.administrativeClass, minAddress.ely, minAddress.validFrom, None, maxAddress.discontinuity, terminated = NoTermination.value
+        )
+        val roadwayParams = createRoadwayParams(roadAddress)
+
+        (linearLocationParams, roadwayParams, calibrationPointParams)
+      }.unzip3 match {
+        case (linear, roadway, calibration) =>
+          (linear.toSeq, roadway.toSeq, calibration.toSeq)
+      }
+
+    // History roadways
+    val historyRoadwaysParams = historyMappedConversionAddresses.map { case (_, addresses) =>
+      val sortedAddresses = addresses.sortBy(_.addrMRange.start)
+      val minAddress = sortedAddresses.head
+      val maxAddress = sortedAddresses.last
+      val addrRange = AddrMRange(minAddress.addrMRange.start, maxAddress.addrMRange.end)
+      val roadAddress = IncomingRoadway(
+        minAddress.roadwayNumber, minAddress.roadPart, minAddress.trackCode, addrRange, minAddress.directionFlag, minAddress.startDate, minAddress.endDate,
+        "import", minAddress.administrativeClass, minAddress.ely, minAddress.validFrom, None, maxAddress.discontinuity, terminated = NoTermination.value
+      )
+      createRoadwayParams(roadAddress)
     }
-    statement.executeBatch()
+
+    val allRoadwayParams = currentRoadwayParams ++ historyRoadwaysParams
+
+    batchUpdateCalibrationPoints(currentCalibrationPointParams)
+    batchUpdateLinearLocations(currentLinearLocationParams)
+    batchUpdateRoadways(allRoadwayParams)
+
+  }
+
+  /** Handle insertion of roadway points and collect calibration point parameters for batch insertion.
+   * If roadway point is new, it needs to be inserted immediately to get its id for the calibration point.
+   * Returns calibration point parameters for later batch insertion.
+   *
+   * @return Sequence of calibration point parameters for batch insert
+   */
+  private def prepareCalibrationPointInsertsAndUpdateRoadwayPoints(startPoint: Option[(RoadwayPoint, CalibrationPoint)],
+                           endPoint: Option[(RoadwayPoint, CalibrationPoint)]): Seq[Seq[Any]] = {
+    // Handle a single point
+    def handlePoint(point: Option[(RoadwayPoint, CalibrationPoint)]): Seq[Seq[Any]] = {
+      point match {
+        // For new roadway points:
+        // 1. Insert roadway point immediately to get id
+        // 2. Return calibration point params with the new roadway point id
+        case Some((roadwayPoint, calibrationPoint)) if roadwayPoint.isNew =>
+          val roadwayPointId = insertRoadwayPointToDb(roadwayPoint) // Insert roadway point and get id
+          Seq(createCalibrationPointParams(calibrationPoint.copy(roadwayPointId = roadwayPointId))) // Return calibration point params with new id
+
+        // For existing roadway points that need new calibration point:
+        // Just return calibration point params
+        case Some((_, calibrationPoint)) if calibrationPoint.id == NewIdValue =>
+          Seq(createCalibrationPointParams(calibrationPoint))
+
+        case _ => Seq.empty
+      }
+    }
+    // Handle both start and end points and return the combined result
+    handlePoint(startPoint) ++ handlePoint(endPoint)
+  }
+
+  private def batchUpdateLinksToDb(links: Iterable[RoadLinkLike]): Unit = {
+
+    val linkBatchSql =
+      sql"""
+        INSERT INTO link (id, source, adjusted_timestamp)
+        VALUES(?, ?, ?)
+     """
+
+    // Filter out links that already exist in the main database
+    val existingLinkIds = LinkDAO.fetchByLinkIds(links.map(_.linkId).toSet).map(_.id) // find existing links
+    val newLinks = links.filterNot(link => existingLinkIds.contains(link.linkId)) // filter out existing links
+
+    // If we have links to insert, prepare the batch params
+    if (newLinks.nonEmpty) {
+      val batchParams = newLinks.map { link =>
+        Seq(
+          link.linkId,
+          link.linkSource.value,
+          link.roadLinkTimeStamp
+        )
+      }
+
+      runBatchUpdateToDb(linkBatchSql, batchParams.toSeq)
+    }
   }
 
   private def createIncomingRoadway(r: ConversionAddress, terminated: TerminationCode): IncomingRoadway = {
     IncomingRoadway(r.roadwayNumber, r.roadPart, r.trackCode, r.addrMRange, reversed = 0, r.startDate, r.endDate, "import", r.administrativeClass, r.ely, r.validFrom, r.expirationDate, r.discontinuity, terminated = terminated.value)
   }
 
-  private def importTerminatedAddresses(terminatedConversionAddresses: Seq[ConversionAddress]): Unit = {
-    val roadwayPs = roadwayStatement()
+    private def importTerminatedAddresses(terminatedConversionAddresses: Seq[ConversionAddress]): Unit = {
+      val roadways = terminatedConversionAddresses.groupBy(t => t.roadwayNumber)
 
-    val roadways = terminatedConversionAddresses.groupBy(t => t.roadwayNumber)
-
-    roadways.foreach {
-      case (_/*roadwayNumber*/, roadways) =>
+      // Collect all roadway parameters
+      val roadwayParams = roadways.flatMap { case (_ /*roadwayNumber*/ , roadways) =>
         val sorted = roadways.sortBy(-_.startDate.get.getMillis)
         val terminated = sorted.head
-        val subsequent: Seq[ConversionAddress] = if (roadways.size > 1) {
-          sorted.tail
-        } else {
-          Seq()
+        val subsequent = if (roadways.size > 1) sorted.tail else Seq()
+
+        // Create params for terminated and subsequent roadways
+        val terminatedParams = createRoadwayParams(
+          createIncomingRoadway(
+            terminated.copy(endDate = Some(terminated.endDate.get.plusDays(1))), Termination)
+        )
+
+        // Then params for all subsequent roadways
+        val subsequentParams = subsequent.map(roadway =>
+          createRoadwayParams(
+            createIncomingRoadway(roadway, Subsequent)
+          )
+        )
+
+        // Combine all params for this roadway group
+        terminatedParams +: subsequentParams
+
+      }
+      // Do batch update if we have any roadways
+      if (roadwayParams.nonEmpty) {
+        batchUpdateRoadways(roadwayParams.toSeq)
+      }
+    }
+
+    private def getStartCalibrationPoint(convertedAddress: ConversionAddress): Option[(RoadwayPoint, CalibrationPoint)] = {
+      convertedAddress.calibrationCode match {
+        case AtBeginning | AtBoth =>
+          val existingRoadwayPoint = roadwayPointDAO.fetch(convertedAddress.roadwayNumber, convertedAddress.addrMRange.start)
+          existingRoadwayPoint match {
+            case Some(x) =>
+              val existingCalibrationPoint = CalibrationPointDAO.fetchByRoadwayPointId(x.id).find(_.startOrEnd == CalibrationPointLocation.StartOfLink)
+              if (existingCalibrationPoint.isDefined)
+                Some((existingRoadwayPoint.get, existingCalibrationPoint.get))
+              else
+                Some((existingRoadwayPoint.get, CalibrationPoint(NewIdValue, x.id, convertedAddress.linkId, x.roadwayNumber, x.addrMValue, CalibrationPointLocation.StartOfLink, CalibrationPointType.RoadAddressCP, createdBy = "import")))
+            case _ =>
+              Some(RoadwayPoint(NewIdValue, convertedAddress.roadwayNumber, convertedAddress.addrMRange.start, "import"),
+                CalibrationPoint(NewIdValue, NewIdValue, convertedAddress.linkId, convertedAddress.roadwayNumber, convertedAddress.addrMRange.start, CalibrationPointLocation.StartOfLink, CalibrationPointType.RoadAddressCP, createdBy = "import"))
+          }
+        case _ => None
+      }
+    }
+
+    private def getEndCalibrationPoint(convertedAddress: ConversionAddress): Option[(RoadwayPoint, CalibrationPoint)] = {
+      convertedAddress.calibrationCode match {
+        case AtEnd | AtBoth =>
+
+          val existingRoadwayPoint = roadwayPointDAO.fetch(convertedAddress.roadwayNumber, convertedAddress.addrMRange.end)
+          existingRoadwayPoint match {
+            case Some(x) =>
+              val existingCalibrationPoint = CalibrationPointDAO.fetchByRoadwayPointId(x.id).find(_.startOrEnd == CalibrationPointLocation.EndOfLink)
+              if (existingCalibrationPoint.isDefined)
+                Some((existingRoadwayPoint.get, existingCalibrationPoint.get))
+              else
+                Some((existingRoadwayPoint.get, CalibrationPoint(NewIdValue, x.id, convertedAddress.linkId, x.roadwayNumber, x.addrMValue, CalibrationPointLocation.EndOfLink, CalibrationPointType.RoadAddressCP, createdBy = "import")))
+            case _ =>
+              Some(RoadwayPoint(NewIdValue, convertedAddress.roadwayNumber, convertedAddress.addrMRange.end, "import"), CalibrationPoint(NewIdValue, NewIdValue, convertedAddress.linkId, convertedAddress.roadwayNumber, convertedAddress.addrMRange.end, CalibrationPointLocation.EndOfLink, CalibrationPointType.RoadAddressCP, createdBy = "import"))
+          }
+        case _ => None
+      }
+    }
+
+    object ConversionAddress extends SQLSyntaxSupport[ConversionAddress] {
+      def apply(rs: WrappedResultSet): ConversionAddress = {
+        val roadPart              = RoadPart(
+          roadNumber              = rs.long("tie"),
+          partNumber              = rs.long("aosa")
+        )
+        val trackCode             = rs.long("ajr")
+        val discontinuity         = rs.long("jatkuu")
+        val addrMRange            = AddrMRange(
+          start                   = rs.long("aet"),
+          end                     = rs.long("let")
+        )
+        val startM                = rs.double("alku")
+        val endM                  = rs.double("loppu")
+        val startDate             = rs.jodaDateTimeOpt("alkupvm")
+        val endDate               = rs.jodaDateTimeOpt("loppupvm")
+        val validFrom             = rs.jodaDateTimeOpt("muutospvm")
+        val expirationDate        = rs.jodaDateTimeOpt("lakkautuspvm")
+        val ely                   = rs.long("ely")
+        val administrativeClass   = rs.long("tietyyppi")
+        val linkId                = rs.string("linkid")
+        val userId                = rs.string("kayttaja")
+        val x1                    = rs.doubleOpt("alkux")
+        val y1                    = rs.doubleOpt("alkuy")
+        val x2                    = rs.doubleOpt("loppux")
+        val y2                    = rs.doubleOpt("loppuy")
+        val roadwayNumber         = rs.long("ajorataid")
+        val directionFlag         = rs.long("kaannetty")
+        val startCalibrationPoint = rs.long("alku_kalibrointipiste")
+        val endCalibrationPoint   = rs.long("loppu_kalibrointipiste")
+
+        def getCalibrationCode(startCalibrationPoint: Long, endCalibrationPoint: Long, addrMRange: AddrMRange): CalibrationCode = {
+          if (addrMRange.start < addrMRange.end) {
+            (startCalibrationPoint, endCalibrationPoint) match {
+              case (1, 1) => CalibrationCode.AtBoth
+              case (1, 0) => CalibrationCode.AtBeginning
+              case (0, 1) => CalibrationCode.AtEnd
+              case _ => CalibrationCode.No
+            }
+          } else {
+            (startCalibrationPoint, endCalibrationPoint) match {
+              case (1, 1) => CalibrationCode.AtBoth
+              case (1, 0) => CalibrationCode.AtEnd
+              case (0, 1) => CalibrationCode.AtBeginning
+              case _ => CalibrationCode.No
+            }
+          }
         }
 
-        insertRoadway(roadwayPs, createIncomingRoadway(terminated.copy(endDate = Some(terminated.endDate.get.plusDays(1))), Termination))
-        subsequent.foreach(roadway => insertRoadway(roadwayPs, createIncomingRoadway(roadway, Subsequent)))
-    }
-    roadwayPs.executeBatch()
-    roadwayPs.close()
-  }
-
-  private def getStartCalibrationPoint(convertedAddress: ConversionAddress): Option[(RoadwayPoint, CalibrationPoint)] = {
-    convertedAddress.calibrationCode match {
-      case AtBeginning | AtBoth =>
-        val existingRoadwayPoint = roadwayPointDAO.fetch(convertedAddress.roadwayNumber, convertedAddress.addrMRange.start)
-        existingRoadwayPoint match {
-          case Some(x) =>
-            val existingCalibrationPoint = CalibrationPointDAO.fetchByRoadwayPointId(x.id).find(_.startOrEnd == CalibrationPointLocation.StartOfLink)
-            if (existingCalibrationPoint.isDefined)
-              Some((existingRoadwayPoint.get, existingCalibrationPoint.get))
-            else
-              Some((existingRoadwayPoint.get, CalibrationPoint(NewIdValue, x.id, convertedAddress.linkId, x.roadwayNumber, x.addrMValue, CalibrationPointLocation.StartOfLink, CalibrationPointType.RoadAddressCP, createdBy = "import")))
-          case _ =>
-            Some(RoadwayPoint(NewIdValue, convertedAddress.roadwayNumber, convertedAddress.addrMRange.start, "import"),
-              CalibrationPoint(NewIdValue, NewIdValue, convertedAddress.linkId, convertedAddress.roadwayNumber, convertedAddress.addrMRange.start, CalibrationPointLocation.StartOfLink, CalibrationPointType.RoadAddressCP, createdBy = "import"))
-        }
-      case _ => None
-    }
-  }
-
-  private def getEndCalibrationPoint(convertedAddress: ConversionAddress): Option[(RoadwayPoint, CalibrationPoint)] = {
-    convertedAddress.calibrationCode match {
-      case AtEnd | AtBoth =>
-
-        val existingRoadwayPoint = roadwayPointDAO.fetch(convertedAddress.roadwayNumber, convertedAddress.addrMRange.end)
-        existingRoadwayPoint match {
-          case Some(x) =>
-            val existingCalibrationPoint = CalibrationPointDAO.fetchByRoadwayPointId(x.id).find(_.startOrEnd == CalibrationPointLocation.EndOfLink)
-            if (existingCalibrationPoint.isDefined)
-              Some((existingRoadwayPoint.get, existingCalibrationPoint.get))
-            else
-              Some((existingRoadwayPoint.get, CalibrationPoint(NewIdValue, x.id, convertedAddress.linkId, x.roadwayNumber, x.addrMValue, CalibrationPointLocation.EndOfLink, CalibrationPointType.RoadAddressCP, createdBy = "import")))
-          case _ =>
-            Some(RoadwayPoint(NewIdValue, convertedAddress.roadwayNumber, convertedAddress.addrMRange.end, "import"), CalibrationPoint(NewIdValue, NewIdValue, convertedAddress.linkId, convertedAddress.roadwayNumber, convertedAddress.addrMRange.end, CalibrationPointLocation.EndOfLink, CalibrationPointType.RoadAddressCP, createdBy = "import"))
-        }
-      case _ => None
-    }
-  }
-
-  implicit val getConversionAddress: GetResult[ConversionAddress] = new GetResult[ConversionAddress] {
-    def apply(r: PositionedResult) = {
-      val roadNumber = r.nextLong()
-      val roadPartNumber = r.nextLong()
-      val trackCode = r.nextLong()
-      val discontinuity = r.nextLong()
-      val startAddrM = r.nextLong()
-      val endAddrM = r.nextLong()
-      val startM = r.nextDouble()
-      val endM = r.nextDouble()
-      val startDate = r.nextTimestampOption().map(timestamp => new DateTime(timestamp))
-      val endDateOption = r.nextTimestampOption().map(timestamp => new DateTime(timestamp))
-      val validFrom = r.nextTimestampOption().map(timestamp => new DateTime(timestamp))
-      val expirationDate = r.nextTimestampOption().map(timestamp => new DateTime(timestamp))
-      val ely = r.nextLong()
-      val administrativeClass = r.nextLong()
-      val linkId = r.nextString()
-      val userId = r.nextString
-      val x1 = r.nextDouble()
-      val y1 = r.nextDouble()
-
-      val x2 = r.nextDouble()
-      val y2 = r.nextDouble()
-      val roadwayNumber = r.nextLong()
-      val directionFlag = r.nextLong()
-      val startCalibrationPoint = r.nextLong()
-      val endCalibrationPoint = r.nextLong()
-
-
-      def getCalibrationCode(startCalibrationPoint: Long, endCalibrationPoint: Long, addrMRange: AddrMRange): CalibrationCode = {
         if (addrMRange.start < addrMRange.end) {
-          (startCalibrationPoint, endCalibrationPoint) match {
-            case (1, 1) => CalibrationCode.AtBoth
-            case (1, 0) => CalibrationCode.AtBeginning
-            case (0, 1) => CalibrationCode.AtEnd
-            case _ => CalibrationCode.No
-          }
+          new ConversionAddress(
+            roadPart, trackCode, discontinuity, addrMRange, startM, endM, startDate, endDate,
+            validFrom, expirationDate, ely, administrativeClass, 0, linkId, userId, x1, y1,
+            x2, y2, roadwayNumber, SideCode.TowardsDigitizing,
+            getCalibrationCode(startCalibrationPoint, endCalibrationPoint, addrMRange), directionFlag)
         } else {
-          (startCalibrationPoint, endCalibrationPoint) match {
-            case (1, 1) => CalibrationCode.AtBoth
-            case (1, 0) => CalibrationCode.AtEnd
-            case (0, 1) => CalibrationCode.AtBeginning
-            case _ => CalibrationCode.No
-          }
+          new ConversionAddress(roadPart, trackCode, discontinuity, addrMRange, startM, endM, startDate, endDate,
+            validFrom, expirationDate, ely, administrativeClass, 0, linkId, userId, x1, y1,
+            x2, y2, roadwayNumber, SideCode.AgainstDigitizing,
+            getCalibrationCode(startCalibrationPoint, endCalibrationPoint, addrMRange), directionFlag)
         }
       }
-
-      val roadPart = RoadPart(roadNumber,roadPartNumber)
-      val addrRange = AddrMRange(startAddrM, endAddrM)
-      if (startAddrM < endAddrM) {
-        ConversionAddress(roadPart, trackCode, discontinuity, addrRange, startM, endM, startDate, endDateOption, validFrom, expirationDate, ely, administrativeClass, 0, linkId, userId, Option(x1), Option(y1), Option(x2), Option(y2), roadwayNumber, SideCode.TowardsDigitizing, getCalibrationCode(startCalibrationPoint, endCalibrationPoint, addrRange), directionFlag)
-      } else {
-        //switch startAddrM, endAddrM and set the side code to AgainstDigitizing
-        ConversionAddress(roadPart, trackCode, discontinuity, addrRange, startM, endM, startDate, endDateOption, validFrom, expirationDate, ely, administrativeClass, 0, linkId, userId, Option(x1), Option(y1), Option(x2), Option(y2), roadwayNumber, SideCode.AgainstDigitizing, getCalibrationCode(startCalibrationPoint, endCalibrationPoint, addrRange), directionFlag)
-      }
     }
-  }
 }
 

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/util/DataFixture.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/util/DataFixture.scala
@@ -8,7 +8,6 @@ import fi.liikennevirasto.digiroad2.util.{SqlScriptRunner, ViiteProperties}
 import fi.liikennevirasto.viite._
 import fi.liikennevirasto.viite.dao._
 import fi.liikennevirasto.viite.process.{ApplyChangeInfoProcess, RoadwayAddressMapper}
-import fi.liikennevirasto.viite.util.DataImporter.Conversion
 import fi.vaylavirasto.viite.dao.MunicipalityDAO
 import fi.vaylavirasto.viite.postgis.PostGISDatabaseScalikeJDBC
 import org.flywaydb.core.api.configuration.FluentConfiguration
@@ -57,7 +56,7 @@ object DataFixture {
   }
 
   def importNodesAndJunctions(): Unit = {
-    dataImporter.importNodesAndJunctions(Conversion.database())
+    dataImporter.importNodesAndJunctions()
   }
 
   def updateCalibrationPointTypes(): Unit = {


### PR DESCRIPTION
- Replaced Slick database operations with ScalikeJDBC equivalents for DataImporter and RoadAddressImporter files. 
-Instead of setting parameters one by one with preparedStatement.setX(), the batch parameters are collected into sequences (Seq[Seq[Any]])
- methods migrate and flywayInit now use the new data source from ScalikeJDBC connection pool