### PR TITLE
VIITE-3420 EVK (classes traits objects tests, etc)

### DIFF
--- a/viite-backend/base/src/main/scala/fi/vaylavirasto/viite/model/ArealRoadMaintainer.scala
+++ b/viite-backend/base/src/main/scala/fi/vaylavirasto/viite/model/ArealRoadMaintainer.scala
@@ -36,18 +36,96 @@ sealed trait ArealRoadMaintainer {
   final def toStringAll    : String = {  s"$typeName $number $name ($shortName)" }
 }
 
+/** A specialized trait for EVKs, with pre-defined typeName, and typeInfo for them. */
+trait EVK extends ArealRoadMaintainer {
+  override val typeName: String = "EVK"
+  override val typeInfo: String = "Elinvoimakeskus. Vastuussa teiden hallinnoinnista 01.01.2026 alkaen."
+  val    number: Int
+  val      name: String
+  val shortName: String
+}
+
 /** Companion object for the abstract ArealRoadMaintainer trait.
  * Defines the ArealRoadMaintainer instances there are, and access to them is to be done through this companion object. */
 object ArealRoadMaintainer {
 
-  /** Getter/constructor.
+  /* Create pre-defined EVK instances. */
+  case object EVKUusimaa           extends EVK {    val number =  1;  val name = "Uusimaa";           val shortName = "UUSI"    }
+  case object EVKLounaisSuomi      extends EVK {    val number =  2;  val name = "Lounais-Suomi";     val shortName = "LOUS"    }
+  case object EVKKaakkoisSuomi     extends EVK {    val number =  3;  val name = "Kaakkois-Suomi";    val shortName = "KAAS"    }
+  case object EVKSisäSuomi         extends EVK {    val number =  4;  val name = "Sisä-Suomi";        val shortName = "SISS"    }
+  case object EVKKeskiSuomi        extends EVK {    val number =  5;  val name = "Keski-Suomi";       val shortName = "KESS"    }
+  case object EVKItäSuomi          extends EVK {    val number =  6;  val name = "Itä-Suomi";         val shortName = "ITÄS"    }
+  case object EVKEteläPohjanmaa    extends EVK {    val number =  7;  val name = "Etelä-Pohjanmaa";   val shortName = "ETPO"    }
+  case object EVKPohjanmaa         extends EVK {    val number =  8;  val name = "Pohjanmaa";         val shortName = "POHJ"    }
+  case object EVKPohjoisSuomi      extends EVK {    val number =  9;  val name = "Pohjois-Suomi";     val shortName = "POHS"    }
+  case object EVKLappi             extends EVK {    val number = 10;  val name = "Lappi";             val shortName = "LAPP"    }
+
+  /* List of pre-defined EVK instances. These are the only ones Viite accepts. */
+  private val EVKset: Set[EVK] = Set[EVK](
+    EVKUusimaa,          EVKLounaisSuomi,
+    EVKKaakkoisSuomi,    EVKSisäSuomi,
+    EVKKeskiSuomi,       EVKItäSuomi,
+    EVKEteläPohjanmaa,   EVKPohjanmaa,
+    EVKPohjoisSuomi,     EVKLappi
+  )
+
+  /** Getter for EVKs only. You may search for an EVK by its number.
+   *
+   * @param number The number of the EVK you wish to get.
+   * @return The EVK asked, when found.
+   **/
+  def getEVK(number: Int): EVK = {
+    EVKset.find(_.number == number).getOrElse(
+      throw ViiteException(s"Olematon EVK ($number)!")
+        // TODO Either:ify the throw?
+    )
+  }
+
+  /** Getter for EVKs only. You may search for an EVK by its DBname, name, or shortName.
+   *
+   * @param string The string we use to identify the correct EVK to be returned.
+   * @return The EVK asked, when found.
+   */
+  def getEVK(string: String): EVK = {
+    EVKset.find( _.id == string).getOrElse(             // look for "EVK1"
+      EVKset.find(  _.name == string).getOrElse(        // look for "Uusimaa"
+        EVKset.find(_.shortName == string).getOrElse(   // look for "UUSI"
+          // TODO Either:ify the throw?
+          throw ViiteException(s"Olematon EVK ('$string')!")   // found nothing resembling the string
+        )
+      )
+    )
+  }
+
+  /** Existance checker for EVKs only.
+   *
+   * @param evk The EVK to be identified
+   * @return true, if the evk asked is a proper EVK, false else. */
+  def existsEVK(evk: EVK): Boolean = {
+    EVKset.find(_ == evk) match {
+      case Some(_) => true
+      case None    => false
+    }
+  }
+
+  /**
+   * Getter/constructor.
+   * As the only allowed ArealRoadMaintainers are pre-defined, getter, and "constructor" are the same.
+   *
+   * @param nameString The string to be interpreted as an ArealRoadMaintainer.
    * @return an ArealRoadMaintainer, according to the given nameString
    * @throws ViiteException, if the given string does not correspond to any known ArealRoadMaintainer instance.
-   * @param nameString The string to be interpreted as an ArealRoadMaintainer. */
+   */
   def apply(nameString: String): ArealRoadMaintainer = {
-                // If still nothing was found, just throw an error. There is no such thing, afawk.
-                throw ViiteException(s"Tuntematon tieverkon ylläpitäjätaho ($nameString)!")
 
+    // Interpret the nameString as it would be in the database: $typeName$number, and find an instance with that.
+    // Sole names, or numbers are not unique. And I doubt whether the shortNames either.
+    EVKset.find(evk => s"${evk.typeName}${evk.number}" == nameString).getOrElse(
+                // If nothing was found, just throw an error. There is no such thing as asked, afawk.
+                throw ViiteException(s"Tuntematon tieverkon ylläpitäjätaho ($nameString)!")
+                // TODO Either:ify the throw?
+    )
   }
 
 }

--- a/viite-backend/base/src/main/scala/fi/vaylavirasto/viite/model/ArealRoadMaintainer.scala
+++ b/viite-backend/base/src/main/scala/fi/vaylavirasto/viite/model/ArealRoadMaintainer.scala
@@ -25,7 +25,7 @@ sealed trait ArealRoadMaintainer {
   assert(typeInfo!="Describe your new typeName here", "Your implementing trait must override typeInfo.")
 
   /** Returns the id for this ArealRoadMaintainer.
-   * Id is a string consisting of the typeName, and number of this ArealRoadMaintainer.
+   * Id is a string consisting of the typeName and number of this ArealRoadMaintainer.
    * This in the id we want to save to the database, too. */
   final def id: String = {  s"$typeName$number"  }
 
@@ -36,7 +36,7 @@ sealed trait ArealRoadMaintainer {
   final def toStringAll    : String = {  s"$typeName $number $name ($shortName)" }
 }
 
-/** A specialized trait for EVKs, with pre-defined typeName, and typeInfo for them. */
+/** A specialized trait for EVKs, with pre-defined typeName and typeInfo for them. */
 trait EVK extends ArealRoadMaintainer {
   override val typeName: String = "EVK"
   override val typeInfo: String = "Elinvoimakeskus. Vastuussa teiden hallinnoinnista 01.01.2026 alkaen."
@@ -111,7 +111,7 @@ object ArealRoadMaintainer {
 
   /**
    * Getter/constructor.
-   * As the only allowed ArealRoadMaintainers are pre-defined, getter, and "constructor" are the same.
+   * As the only allowed ArealRoadMaintainers are pre-defined, getter and "constructor" are the same.
    *
    * @param nameString The string to be interpreted as an ArealRoadMaintainer.
    * @return an ArealRoadMaintainer, according to the given nameString

--- a/viite-backend/base/src/test/scala/fi/vaylavirasto/viite/model/ArealRoadMaintainerSpec.scala
+++ b/viite-backend/base/src/test/scala/fi/vaylavirasto/viite/model/ArealRoadMaintainerSpec.scala
@@ -12,4 +12,55 @@ class ArealRoadMaintainerSpec extends AnyFunSuite with Matchers {
     intercept[Exception](ArealRoadMaintainer("1"))       shouldBe a[ViiteException]
   }
 
+
+  //////// ArealRoadMaintainer/EVK tests ////////
+
+    test("Test ArealRoadMaintainer/EVK: test basic ArealRoadMaintainer functionality working") {
+
+      val EVK = ArealRoadMaintainer.getEVK("Pohjanmaa")
+
+      //Testing field access, and values
+      EVK.typeName  shouldBe "EVK"
+      EVK.number    shouldBe 8
+      EVK.name      shouldBe "Pohjanmaa"
+      EVK.shortName shouldBe "POHJ"
+
+      // testing print functionality
+      EVK.toString        shouldBe "EVK 8 Pohjanmaa"
+      EVK.id              shouldBe "EVK8"
+      EVK.id              shouldBe EVK.typeName+EVK.number
+      EVK.toStringVerbose shouldBe "EVK 8 Pohjanmaa"
+      EVK.toStringShort   shouldBe "POHJ"
+      EVK.toStringAll     shouldBe "EVK 8 Pohjanmaa (POHJ)"
+  }
+
+  test("Test ArealRoadMaintainer/EVK: getEVK by id numbers.") {
+    intercept[Exception] (ArealRoadMaintainer.getEVK( 0)) shouldBe a[ViiteException] // No such EVK number -> not found
+                          ArealRoadMaintainer.getEVK( 1)                             // Proper EVK number  -> found
+                          ArealRoadMaintainer.getEVK(10)                             // Proper EVK number  -> found
+    intercept[Exception] (ArealRoadMaintainer.getEVK(11)) shouldBe a[ViiteException] // No such EVK number -> not found
+    intercept[Exception] (ArealRoadMaintainer.getEVK(14)) shouldBe a[ViiteException] // *ELY*-only number  -> not found
+  }
+
+  test("Test ArealRoadMaintainer/EVK: getEVK by string.") {
+    //gets succeed with values corresponding to predefined EVK ARMs
+    val predefEVK1 = ArealRoadMaintainer.getEVK("EVK3")    // Get a pre-defined EVK with existing EVK db name
+    val predefEVK3 = ArealRoadMaintainer.getEVK("Uusimaa") // Get a pre-defined EVK with existing EVK name
+    val predefEVK4 = ArealRoadMaintainer.getEVK("SISS")    // Get a pre-defined EVK with existing EVK shortName
+
+    // gets fail with non-EVK values, even if proper ARMs, but not EVKs
+    val noELY1 = intercept[Exception] (ArealRoadMaintainer.getEVK("ELY3")     )  shouldBe a[ViiteException]  // Try getting a pre-defined EVK with an *ELY* db name
+    val noELY3 = intercept[Exception] (ArealRoadMaintainer.getEVK("Pirkanmaa"))  shouldBe a[ViiteException]  // Try getting a pre-defined EVK with an *ELY*-only name
+    val noELY2 = intercept[Exception] (ArealRoadMaintainer.getEVK("LAP")      )  shouldBe a[ViiteException]  // Try getting a pre-defined EVK with an *ELY* short name
+  }
+
+  test("Test ArealRoadMaintainer/EVK: getEVK existence.") {
+    val testEVK = ArealRoadMaintainer.getEVK(1)
+    case class EVKclone(val name: String, val number: Int, val shortName: String) extends EVK // class to test EVK ArealRoadMaintainer functionality with
+    val testEVKClone = EVKclone("Uusimaa", 1, "UUSI") // A basically proper EVK, but this is not any of our pre-defined instances
+
+    ArealRoadMaintainer.existsEVK(testEVK)      shouldBe true // EVK 1 is found.
+    ArealRoadMaintainer.existsEVK(testEVKClone) shouldBe false // ArealRoadMaintainer does not recognize randomly created EVK clones.
+  }
+
 }


### PR DESCRIPTION
-A specialized trait for EVKs.
-Defining EVKs proper instances (to be probably refined later, as the naming gets fixed by the law) 
-EVK-getters, and EVK-existance check for ArealRoadMaintainer 
-Tests for ArealRoadMaintainer/EVK trait, and fixed EVK objects