### PR TITLE
VIITE-3491 Add a parameter to dynamic link network API

### DIFF
--- a/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/AdminApi.scala
+++ b/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/AdminApi.scala
@@ -299,10 +299,10 @@ class AdminApi(val dataImporter: DataImporter, implicit val swagger: Swagger) ex
     (format.parseDateTime(previousDate), format.parseDateTime(newDate))
   }
 
-  def handleUpdate(previousDate: String, newDate: String, processDaily: Boolean): ActionResult = {
+  def handleUpdate(previousDate: String, newDate: String, processPerDay: Boolean): ActionResult = {
     try {
       val (previousDateTimeObject, newDateTimeObject) = validateDateParams(previousDate, newDate)
-      Future(dynamicRoadNetworkService.initiateLinkNetworkUpdates(previousDateTimeObject, newDateTimeObject, processDaily))
+      Future(dynamicRoadNetworkService.initiateLinkNetworkUpdates(previousDateTimeObject, newDateTimeObject, processPerDay))
       Ok("Samuutus käynnistetty")
     } catch {
       case ex: IllegalArgumentException =>
@@ -327,13 +327,13 @@ class AdminApi(val dataImporter: DataImporter, implicit val swagger: Swagger) ex
 
       (previousDate, newDate) match {
         case (Some(previousDate), Some(newDate)) =>
-          params.get("processDaily") match {
-            case Some("true")  => handleUpdate(previousDate, newDate, processDaily = true)
-            case Some("false") => handleUpdate(previousDate, newDate, processDaily = false)
+          params.get("processPerDay") match {
+            case Some("true")  => handleUpdate(previousDate, newDate, processPerDay = true)
+            case Some("false") => handleUpdate(previousDate, newDate, processPerDay = false)
             case Some(invalid) =>
-              logger.error(s"Invalid boolean value for 'processDaily': $invalid")
-              BadRequest(s"Invalid boolean value for 'processDaily': $invalid")
-            case None => handleUpdate(previousDate, newDate, processDaily = false)
+              logger.error(s"Invalid boolean value for 'processPerDay': $invalid")
+              BadRequest(s"Invalid boolean value for 'processPerDay': $invalid")
+            case None => handleUpdate(previousDate, newDate, processPerDay = false)
           }
 
         case _ =>

--- a/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/AdminApi.scala
+++ b/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/AdminApi.scala
@@ -299,6 +299,21 @@ class AdminApi(val dataImporter: DataImporter, implicit val swagger: Swagger) ex
     (format.parseDateTime(previousDate), format.parseDateTime(newDate))
   }
 
+  def handleUpdate(previousDate: String, newDate: String, processDaily: Boolean): ActionResult = {
+    try {
+      val (previousDateTimeObject, newDateTimeObject) = validateDateParams(previousDate, newDate)
+      Future(dynamicRoadNetworkService.initiateLinkNetworkUpdates(previousDateTimeObject, newDateTimeObject, processDaily))
+      Ok("Samuutus käynnistetty")
+    } catch {
+      case ex: IllegalArgumentException =>
+        logger.error("Updating link network failed.", ex)
+        BadRequest("Unable to parse date, the date should be in yyyy-MM-dd format.")
+      case e: Exception =>
+        logger.error("Updating link network failed.", e)
+        InternalServerError(s"Updating link network failed: ${e.getMessage}")
+    }
+  }
+
   /**
    * Part of dynamic link network.
    * End point to initiate link network update from @previousDate to @newDate
@@ -307,25 +322,22 @@ class AdminApi(val dataImporter: DataImporter, implicit val swagger: Swagger) ex
    */
   get("/update_link_network") {
     time(logger, "GET request for /update_link_network") {
-
       val previousDate = params.get("previousDate")
       val newDate = params.get("newDate")
 
       (previousDate, newDate) match {
         case (Some(previousDate), Some(newDate)) =>
-          try {
-            val (previousDateTimeObject, newDateTimeObject) = validateDateParams(previousDate, newDate)
-            Future(dynamicRoadNetworkService.initiateLinkNetworkUpdates(previousDateTimeObject, newDateTimeObject))
-            "Samuutus käynnistetty"
-          } catch {
-            case ex: IllegalArgumentException =>
-              logger.error("Updating link network failed.", ex)
-              BadRequest("Unable to parse date, the date should be in yyyy-MM-dd format.")
-            case e: Exception =>
-              logger.error("Updating link network failed.", e)
-              InternalServerError(s"Updating link network failed: ${e.getMessage}")
+          params.get("processDaily") match {
+            case Some("true")  => handleUpdate(previousDate, newDate, processDaily = true)
+            case Some("false") => handleUpdate(previousDate, newDate, processDaily = false)
+            case Some(invalid) =>
+              logger.error(s"Invalid boolean value for 'processDaily': $invalid")
+              BadRequest(s"Invalid boolean value for 'processDaily': $invalid")
+            case None => handleUpdate(previousDate, newDate, processDaily = false)
           }
-        case _ => BadRequest("Missing mandatory date parameter from the url - for example: /update_link_network?previousDate=2023-05-20&newDate=2023-05-23")
+
+        case _ =>
+          BadRequest("Missing mandatory date parameter from the url - for example: /update_link_network?previousDate=2023-05-20&newDate=2023-05-23")
       }
     }
   }

--- a/viite-backend/viite-main/src/main/scala/fi/vaylavirasto/viite/dynamicnetwork/DynamicRoadNetworkService.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/vaylavirasto/viite/dynamicnetwork/DynamicRoadNetworkService.scala
@@ -632,20 +632,27 @@ class DynamicRoadNetworkService(linearLocationDAO: LinearLocationDAO, roadwayDAO
     }
   }
 
-  def initiateLinkNetworkUpdates(previousDate: DateTime, newDate: DateTime, processDaily: Boolean): Unit = {
+  /**
+   * Initiates the update process for the link network, either as a single batch job or divided into daily incremental updates.
+   *
+   * @param previousDate   The starting date of the current link network state.
+   * @param newDate        The target date to which the link network should be updated.
+   * @param processPerDay  If true, the update is performed in daily intervals; if false, the entire range is processed as a single batch.
+   */
+  def initiateLinkNetworkUpdates(previousDate: DateTime, newDate: DateTime, processPerDay: Boolean): Unit = {
     time(logger, s"Link network update from ${previousDate} to ${newDate}") {
       try {
-        var currentDateTime = previousDate
+        var currentLinkNetworkStateDate = previousDate
         var skippedTiekamuRoadLinkChanges = Seq[TiekamuRoadLinkChange]()
 
-        if (processDaily) {
-          while (currentDateTime.isBefore(newDate)) {
-            val nextDateTime = currentDateTime.plusDays(1)
-            skippedTiekamuRoadLinkChanges ++= updateLinkNetwork(currentDateTime, nextDateTime)
-            currentDateTime = nextDateTime
+        if (processPerDay) {
+          while (currentLinkNetworkStateDate.isBefore(newDate)) {
+            val nextDateTime = currentLinkNetworkStateDate.plusDays(1)
+            skippedTiekamuRoadLinkChanges ++= updateLinkNetwork(currentLinkNetworkStateDate, nextDateTime)
+            currentLinkNetworkStateDate = nextDateTime
           }
         } else {
-          skippedTiekamuRoadLinkChanges ++= updateLinkNetwork(currentDateTime, newDate)
+          skippedTiekamuRoadLinkChanges ++= updateLinkNetwork(currentLinkNetworkStateDate, newDate)
         }
 
         if (skippedTiekamuRoadLinkChanges.nonEmpty) {


### PR DESCRIPTION
Introduce a new parameter to control the update logic. Allows either processing updates day-by-day or in a single batch from the old date to the new date.