### PR TITLE
VIITE-3322/VIITE-3511 add split link check and test for handle junctions and junction points

### DIFF
--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/NodesAndJunctionsService.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/NodesAndJunctionsService.scala
@@ -1009,7 +1009,7 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
       // Find all segments of the same link
       val sameLinkSegments = allLinks.filter(_.linkId == projectLink.linkId)
 
-      // Find min/max values of ADDRESS measures (not link measures)
+      // Find min/max AddrM values for the same link segments
       val minAddrM = sameLinkSegments.map(_.addrMRange.start).min
       val maxAddrM = sameLinkSegments.map(_.addrMRange.end).max
 

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/NodesAndJunctionsService.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/NodesAndJunctionsService.scala
@@ -179,7 +179,7 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
 
   private def handleJunctionPointUpdate(junctionId: Long, oldJunctionPoint: JunctionPoint, newJunctionPoint: JunctionPoint, username: String): JunctionPoint = {
     // Update JunctionPoint and CalibrationPoint addresses by pointing them to another RoadwayPoint
-    val roadwayPointId = getOrCreateRoadwayPointId(newJunctionPoint.roadwayNumber, newJunctionPoint.addrM, username)
+    val roadwayPointId = getIdOrCreateNewRoadwayPoint(newJunctionPoint.roadwayNumber, newJunctionPoint.addrM, username)
     CalibrationPointsUtils.updateCalibrationPointAddress(oldJunctionPoint.roadwayPointId, roadwayPointId, username)
 
     newJunctionPoint.copy(id = NewIdValue, junctionId = junctionId, roadwayPointId = roadwayPointId, createdBy = username)
@@ -390,8 +390,7 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
     }
   }
 
-
-  def getOrCreateRoadwayPointId(roadwayNumber: Long, address: Long, username: String): Long = {
+  private def getIdOrCreateNewRoadwayPoint(roadwayNumber: Long, address: Long, username: String): Long = {
     val existingRoadwayPoint = roadwayPointDAO.fetch(roadwayNumber, address)
     val rwPoint = if (existingRoadwayPoint.nonEmpty) {
       existingRoadwayPoint.get.id
@@ -567,37 +566,44 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
     }
 
     /**
-     * Finds all roads that geometrically intersect with the endpoints of a project link.
+     * Finds all roads that geometrically intersect with the true endpoints of a link.
+     * Only searches for connections at points that are actual link endpoints, not at split points.
      * For reversed links, uses the coordinates which represent the link after reversal.
-     * @return
+     *
+     * @return Tuple of (roadsInFirstPoint, roadsInLastPoint)
      */
     def findConnectedRoads(projectLink: BaseRoadAddress,
                            reversed: Boolean,
-                           roadNumberLimits: Seq[(Int, Int)]): (Seq[BaseRoadAddress], Seq[BaseRoadAddress]) = {
+                           roadNumberLimits: Seq[(Int, Int)],
+                           isAtLinkStart: Boolean,
+                           isAtLinkEnd: Boolean): (Seq[BaseRoadAddress], Seq[BaseRoadAddress]) = {
 
       // Only find roads at first point if it's a true link start
-      val roadsInFirstPoint: Seq[BaseRoadAddress] = if(reversed) {
+      val roadsInFirstPoint: Seq[BaseRoadAddress] = if (isAtLinkStart) {
+        if (reversed) {
           roadwayAddressMapper.getRoadAddressesByBoundingBox(BoundingRectangle(projectLink.newStartingPoint, projectLink.newStartingPoint), roadNumberLimits)
             .filterNot(_.linearLocationId == projectLink.linearLocationId)
         } else {
           roadwayAddressMapper.getRoadAddressesByBoundingBox(BoundingRectangle(projectLink.startingPoint, projectLink.startingPoint), roadNumberLimits)
             .filterNot(_.linearLocationId == projectLink.linearLocationId)
         }
-
+      } else Seq.empty[BaseRoadAddress]
       // Only find roads at last point if it's a true link end
-      val roadsInLastPoint: Seq[BaseRoadAddress] = if(reversed) {
+      val roadsInLastPoint: Seq[BaseRoadAddress] = if (isAtLinkEnd) {
+        if (reversed) {
           roadwayAddressMapper.getRoadAddressesByBoundingBox(BoundingRectangle(projectLink.newEndPoint, projectLink.newEndPoint), roadNumberLimits)
             .filterNot(_.linearLocationId == projectLink.linearLocationId)
         } else {
           roadwayAddressMapper.getRoadAddressesByBoundingBox(BoundingRectangle(projectLink.endPoint, projectLink.endPoint), roadNumberLimits)
             .filterNot(_.linearLocationId == projectLink.linearLocationId)
         }
+      } else Seq.empty[BaseRoadAddress]
 
       (roadsInFirstPoint, roadsInLastPoint)
     }
 
 
-    /**
+       /**
      * Filters roads based on discontinuity type to determine which roads should have junctions created.
      *
      * Handles different scenarios:
@@ -605,11 +611,11 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
      * - Regular roads: Topology analysis for various discontinuity cases
      * - Reversed links: Uses appropriate coordinate systems and topology filters
      *
-     * @param projectLink The main project link being processed
-     * @param roadsInFirstPoint Roads found at the start point of the project link
-     * @param roadsInLastPoint Roads found at the end point of the project link
+     * @param projectLink        The main project link being processed
+     * @param roadsInFirstPoint  Roads found at the start point of the project link
+     * @param roadsInLastPoint   Roads found at the end point of the project link
      * @param nonTerminatedLinks All non-terminated links in the project (used for topology analysis)
-     * @param reversed Whether the project link has been reversed
+     * @param reversed           Whether the project link has been reversed
      * @return Tuple of (headRoads, tailRoads) - roads that should have junctions at start and end points respectively
      */
     def filterRoadsByDiscontinuity(projectLink: BaseRoadAddress,
@@ -650,22 +656,27 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
           case Discontinuity.MinorDiscontinuity =>
 
             // Discontinuity cases for same road number
-            val head = if (roadsInFirstPoint.exists(fl => if(reversed) RoadAddressFilters.reversedEndingOfRoad(fl)(projectLink) else RoadAddressFilters.endingOfRoad(fl)(projectLink)))
+            val head = if (roadsInFirstPoint.exists(fl =>
+              if (reversed) RoadAddressFilters.reversedEndingOfRoad(fl)(projectLink)
+              else RoadAddressFilters.endingOfRoad(fl)(projectLink)))
               roadsInFirstPoint
             else
               roadsInFirstPoint filterNot RoadAddressFilters.sameRoad(projectLink)
 
-            //even if there are no connecting points (for e.g. in case of a geometry jump), the discontinuous links should have one junction point in the ending point in middle of the part (MinorDiscontinuity)
+            //even if there are no connecting points (for e.g. in case of a geometry jump),
+            // the discontinuous links should have one junction point in the ending point in middle of the part (MinorDiscontinuity)
             val tail: Seq[BaseRoadAddress] = if (roadsInLastPoint.exists(fl =>
-              if(reversed) RoadAddressFilters.reversedEndingOfRoad(fl)(projectLink)
+              if (reversed) RoadAddressFilters.reversedEndingOfRoad(fl)(projectLink)
               else RoadAddressFilters.endingOfRoad(fl)(projectLink))) {
               roadsInLastPoint
             }
             else {
               // Filter for continuous topology or connecting tails
               roadsInLastPoint.filter(r =>
-                if(reversed) RoadAddressFilters.reversedContinuousTopology(projectLink)(r) || RoadAddressFilters.reversedConnectingBothTails(r)(projectLink)
-                else RoadAddressFilters.continuousTopology(projectLink)(r) || RoadAddressFilters.connectingBothTails(r)(projectLink))
+                if (reversed) RoadAddressFilters.reversedContinuousTopology(projectLink)(r) ||
+                  RoadAddressFilters.reversedConnectingBothTails(r)(projectLink)
+                else RoadAddressFilters.continuousTopology(projectLink)(r) ||
+                  RoadAddressFilters.connectingBothTails(r)(projectLink))
             }
             (head, tail)
 
@@ -674,7 +685,7 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
 
             // HEAD FILTERING: Multi-step decision process
             val head = if (roadsInFirstPoint.exists(fl =>
-              if(reversed) {
+              if (reversed) {
                 // Check for reversed road ending, half-continuous-half-discontinuous, or discontinuous part intersection
                 RoadAddressFilters.reversedEndingOfRoad(fl)(projectLink) ||
                   RoadAddressFilters.reversedHalfContinuousHalfDiscontinuous(fl)(projectLink) ||
@@ -693,7 +704,7 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
 
             } else if (nonTerminatedLinks.exists(fl =>
               // Check for continuous road part/track with discontinuous topology
-              if(reversed) {
+              if (reversed) {
                 RoadAddressFilters.continuousRoadPartTrack(fl)(projectLink) && RoadAddressFilters.discontinuousTopology(fl)(projectLink)
               } else {
                 RoadAddressFilters.continuousRoadPartTrack(fl)(projectLink) && RoadAddressFilters.reversedDiscontinuousTopology(fl)(projectLink)
@@ -701,12 +712,12 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
 
               // Handle mixed topology cases: add non-terminated links where one road has continuous
               // road part but discontinuous topology, or discontinuous road part but continuous topolog
-              if(reversed) {
+              if (reversed) {
                 roadsInFirstPoint.filterNot(RoadAddressFilters.sameRoad(projectLink)) ++
                   nonTerminatedLinks.filter(fl => fl.id != projectLink.id &&
                     (RoadAddressFilters.reversedHalfContinuousHalfDiscontinuous(fl)(projectLink) ||
                       projectLink.newStartingPoint.connected(fl.newStartingPoint)))
-              }else {
+              } else {
                 roadsInFirstPoint.filterNot(RoadAddressFilters.sameRoad(projectLink)) ++
                   nonTerminatedLinks.filter(fl => fl.id != projectLink.id &&
                     (RoadAddressFilters.halfContinuousHalfDiscontinuous(fl)(projectLink) ||
@@ -720,11 +731,11 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
             // Tail filtering
             val tail = if (roadsInLastPoint.exists(fl =>
               // Check for various ending and discontinuous conditions (reversed)
-              if(reversed){
+              if (reversed) {
                 RoadAddressFilters.reversedEndingOfRoad(projectLink)(fl) ||
                   RoadAddressFilters.reversedHalfContinuousHalfDiscontinuous(projectLink)(fl) ||
                   RoadAddressFilters.reversedDiscontinuousPartTailIntersection(projectLink)(fl)
-              }else {
+              } else {
                 // Same checks for non-reversed case
                 RoadAddressFilters.endingOfRoad(projectLink)(fl) ||
                   RoadAddressFilters.halfContinuousHalfDiscontinuous(projectLink)(fl) ||
@@ -747,6 +758,7 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
      * - roadsFromHead: Roads that start from project link's start point
      * - roadsToTail: Roads that end at project link's end point
      * - roadsFromTail: Roads that start from project link's end point
+     *
      * @return CategorizedRoads object containing the categorized roads
      */
     def categorizeRoadConnections(projectLink: BaseRoadAddress,
@@ -759,7 +771,7 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
       // 1. Continuously connected (their endpoint connects to project link's start)
       // 2. Have a discontinuity that requires a junction (afterDiscontinuousJump)
       val roadsToHead = headRoads.filter(hr => {
-        if(reversed) {
+        if (reversed) {
           RoadAddressFilters.reversedContinuousTopology(hr)(projectLink)
         } else {
           RoadAddressFilters.continuousTopology(hr)(projectLink) || RoadAddressFilters.afterDiscontinuousJump(hr)(projectLink)
@@ -768,24 +780,24 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
 
       // Roads that start at the project link's start point
       val roadsFromHead = headRoads.filter(hr =>
-        if(reversed){
+        if (reversed) {
           RoadAddressFilters.reversedConnectingBothHeads(hr)(projectLink)
-        }else {
+        } else {
           RoadAddressFilters.connectingBothHeads(hr)(projectLink)
         })
 
       // Roads that end at the project link's end point
       val roadsToTail = tailRoads.filter(tr =>
-        if(reversed){
+        if (reversed) {
           RoadAddressFilters.reversedConnectingBothTails(tr)(projectLink)
         } else {
           RoadAddressFilters.connectingBothTails(tr)(projectLink)
         })
 
       val roadsFromTail = tailRoads.filter(tr =>
-        if(reversed){
+        if (reversed) {
           RoadAddressFilters.reversedContinuousTopology(projectLink)(tr)
-        }else {
+        } else {
           RoadAddressFilters.continuousTopology(projectLink)(tr)
         })
 
@@ -796,8 +808,8 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
      * Helper function to find existing junction IDs for roads connecting to the same road part.
      * This is used for loop roads ("lenkkitie") that end in themselves.
      *
-     * @param roadsTo Roads that end at the connection point
-     * @param roadsFrom Roads that start from the connection point
+     * @param roadsTo     Roads that end at the connection point
+     * @param roadsFrom   Roads that start from the connection point
      * @param projectLink The project link being processed
      * @return Optional junction ID if found
      */
@@ -828,9 +840,9 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
      * Creates a junction point at the start of a project link if connecting roads exist.
      * Handles special case for loop roads (roads that end at themselves).
      *
-     * @param projectLink The project link where the junction point will be created
+     * @param projectLink      The project link where the junction point will be created
      * @param categorizedRoads Roads categorized by their connection type to the project link
-     * @param reversed Whether the project link geometry has been reversed
+     * @param reversed         Whether the project link geometry has been reversed
      * @return A tuple containing roadwayPointId, linkId, and CalibrationPointLocation if created, None if not needed.
      */
     def createStartJunctionPoint(projectLink: BaseRoadAddress,
@@ -870,16 +882,18 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
           roadsFrom = roadsFrom,
           username = username
         )
-      } else { None }
+      } else {
+        None
+      }
     }
 
     /**
      * Creates a junction point at the end of a project link if connecting roads exist.
      * Handles special case for loop roads (roads that end at themselves).
      *
-     * @param projectLink The project link where the junction point will be created
+     * @param projectLink      The project link where the junction point will be created
      * @param categorizedRoads Roads categorized by their connection type to the project link
-     * @param reversed Whether the project link geometry has been reversed
+     * @param reversed         Whether the project link geometry has been reversed
      * @return A tuple containing roadwayPointId, linkId, and CalibrationPointLocation if created, None if not needed.
      */
     def createEndJunctionPoint(projectLink: BaseRoadAddress,
@@ -922,13 +936,16 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
           roadsFrom = roadsFrom,
           username = username
         )
-      } else { None }
+      } else {
+        None
+      }
     }
 
 
     /**
      * Creates junction points on the connected roads themselves,
      * ensuring both sides of a connection have appropriate junction points.
+     *
      * @return A sequence of tuples containing roadwayPointId, linkId, and CalibrationPointLocation
      */
     def createConnectedRoadJunctionPoints(projectLink: BaseRoadAddress,
@@ -938,7 +955,7 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
       // Create junction points for roads that end at the start of the project link
       val toHeadCpLocation = categorizedRoads.roadsToHead.flatMap { roadAddress: BaseRoadAddress =>
         val junctionId = getJunctionIdIfConnected(
-          roadAddress.endPoint, if(reversed)projectLink.newStartingPoint else projectLink.startingPoint,
+          roadAddress.endPoint, if (reversed) projectLink.newStartingPoint else projectLink.startingPoint,
           roadwayNumber = projectLink.roadwayNumber, addr = projectLink.addrMRange.start, pos = BeforeAfter.After
         )
         createJunctionAndJunctionPointIfNeeded(
@@ -949,7 +966,7 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
       // Create junction points for roads that start from the start of the project link
       val fromHeadCpLocation = categorizedRoads.roadsFromHead.flatMap { roadAddress: BaseRoadAddress =>
         val junctionId = getJunctionIdIfConnected(
-          roadAddress.startingPoint, if(reversed)projectLink.newStartingPoint else projectLink.startingPoint,
+          roadAddress.startingPoint, if (reversed) projectLink.newStartingPoint else projectLink.startingPoint,
           roadwayNumber = projectLink.roadwayNumber, addr = projectLink.addrMRange.start, pos = BeforeAfter.After
         )
         createJunctionAndJunctionPointIfNeeded(roadAddress, junctionId, BeforeAfter.After, roadAddress.addrMRange.start, username = username)
@@ -958,7 +975,7 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
       // Create junction points for roads that end at the end of the project link
       val toTailCpLocation = categorizedRoads.roadsToTail.flatMap { roadAddress: BaseRoadAddress =>
         val junctionId = getJunctionIdIfConnected(
-          roadAddress.endPoint, if(reversed)projectLink.newEndPoint else projectLink.endPoint,
+          roadAddress.endPoint, if (reversed) projectLink.newEndPoint else projectLink.endPoint,
           roadwayNumber = projectLink.roadwayNumber, addr = projectLink.addrMRange.end, pos = BeforeAfter.Before
         )
         createJunctionAndJunctionPointIfNeeded(roadAddress, junctionId, BeforeAfter.Before, roadAddress.addrMRange.end, username = username)
@@ -967,7 +984,7 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
       // Create junction points for roads that start from the end of the project link
       val fromTailCpLocation = categorizedRoads.roadsFromTail.flatMap { roadAddress: BaseRoadAddress =>
         val junctionId = getJunctionIdIfConnected(
-          roadAddress.startingPoint, if(reversed)projectLink.newEndPoint else projectLink.endPoint,
+          roadAddress.startingPoint, if (reversed) projectLink.newEndPoint else projectLink.endPoint,
           roadwayNumber = projectLink.roadwayNumber, addr = projectLink.addrMRange.end, pos = BeforeAfter.Before
         )
         createJunctionAndJunctionPointIfNeeded(roadAddress, junctionId, BeforeAfter.After, roadAddress.addrMRange.start, username = username)
@@ -977,9 +994,43 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
       toHeadCpLocation ++ fromHeadCpLocation ++ toTailCpLocation ++ fromTailCpLocation
     }
 
+    /**
+     * Determines if a project link is at the actual start or end of a link.
+     * This is needed to avoid creating junctions at points where a single link
+     * is split into multiple project links.
+     *
+     * @param projectLink The project link to check
+     * @param allLinks    All non-terminated links in the project
+     * @return A tuple of Booleans (isAtLinkStart, isAtLinkEnd) indicating if this project link
+     *         is at the true start or end of the physical link
+     */
+    def identifyLinkEndpoints(projectLink: BaseRoadAddress,
+                              allLinks: Seq[BaseRoadAddress]): (Boolean, Boolean) = {
+      // Find all segments of the same link
+      val sameLinkSegments = allLinks.filter(_.linkId == projectLink.linkId)
+
+      // Find min/max values of ADDRESS measures (not link measures)
+      val minAddrM = sameLinkSegments.map(_.addrMRange.start).min
+      val maxAddrM = sameLinkSegments.map(_.addrMRange.end).max
+
+      // Determine if current projectLink is at actual link endpoints
+      val isAtLinkStart = projectLink.addrMRange.start == minAddrM
+      val isAtLinkEnd = projectLink.addrMRange.end == maxAddrM
+
+      (isAtLinkStart, isAtLinkEnd)
+    }
 
     // === MAIN PROCESSING LOGIC == //
     val processedJunctions = nonTerminatedLinks.flatMap { projectLink =>
+
+      // Identify if the projectLink is at the true start or end of the link
+      val (isAtLinkStart, isAtLinkEnd) = identifyLinkEndpoints(projectLink, nonTerminatedLinks)
+
+      // If neither end is a true link endpoint (PL in middle of a link), skip this project link entirely
+      if (!isAtLinkStart && !isAtLinkEnd) {
+        logger.info(s"Skipping the processing of projectLink (no physical endpoints): ${projectLink.roadPart}, linkId=${projectLink.linkId}")
+        Seq.empty // No junction points created
+      } else {
         logger.info(s"\nProcessing projectLink: ${projectLink.roadPart}, addrRange=${projectLink.addrMRange}, linkId=${projectLink.linkId}")
         val roadNumberLimits = Seq((RoadClass.forJunctions.start, RoadClass.forJunctions.end))
 
@@ -987,7 +1038,9 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
         val reversed = isProjectLinkReversed(projectLink, roadwayChanges)
 
         // Find connected roads
-        val (roadsInFirstPoint, roadsInLastPoint) = findConnectedRoads(projectLink, reversed, roadNumberLimits)
+        val (roadsInFirstPoint, roadsInLastPoint) = findConnectedRoads(
+          projectLink, reversed, roadNumberLimits, isAtLinkStart, isAtLinkEnd
+        )
 
         // Filter roads based on discontinuity type
         val (headRoads, tailRoads) = filterRoadsByDiscontinuity(
@@ -1003,6 +1056,7 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
         val jpAtConnectedRoadsCpLocation = createConnectedRoadJunctionPoints(projectLink, roadConnections, reversed)
 
         jpAtStartCpLocation ++ jpAtEndCpLocation ++ jpAtConnectedRoadsCpLocation
+      }
     }.toSet
 
     processedJunctions
@@ -1036,7 +1090,7 @@ class NodesAndJunctionsService(roadwayDAO: RoadwayDAO, roadwayPointDAO: RoadwayP
                                                      roadsFrom: Seq[BaseRoadAddress] = Seq.empty[BaseRoadAddress],
                                                      username: String): Option[(Long, String, CalibrationPointLocation)] = {
 
-    val roadwayPointId = getOrCreateRoadwayPointId(target.roadwayNumber, addr, username)
+    val roadwayPointId = getIdOrCreateNewRoadwayPoint(target.roadwayNumber, addr, username)
     val existingJunctionPoint = junctionPointDAO.fetchByRoadwayPoint(target.roadwayNumber, addr, pos)
 
     if (existingJunctionPoint.isEmpty) {

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/NodesAndJunctionsServiceSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/NodesAndJunctionsServiceSpec.scala
@@ -4301,7 +4301,7 @@ class NodesAndJunctionsServiceSpec extends AnyFunSuite with Matchers with Before
         ely = 1L
       )
 
-      // Linear locations with exact M-
+      // Linear locations
       // 0-14
       val linearLocation1 = ll1.copy(
         startMValue = llStartM1,

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/NodesAndJunctionsServiceSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/NodesAndJunctionsServiceSpec.scala
@@ -22,8 +22,6 @@ import org.scalatest.BeforeAndAfter
 import org.scalatestplus.mockito.MockitoSugar
 import scalikejdbc._
 
-
-import scala.concurrent.Future
 import scala.util.{Left, Right}
 
 class NodesAndJunctionsServiceSpec extends AnyFunSuite with Matchers with BeforeAndAfter with BaseDAO {
@@ -4119,6 +4117,406 @@ class NodesAndJunctionsServiceSpec extends AnyFunSuite with Matchers with Before
       // only one junction should remain after the termination
       val allJunctionsAfterTermination = junctionDAO.fetchTemplatesByRoadwayNumbers(allRoadwayPointsAfterTermination.map(_.roadwayNumber).distinct)
       allJunctionsAfterTermination.size should be(1)
+    }
+  }
+
+  test("Test nodesAndJunctionsService.handleJunctionAndJunctionPoints When one link is split into two linear locations " +
+    "Then junction points or calibration points should not be created at the split point") {
+    runWithRollback {
+      /*
+       * Real scenario (simplified to 0 track) from manual regression testing:
+       * Link eafcd4bc-f1a9-4cad-a4dc-85fd29e5335a:1 (0-15) split into two linear locations:
+       *
+       *                   |
+       *                   |<- Connecting road 51
+       *                   |
+       * |----0-14->|14-15-V---15-33-->
+       *            ^
+       *         Junction points or calibration points should not be created at the split point, even when
+       *         connecting road has minor discontinuity
+       */
+
+      // Create a local service instance:
+      val testNodesAndJunctionsService = new NodesAndJunctionsService(
+        roadwayDAO,
+        roadwayPointDAO,
+        linearLocationDAO,
+        nodeDAO,
+        nodePointDAO,
+        junctionDAO,
+        junctionPointDAO,
+        roadwayChangesDAO,
+        projectReservedPartDAO
+      )
+
+      val road = 40955L
+      val connectingRoad = 51L
+      val part = 1L
+      val connectingPart = 2L
+      val projectId = Sequences.nextViiteProjectId
+      val rwId1 = Sequences.nextRoadwayId // for fist pl
+      val rwId2and3 = Sequences.nextRoadwayId // for second and third pl
+      val rwIdC = Sequences.nextRoadwayId // for connecting road
+      val llId1 = Sequences.nextLinearLocationId // for fist pl
+      val llId2 = Sequences.nextLinearLocationId // for second pl
+      val llId3 = Sequences.nextLinearLocationId // for third pl
+      val llIdC = Sequences.nextLinearLocationId // for connecting road
+      val rwNumber1 = Sequences.nextRoadwayNumber // First roadway number for first pl
+      val rwNumber2and3 = Sequences.nextRoadwayNumber // Same roadway number for second and third pl
+      val rwNumberC = Sequences.nextRoadwayNumber // for connecting road
+      val plId1 = Sequences.nextProjectLinkId
+      val plId2 = Sequences.nextProjectLinkId
+      val plId3 = Sequences.nextProjectLinkId
+
+      // Actual link IDs
+      val linkId1and2 = "eafcd4bc-f1a9-4cad-a4dc-85fd29e5335a:1"
+      val linkId3 = "7a238410-e6f2-4f24-99d2-e69fd2e276f4:1"
+      val linkIdC = "c1bc136d-2a5f-4ada-ace3-dc509ca56ad8:1"
+
+      // Project Link 1
+      val addrMRange1 = AddrMRange(0, 14)
+      val geom1 = Seq(Point(384727.426, 6671276.382), Point(384738.345, 6671284.973))
+      val llStartM1 = 0.992
+      val llEndM1 = 14.886
+
+      // Project Link 2
+      val addrMRange2 = AddrMRange(14, 15)
+      val geom2 = Seq(Point(384726.646, 6671275.769), Point(384727.426, 6671276.382))
+      val llStartM2 = 0.000
+      val llEndM2 = 0.992
+
+      // Project Link 3
+      val addrMRange3 = AddrMRange(15, 33)
+      val geom3 = Seq(Point(384709.126, 6671269.028), Point(384726.646, 6671275.769))
+      val llStartM3 = 0.000
+      val llEndM3 = 18.772
+
+      // Connecting road link
+      val addrMRangeC = AddrMRange(1688, 1694)
+      val geomC = Seq(Point(384730.423, 6671271.031), Point(384726.646, 6671275.769))
+      val llStartMC = 0.000
+      val llEndMC = 6.059
+
+      // Create the first part (0-14)
+      val projectLink1 = dummyProjectLink(
+        RoadPart(road, part),
+        Track.Combined,
+        Discontinuity.Continuous,
+        addrMRange1,
+        addrMRange1,
+        Some(DateTime.now()),
+        None,
+        linkId1and2,
+        llStartM1,
+        llEndM1,
+        SideCode.AgainstDigitizing,
+        RoadAddressChangeType.Transfer,
+        projectId,
+        AdministrativeClass.Municipality,
+        geom1,
+        rwNumber1
+      ).copy(
+        id = plId1,
+        projectId = projectId,
+        roadwayId = rwId1,
+        linearLocationId = llId1,
+        ely = 1
+      )
+
+      // Create the second part (14-15)
+      val projectLink2 = dummyProjectLink(
+        RoadPart(road, part),
+        Track.Combined,
+        Discontinuity.Continuous,
+        addrMRange2,
+        addrMRange2,
+        Some(DateTime.now()),
+        None,
+        linkId1and2,
+        llStartM2,
+        llEndM2,
+        SideCode.AgainstDigitizing,
+        RoadAddressChangeType.Transfer,
+        projectId,
+        AdministrativeClass.Municipality,
+        geom2,
+        rwNumber2and3
+      ).copy(
+        id = plId2,
+        projectId = projectId,
+        roadwayId = rwId2and3,
+        linearLocationId = llId2,
+        ely = 1
+      )
+
+      // Create ProjectLink 3 (15-33)
+      val projectLink3 = dummyProjectLink(
+        RoadPart(road, part),
+        Track.Combined,
+        Discontinuity.Continuous,
+        addrMRange3,
+        addrMRange3,
+        Some(DateTime.now()),
+        None,
+        linkId3,
+        llStartM3,
+        llEndM3,
+        SideCode.AgainstDigitizing,
+        RoadAddressChangeType.Transfer,
+        projectId,
+        AdministrativeClass.Municipality,
+        geom3,
+        rwNumber2and3
+      ).copy(
+        id = plId3,
+        projectId = projectId,
+        roadwayId = rwId2and3,
+        linearLocationId = llId3,
+        ely = 1
+      )
+
+      val projectLinks = Seq(projectLink1, projectLink2, projectLink3)
+
+      // Create project
+      val project = Project(
+        projectId, ProjectState.Incomplete, "SplitLinkTest", "s", DateTime.now(), "",
+        DateTime.now(), DateTime.now(), "", Seq(), Seq(), None, None
+      )
+
+      // Create roadways with M-value alignment
+      val (ll1, rw1): (LinearLocation, Roadway) = toRoadwayAndLinearLocation(projectLink1)
+      val (ll2, rw2): (LinearLocation, Roadway) = toRoadwayAndLinearLocation(projectLink2)
+      val (ll3, _): (LinearLocation, Roadway) = toRoadwayAndLinearLocation(projectLink3)
+
+      val roadway1 = rw1.copy(
+        roadwayNumber = rwNumber1,
+        addrMRange = addrMRange1,
+        ely = 1L
+      )
+
+      val roadway2 = rw2.copy(
+        id = rwId2and3,
+        roadwayNumber = rwNumber2and3,
+        addrMRange = AddrMRange(14, 33), // both lls combined
+        ely = 1L
+      )
+
+      // Linear locations with exact M-
+      // 0-14
+      val linearLocation1 = ll1.copy(
+        startMValue = llStartM1,
+        orderNumber = 1,
+        endMValue = llEndM1,
+        roadwayNumber = rwNumber1
+      )
+
+      // 14-15
+      val linearLocation2 = ll2.copy(
+        id = llId2,
+        orderNumber = 1,
+        startMValue = llStartM2,
+        endMValue = llEndM2,
+        roadwayNumber = rwNumber2and3
+      )
+
+      // 15-33
+      val linearLocation3 = ll3.copy(
+        id = llId3,
+        orderNumber = 2,
+        startMValue = llStartM3,
+        endMValue = llEndM3,
+        roadwayNumber = rwNumber2and3
+      )
+
+      // Create existing connecting road (road 51, link c1bc136d-2a5f-4ada-ace3-dc509ca56ad8:1)
+      val existingRoadway = Roadway(
+        rwIdC, rwNumberC, RoadPart(connectingRoad, connectingPart), AdministrativeClass.Municipality,
+        Track.Combined, Discontinuity.MinorDiscontinuity, addrMRangeC, reversed = false,
+        DateTime.now().minusDays(10), None, "test", Some("Road 51"), 1L, TerminationCode.NoTermination
+      )
+
+      // Create linear location for connecting road
+      val connectingLinearLocation = LinearLocation(
+        llIdC,
+        1,
+        linkIdC,
+        llStartMC,
+        llEndMC,
+        SideCode.TowardsDigitizing,
+        10000000000L,
+        (CalibrationPointReference.None, CalibrationPointReference.None),
+        geomC,
+        LinkGeomSource.NormalLinkInterface,
+        rwNumberC,
+        Some(DateTime.now().minusDays(10)),
+        None
+      )
+
+      // Create existing road
+      roadwayDAO.create(Seq(existingRoadway))
+      linearLocationDAO.create(Seq(connectingLinearLocation), "test")
+
+      // Build test data for project with corrected linear locations
+      buildTestDataForProject(
+        Some(project),
+        Some(Seq(roadway1, roadway2)),
+        Some(Seq(linearLocation1, linearLocation2, linearLocation3)),
+        Some(projectLinks)
+      )
+
+      // Create project changes
+      val projectChanges = List(
+        ProjectRoadwayChange(
+          projectId,
+          Some("SplitLinkTest"),
+          1L,
+          "test user",
+          DateTime.now,
+          RoadwayChangeInfo(
+            RoadAddressChangeType.Transfer,
+            RoadwayChangeSection(
+              Some(road),
+              Some(Track.Combined.value.toLong),
+              startRoadPartNumber = Some(part),
+              endRoadPartNumber = Some(part),
+              addrMRange = Some(AddrMRange(0L, 14L)),
+              Some(AdministrativeClass.Municipality),
+              Some(Discontinuity.Continuous),
+              Some(1L)
+            ),
+            RoadwayChangeSection(
+              Some(road),
+              Some(Track.Combined.value.toLong),
+              startRoadPartNumber = Some(part),
+              endRoadPartNumber = Some(part),
+              addrMRange = Some(AddrMRange(0L, 14L)),
+              Some(AdministrativeClass.Municipality),
+              Some(Discontinuity.Continuous),
+              Some(1L)
+            ),
+            Discontinuity.Continuous,
+            AdministrativeClass.Municipality,
+            reversed = false,
+            1,
+            1
+          ),
+          DateTime.now
+        ),
+        ProjectRoadwayChange(
+          projectId,
+          Some("SplitLinkTest"),
+          1L,
+          "test user",
+          DateTime.now,
+          RoadwayChangeInfo(
+            RoadAddressChangeType.Transfer,
+            RoadwayChangeSection(
+              Some(road),
+              Some(Track.Combined.value.toLong),
+              startRoadPartNumber = Some(part),
+              endRoadPartNumber = Some(part),
+              addrMRange = Some(AddrMRange(14L, 15L)),
+              Some(AdministrativeClass.Municipality),
+              Some(Discontinuity.Continuous),
+              Some(1L)
+            ),
+            RoadwayChangeSection(
+              Some(road),
+              Some(Track.Combined.value.toLong),
+              startRoadPartNumber = Some(part),
+              endRoadPartNumber = Some(part),
+              addrMRange = Some(AddrMRange(14L, 15L)),
+              Some(AdministrativeClass.Municipality),
+              Some(Discontinuity.Continuous),
+              Some(1L)
+            ),
+            Discontinuity.Continuous,
+            AdministrativeClass.Municipality,
+            reversed = false,
+            1,
+            1
+          ),
+          DateTime.now
+        ),
+        ProjectRoadwayChange(
+          projectId,
+          Some("SplitLinkTest"),
+          1L,
+          "test user",
+          DateTime.now,
+          RoadwayChangeInfo(
+            RoadAddressChangeType.Transfer,
+            RoadwayChangeSection(
+              Some(road),
+              Some(Track.Combined.value.toLong),
+              startRoadPartNumber = Some(part),
+              endRoadPartNumber = Some(part),
+              addrMRange = Some(AddrMRange(15L, 33L)),
+              Some(AdministrativeClass.Municipality),
+              Some(Discontinuity.Continuous),
+              Some(1L)
+            ),
+            RoadwayChangeSection(
+              Some(road),
+              Some(Track.Combined.value.toLong),
+              startRoadPartNumber = Some(part),
+              endRoadPartNumber = Some(part),
+              addrMRange = Some(AddrMRange(15L, 33L)),
+              Some(AdministrativeClass.Municipality),
+              Some(Discontinuity.Continuous),
+              Some(1L)
+            ),
+            Discontinuity.Continuous,
+            AdministrativeClass.Municipality,
+            reversed = false,
+            1,
+            1
+          ),
+          DateTime.now
+        ),
+      )
+
+      val mappedRoadwayNumbers = projectLinkDAO.fetchProjectLinksChange(projectId)
+
+      // Handle roadway points and junctions
+      roadAddressService.handleRoadwayPointsUpdate(projectChanges, mappedRoadwayNumbers)
+      testNodesAndJunctionsService.handleJunctionAndJunctionPoints(projectChanges, projectLinks, mappedRoadwayNumbers)
+
+      // Verify roadway points were created
+      val roadwayPoints1 = roadwayPointDAO.fetchByRoadwayNumber(rwNumber1)
+      val roadwayPoints2 = roadwayPointDAO.fetchByRoadwayNumber(rwNumber2and3)
+
+      val allRoadwayPoints = roadwayPoints1 ++ roadwayPoints2
+      val junctionPoints = junctionPointDAO.fetchByRoadwayPointIds(allRoadwayPoints.map(_.id))
+
+
+      // Verify roadway point was not created at address 14
+      val roadwayPointAt14 = allRoadwayPoints.find(_.addrMValue == 14)
+      roadwayPointAt14 should be(None)
+
+      // Verify junction points were created
+      junctionPoints should not be empty
+
+      // Should NOT have junction point at address 14 (split point)
+      val junctionPointAt14 = junctionPoints.find(jp => jp.addrM == 14)
+      junctionPointAt14 should be(None)
+
+      // Should HAVE junction points at address 15 (true endpoint)
+      val junctionPointsAt15 = junctionPoints.filter(_.addrM == 15)
+      junctionPointsAt15.size should be(2)
+      junctionPointsAt15.map(_.beforeAfter).toSet should be(Set(BeforeAfter.Before, BeforeAfter.After))
+
+      // Verify calibration points
+      val calibrationPoints = CalibrationPointDAO.fetchByLinkId(Seq(linkId1and2))
+      calibrationPoints should not be empty
+
+      // Should NOT have calibration point at address 14
+      val calibrationPointAt14 = calibrationPoints.find(_.addrM == 14)
+      calibrationPointAt14 should be(None)
+
+      // Should HAVE calibration point at address 15
+      val calibrationPointAt15 = calibrationPoints.find(_.addrM == 15)
+      calibrationPointAt15 should be(defined)
     }
   }
 


### PR DESCRIPTION
VIITE-3322 Fix to a bug where junction points were created at split point of a link:
- Add identifyLinkEndpoints to identify true link endpoints of project links
- Add boolean to findConnectedRoad use only true start/endpoints of a link
- Rename getOrCreateRoadwayPointId to   getIdOrCreateNewRoadwayPoint
- Better alignment of the code

VIITE-3511:
- Add test case for VIITE-3322 bug