### PR TITLE
VIITE-3531 Fix TooManyRowsException in fetchLatestId DAO function

### DIFF
--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/NodeDAO.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/NodeDAO.scala
@@ -95,7 +95,7 @@ class NodeDAO extends BaseDAO {
       WHERE node_number = $nodeNumber and valid_to IS NULL
       ORDER BY created_time DESC, end_date DESC
       """
-    runSelectSingleOption(query.map(_.long("id"))) // Return the id
+    runSelectFirst(query.map(_.long("id"))) // Return the id
   }
 
   def fetchAllValidNodes(): Seq[Node] = {


### PR DESCRIPTION
When a Node was edited, both a history row and a new "current" row were created. As a result, fetching nodes by node number could return multiple rows. The runSelectSingleOption method uses .single(), which expects exactly one result, leading to a TooManyRowsException when multiple rows were returned.

This fix updates the logic to select only the latest node ID from the already ordered query result, ensuring a single result is returned.