### PR TITLE
VIITE-3530: Fix node drift after moving and prevent zoom from resetting node

### DIFF
--- a/viite-UI/src/view/NodeForm.js
+++ b/viite-UI/src/view/NodeForm.js
@@ -120,7 +120,7 @@
         ' <div class="form form-horizontal form-dark">' +
         '   <div>' +
         staticField('Solmunumero:', nodeNumber) +
-        staticField('Koordinaatit (<i>P</i>, <i>I</i>):', '<span id="node-coordinates">' + node.coordinates.y + ', ' + node.coordinates.x + '</span>') +
+        staticField('Koordinaatit (<i>P</i>, <i>I</i>):', '<span id="node-coordinates">' + Math.round(node.coordinates.y) + ', ' + Math.round(node.coordinates.x) + '</span>') +
         inputFieldRequired('Solmun nimi', 'nodeName', '', nodeName, 'maxlength', 30) +
         addNodeTypeDropdown('Solmutyyppi', 'nodeTypeDropdown', getNodeType(node.type)) +
         inputFieldRequired('Alkupvm', 'nodeStartDate', 'pp.kk.vvvv', startDate, 'disabled', true) +
@@ -802,7 +802,9 @@
           $('.btn-edit-node-save').prop('disabled', formIsInvalid());
 
           eventbus.on('node:displayCoordinates', function (coordinates) {
-            $("#node-coordinates").text(coordinates.y + ', ' + coordinates.x);
+            $("#node-coordinates").text(
+                Math.round(coordinates.y) + ', ' + Math.round(coordinates.x)
+            );
           });
 
           eventbus.on('change:nodeName', function (nodeName) {

--- a/viite-UI/src/view/NodeLayer.js
+++ b/viite-UI/src/view/NodeLayer.js
@@ -211,8 +211,6 @@
       }
     });
 
-    // eventbus.on('map:refresh'
-
     /**
      * This will add all the following interactions from the map:
      * - nodeLayerSelectInteraction

--- a/viite-UI/src/view/RoadLayer.js
+++ b/viite-UI/src/view/RoadLayer.js
@@ -1,7 +1,9 @@
 (function (root) {
   root.RoadLayer = function (map, roadCollection, selectedLinkProperty, nodeCollection) {
-
     Layer.call(this, map);
+
+    window.ViiteState = window.ViiteState || {}; // Global variable for trackin state like node translation
+
     var me = this;
     var roadLinkStyler = new RoadLinkStyler();
 
@@ -203,7 +205,9 @@
             eventbus.trigger('roadAddressProject:fetch');
             break;
           case 'node':
-            eventbus.trigger('nodeLayer:fetch');
+            // Don't fetch nodes if one is currently being moved (translated)
+            if (window.ViiteState?.isTranslatingNode) break;
+              eventbus.trigger('nodeLayer:fetch');
             break;
           default:
             break;


### PR DESCRIPTION
Solmut eivät enää liiku itsestään liikuttamisen jälkeen, ja niitä pystyy myös liikuttamaan zoomatessa ilman että ne palaavat takaisin aikaisempiin koordinaatteihin..