### PR TITLE
Viite 3543 responsive toolbar

### DIFF
--- a/viite-UI/src/less/site/global.less
+++ b/viite-UI/src/less/site/global.less
@@ -188,6 +188,10 @@ img.calibration-point {
   border-bottom: 1px solid darkgray;
 }
 
+.ol-unselectable {
+  background-color: #f0f0f0;
+}
+
 // Scrollbars
 ::-webkit-scrollbar {
   width: 6px;

--- a/viite-UI/src/less/site/map-plugins.less
+++ b/viite-UI/src/less/site/map-plugins.less
@@ -68,6 +68,49 @@
 			}
 		}		
 	}
+
+	.checkbox-dropdown-wrapper .dropdown-toggle {
+		margin-left: 8px;
+		padding: 0 6px;
+		cursor: pointer;
+		user-select: none;
+		width: 100%;
+		height: 22px;
+		font-size: 11px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		box-sizing: border-box;
+	}
+
+	.checkbox-dropdown-wrapper .checkbox-dropdown {
+		margin-left: 8px;
+		display: none;
+		position: absolute;
+		bottom: 100%;
+		left: 0;
+		background: white;
+		border: 1px solid #ccc;
+		box-shadow: 0 2px 5px rgba(0,0,0,0.15);
+		z-index: 15001;
+		padding: 6px;
+		width: 215px;
+		vertical-align: center;
+	}
+
+	.checkbox-dropdown-wrapper.open .checkbox-dropdown {
+		display: block !important;
+	}
+
+	.checkbox-dropdown-wrapper {
+		position: relative;
+	}
+
+	@media (max-width: 1350px) {
+		.hide-on-medium {
+			visibility: hidden;
+		}
+	}
 }
 
 //** Background layer select
@@ -303,7 +346,7 @@
 }
 
 .selectable {
-  -webkit-touch-callout: all; /* iOS Safari */
+  -webkit-touch-callout: default; /* iOS Safari */
   -webkit-user-select: all; /* Safari */
   -khtml-user-select: all; /* Konqueror HTML */
   -moz-user-select: all; /* Firefox */

--- a/viite-UI/src/view/CoordinatesDisplay.js
+++ b/viite-UI/src/view/CoordinatesDisplay.js
@@ -1,36 +1,37 @@
 (function (root) {
-  root.CoordinatesDisplay = function (map, container) {
-    var element =
-      '<div class="mapplugin coordinates" data-position="4">' +
-      '<div class="cbSpansWrapper">' +
-      '<div class="cbRow">' +
-      '<div class="cbCrsLabel">ETRS89-TM35FIN</div>' +
-      '</div>' +
-      '<div class="cbRow">' +
-      '<div class="cbLabel cbLabelN" axis="lat">P:</div>' +
-      '<div class="cbValue" axis="lat">lat</div>' +
-      '</div>' +
-      '<br clear="both">' +
-      '<div class="cbRow">' +
-      '<div class="cbLabel cbLabelE" axis="lon">I:</div>' +
-      '<div class="cbValue" axis="lon">lon</div>' +
-      '</div>' +
-      '</div>' +
-      '<button class="btn btn-sm btn-tertiary" id="mark-coordinates">Merkitse</button>' +
-      '</div>';
-    container.append(element);
+    root.CoordinatesDisplay = function (map, container) {
+        const element = `
+          <div class="mapplugin coordinates" data-position="4">
+            <div class="cbSpansWrapper">
+              <div class="cbRow">
+                <div class="cbCrsLabel hide-on-medium">ETRS89-TM35FIN</div>
+              </div>
+              <div class="cbRow">
+                <div class="cbLabel cbLabelN" axis="lat">P:</div>
+                <div class="cbValue" axis="lat">lat</div>
+              </div>
+              <div class="cbRow">
+                <div class="cbLabel cbLabelE" axis="lon">I:</div>
+                <div class="cbValue" axis="lon">lon</div>
+              </div>
+            </div>
+            <button class="btn btn-sm btn-tertiary" id="mark-coordinates">Merkitse</button>
+          </div>
+        `;
 
-    var centerLonLat = {lon: 0, lat: 0};
-    eventbus.on('map:refresh', function (event) {
-      centerLonLat = event.center;
-      if (centerLonLat) {
-        container.find('.cbValue[axis="lat"]').text(Math.round(centerLonLat[1]));
-        container.find('.cbValue[axis="lon"]').text(Math.round(centerLonLat[0]));
-      }
-    });
+        container.append(element);
 
-    $('#mark-coordinates').on('click', function () {
-      eventbus.trigger('coordinates:marked', centerLonLat);
-    });
-  };
+        let centerLonLat = { lon: 0, lat: 0 };
+        eventbus.on('map:refresh', (event) => {
+            centerLonLat = event.center;
+            if (centerLonLat) {
+                container.find('.cbValue[axis="lat"]').text(Math.round(centerLonLat[1]));
+                container.find('.cbValue[axis="lon"]').text(Math.round(centerLonLat[0]));
+            }
+        });
+
+        $('#mark-coordinates').on('click', () => {
+            eventbus.trigger('coordinates:marked', centerLonLat);
+        });
+    };
 }(this));

--- a/viite-UI/src/view/TileMapCollection.js
+++ b/viite-UI/src/view/TileMapCollection.js
@@ -1,79 +1,77 @@
 (function (root) {
   root.TileMapCollection = function () {
-    var layerConfig = {
-      // minResolution: ?,
-      // maxResolution: ?,
+    const layerConfig = {
       visible: false,
       extent: [-548576, 6291456, 1548576, 8388608]
     };
 
-    var propertyLayerConfig = {
+    const propertyLayerConfig = {
       maxResolution: 5,
       visible: true,
       extent: [-548576, 6291456, 1548576, 8388608]
     };
 
-    var sourceConfig = {
+    const sourceConfig = {
       cacheSize: 4096,
       projection: 'EPSG:3067',
       tileSize: [256, 256]
     };
 
-    var tileGridConfig = {
+    const tileGridConfig = {
       extent: [-548576, 6291456, 1548576, 8388608],
       origin: [-548576, 8388608],
       projection: 'EPSG:3067'
     };
 
-    var resolutionConfig = {
+    const resolutionConfig = {
       resolutions: [8192, 4096, 2048, 1024, 512, 256, 128, 64, 32, 16, 8, 4, 2, 1, 0.5]
     };
 
-    var aerialMapConfig = _.merge({}, sourceConfig, {
+    const aerialMapConfig = _.merge({}, sourceConfig, {
       url: 'wmts/maasto/1.0.0/ortokuva/default/ETRS-TM35FIN/{z}/{y}/{x}.jpg'
     });
 
-    var backgroundMapConfig = _.merge({}, sourceConfig, {
+    const backgroundMapConfig = _.merge({}, sourceConfig, {
       url: 'wmts/maasto/1.0.0/taustakartta/default/ETRS-TM35FIN/{z}/{y}/{x}.png'
     });
 
-    var propertyBorderMapConfig = _.merge({}, sourceConfig, {
+    const propertyBorderMapConfig = _.merge({}, sourceConfig, {
       url: 'wmts/kiinteisto/1.0.0/kiinteistojaotus/default/ETRS-TM35FIN/{z}/{y}/{x}.png'
     });
 
-    var terrainMapConfig = _.merge({}, sourceConfig, {
+    const terrainMapConfig = _.merge({}, sourceConfig, {
       url: 'wmts/maasto/1.0.0/maastokartta/default/ETRS-TM35FIN/{z}/{y}/{x}.png'
     });
 
-    var aerialMapLayer = new ol.layer.Tile(_.merge({
+    const aerialMapLayer = new ol.layer.Tile(_.merge({
       source: new ol.source.XYZ(_.merge({
         tileGrid: new ol.tilegrid.TileGrid(_.merge({}, tileGridConfig, resolutionConfig))
       }, aerialMapConfig))
     }, layerConfig));
     aerialMapLayer.set('name', 'aerialMapLayer');
 
-    var backgroundMapLayer = new ol.layer.Tile(_.merge({
+    const backgroundMapLayer = new ol.layer.Tile(_.merge({
       source: new ol.source.XYZ(_.merge({
         tileGrid: new ol.tilegrid.TileGrid(_.merge({}, tileGridConfig, resolutionConfig))
       }, backgroundMapConfig))
     }, layerConfig));
     backgroundMapLayer.set('name', 'backgroundMapLayer');
 
-    var propertyBorderLayer = new ol.layer.Tile(_.merge({
+    const propertyBorderLayer = new ol.layer.Tile(_.merge({
       source: new ol.source.XYZ(_.merge({
         tileGrid: new ol.tilegrid.TileGrid(_.merge({}, tileGridConfig, resolutionConfig))
       }, propertyBorderMapConfig))
     }, propertyLayerConfig));
     propertyBorderLayer.set('name', 'propertyBorderLayer');
 
-    var terrainMapLayer = new ol.layer.Tile(_.merge({
+    const terrainMapLayer = new ol.layer.Tile(_.merge({
       source: new ol.source.XYZ(_.merge({
         tileGrid: new ol.tilegrid.TileGrid(_.merge({}, tileGridConfig, resolutionConfig))
       }, terrainMapConfig))
     }, layerConfig));
     terrainMapLayer.set('name', 'terrainMapLayer');
 
-    var tileMapLayers = {
+    const tileMapLayers = {
       background: backgroundMapLayer,
       aerial: aerialMapLayer,
       terrain: terrainMapLayer,
@@ -86,10 +84,10 @@
       });
     };
 
-    var togglePropertyBorderVisibility = function (showPropertyBorder) {
+
+    const togglePropertyBorderVisibility = function (showPropertyBorder) {
       propertyBorderLayer.setVisible(showPropertyBorder);
     };
-
 
     selectMap('background');
     eventbus.on('tileMap:selected', selectMap);

--- a/viite-UI/src/view/TileMapSelector.js
+++ b/viite-UI/src/view/TileMapSelector.js
@@ -127,14 +127,6 @@
       eventbus.trigger('tileMap:selected', selectedTileMap.data('layerid'));
     });
 
-    // Toggle map visibility button (unchanged)
-    $('#toggleMapVisibility').on('click', function () {
-      const map = $('#map');
-      map.toggle();
-      const isHidden = map.is(':hidden');
-      $(this).text(isHidden ? 'Näytä kartta' : 'Piilota kartta');
-    });
-
     // Dropdown toggle
     $dropdownToggle.on('click', function (e) {
       e.stopPropagation();

--- a/viite-UI/src/view/TileMapSelector.js
+++ b/viite-UI/src/view/TileMapSelector.js
@@ -44,12 +44,82 @@
             </label>
           </div>
         </div>
+
+        <!-- Dropdown version for small screens -->
+        <div class="checkbox-dropdown-wrapper">
+          <button class="dropdown-toggle" aria-expanded="false">Valitse karttavaihtoehdot</button>
+          <div class="checkbox-dropdown">
+            <label><input type="checkbox" value="propertyBoundariesVisible"  id="dropdown-propertyBoundariesVisible"> Näytä kiinteistörajat</label><br>
+            <label><input type="checkbox" value="unAddressedRoadsVisible" id="dropdown-unAddressedRoadsVisible"> Näytä tieosoitteettomat-linkit</label><br>
+            <label><input type="checkbox" value="underConstructionVisible" id="dropdown-underConstructionVisible"> Näytä rakenteilla-linkit</label><br>
+            <label><input type="checkbox" value="roadsVisible" id="dropdown-roadsVisible"> Näytä tieosoiteverkko</label>
+          </div>
+        </div>
       </div>
     `;
 
     container.append(element);
 
-    // Handle tile map selection
+    const BREAKPOINT_PX = 1220;
+
+    const $checkboxDropdownWrapper = container.find('.checkbox-dropdown-wrapper');
+    const $dropdownToggle = $checkboxDropdownWrapper.find('.dropdown-toggle');
+    const $dropdownCheckboxes = $checkboxDropdownWrapper.find('input[type="checkbox"]');
+
+    const dropdownValueToCheckboxId = {
+      propertyBoundariesVisible: 'propertyBoundariesVisibleCheckbox',
+      unAddressedRoadsVisible: 'unAddressedRoadsVisibleCheckbox',
+      underConstructionVisible: 'underConstructionVisibleCheckbox',
+      roadsVisible: 'roadsVisibleCheckbox'
+    };
+
+    // Sync dropdown checkboxes to match main checkboxes (no events triggered)
+    function syncDropdownCheckboxesFromMain() {
+      $dropdownCheckboxes.each(function () {
+        const value = $(this).val();
+        const mainCheckbox = container.find(`#${dropdownValueToCheckboxId[value]}`);
+        $(this).prop('checked', Boolean(mainCheckbox.prop('checked')));
+      });
+    }
+
+    // When a dropdown checkbox changes, update the corresponding main checkbox
+    // and trigger its change handler only if its state actually changed.
+    function syncMainCheckboxesFromDropdownAndTrigger() {
+      $dropdownCheckboxes.each(function () {
+        const value = $(this).val();
+        const mainCheckbox = container.find(`#${dropdownValueToCheckboxId[value]}`);
+        const newChecked = Boolean($(this).prop('checked'));
+        const prevChecked = Boolean(mainCheckbox.prop('checked'));
+        if (prevChecked !== newChecked) {
+          mainCheckbox.prop('checked', newChecked);
+          mainCheckbox.trigger('change'); // will run the main checkbox handler once
+        }
+      });
+    }
+
+    // Per-checkbox handlers (match original behavior)
+    container.on('change', '#propertyBoundariesVisibleCheckbox', function () {
+      eventbus.trigger('tileMap:togglepropertyBorder', this.checked);
+    });
+
+    container.on('change', '#unAddressedRoadsVisibleCheckbox', function () {
+      eventbus.trigger('unAddressedRoads:toggleVisibility', this.checked);
+      eventbus.trigger('unAddressedProjectRoads:toggleVisibility', this.checked);
+    });
+
+    container.on('change', '#underConstructionVisibleCheckbox', function () {
+      eventbus.trigger('underConstructionRoads:toggleVisibility', this.checked);
+      eventbus.trigger('underConstructionProjectRoads:toggleVisibility', this.checked);
+    });
+
+    // keep same signature as original: call toggleRoadVisibility() (no arg) so existing applicationModel logic is preserved
+    container.on('change', '#roadsVisibleCheckbox', function () {
+      applicationModel.toggleRoadVisibility();
+      eventbus.trigger('linkProperty:visibilityChanged');
+      eventbus.trigger('roadAddressProject:visibilityChanged');
+    });
+
+    // Tile map selection (keeps single-selection behavior for base maps)
     container.find('li[data-layerid]').on('click', event => {
       container.find('li.selected').removeClass('selected');
       const selectedTileMap = $(event.target);
@@ -57,8 +127,7 @@
       eventbus.trigger('tileMap:selected', selectedTileMap.data('layerid'));
     });
 
-
-    // Toggle map visibility
+    // Toggle map visibility button (unchanged)
     $('#toggleMapVisibility').on('click', function () {
       const map = $('#map');
       map.toggle();
@@ -66,21 +135,64 @@
       $(this).text(isHidden ? 'Näytä kartta' : 'Piilota kartta');
     });
 
-    $('#propertyBoundariesVisibleCheckbox').on('change', function () {
-      eventbus.trigger('tileMap:togglepropertyBorder', this.checked);
+    // Dropdown toggle
+    $dropdownToggle.on('click', function (e) {
+      e.stopPropagation();
+      const isOpen = $checkboxDropdownWrapper.hasClass('open');
+      if (isOpen) {
+        $checkboxDropdownWrapper.removeClass('open');
+        $dropdownToggle.attr('aria-expanded', 'false');
+      } else {
+        // before opening, sync states so checkbox states reflect current mains
+        syncDropdownCheckboxesFromMain();
+        $checkboxDropdownWrapper.addClass('open');
+        $dropdownToggle.attr('aria-expanded', 'true');
+      }
     });
-    $('#unAddressedRoadsVisibleCheckbox').on('change', function () {
-      eventbus.trigger('unAddressedRoads:toggleVisibility', this.checked);
-      eventbus.trigger('unAddressedProjectRoads:toggleVisibility', this.checked);
+
+    // Close dropdown when clicking outside
+    $(document).on('click', function (e) {
+      if (!$(e.target).closest('.checkbox-dropdown-wrapper').length) {
+        $checkboxDropdownWrapper.removeClass('open');
+        $dropdownToggle.attr('aria-expanded', 'false');
+      }
     });
-    $('#underConstructionVisibleCheckbox').on('change', function () {
-      eventbus.trigger('underConstructionRoads:toggleVisibility', this.checked);
-      eventbus.trigger('underConstructionProjectRoads:toggleVisibility', this.checked);
+
+    // When dropdown checkbox changes -> sync main checkboxes and run main handlers as necessary
+    $dropdownCheckboxes.on('change', function () {
+      syncMainCheckboxesFromDropdownAndTrigger();
     });
-    $('#roadsVisibleCheckbox').on('change', function () {
-      applicationModel.toggleRoadVisibility();
-      eventbus.trigger('linkProperty:visibilityChanged');
-      eventbus.trigger('roadAddressProject:visibilityChanged');
+
+    // When any main checkbox changes, sync dropdown checkboxes when on small screens
+    container.on('change', '#propertyBoundariesVisibleCheckbox, #unAddressedRoadsVisibleCheckbox, #underConstructionVisibleCheckbox, #roadsVisibleCheckbox', function () {
+      if (window.innerWidth <= BREAKPOINT_PX) {
+        syncDropdownCheckboxesFromMain();
+      }
+    });
+
+    function updateUIForScreenSize() {
+      if (window.innerWidth <= BREAKPOINT_PX) {
+        container.find('.property-boundaries-visible-wrapper, .noroadaddress-visible-wrapper, .underconstruction-visible-wrapper, .roads-visible-wrapper').hide();
+        $checkboxDropdownWrapper.show();
+        syncDropdownCheckboxesFromMain();
+        $checkboxDropdownWrapper.removeClass('open');
+        $dropdownToggle.attr('aria-expanded', 'false');
+      } else {
+        container.find('.property-boundaries-visible-wrapper, .noroadaddress-visible-wrapper, .underconstruction-visible-wrapper, .roads-visible-wrapper').show();
+        $checkboxDropdownWrapper.hide();
+        $checkboxDropdownWrapper.removeClass('open');
+        $dropdownToggle.attr('aria-expanded', 'false');
+      }
+    }
+
+    updateUIForScreenSize();
+
+    window.addEventListener('resize', () => {
+      updateUIForScreenSize();
+      if (window.innerWidth > BREAKPOINT_PX) {
+        $checkboxDropdownWrapper.removeClass('open');
+        $dropdownToggle.attr('aria-expanded', 'false');
+      }
     });
   };
 }(this));

--- a/viite-UI/src/view/TileMapSelector.js
+++ b/viite-UI/src/view/TileMapSelector.js
@@ -1,59 +1,86 @@
 (function (root) {
   root.TileMapSelector = function (container, applicationModel) {
-    var element =
-      '<div class="tile-map-selector">' +
-      '<ul>' +
-      '<li data-layerid="terrain" title="Maastokartta">Maastokartta</li>' +
-      '<li data-layerid="aerial" title="Ortokuvat">Ortokuvat</li>' +
-      '<li data-layerid="background" title="Taustakarttasarja" class="selected">Taustakarttasarja</li>' +
-      '</ul>' +
-      '<div class="property-boundaries-visible-wrapper">' +
-      '<div class="checkbox">' +
-      '<label><input type="checkbox" name="propertyBoundariesVisible" value="propertyBoundariesVisible"  id="propertyBoundariesVisibleCheckbox">Näytä kiinteistörajat</label>' +
-      '</div>' +
-      '</div>' +
-      '<div class="noroadaddress-visible-wrapper">' +
-      '<div class="checkbox">' +
-      '<label><input type="checkbox" name="unAddressedRoadsVisible" value="unAddressedRoadsVisible" checked="false" id="unAddressedRoadsVisibleCheckbox">Näytä tieosoitteettomat-linkit</label>' +
-      '</div>' +
-      '</div>' +
-      '<div class="underconstruction-visible-wrapper">' +
-      '<div class="checkbox">' +
-      '<label><input type="checkbox" name="underConstructionVisible" value="underConstructionVisible" checked="true" id="underConstructionVisibleCheckbox">Näytä rakenteilla-linkit</label>' +
-      '</div>' +
-      '</div>' +
+    const element = `
+      <div class="tile-map-selector">
+        <ul>
+          <li data-layerid="terrain" title="Maastokartta">Maastokartta</li>
+          <li data-layerid="aerial" title="Ortokuvat">Ortokuvat</li>
+          <li data-layerid="background" title="Taustakarttasarja" class="selected">Taustakarttasarja</li>
+          <li data-layerid="none" title="Piilota kartta">Piilota kartta</li>
+        </ul>
 
-      '<div class="roads-visible-wrapper">' +
-      '<div class="checkbox">' +
-      '<label><input type="checkbox" name="roadsVisible" value="roadsVisible" checked="true" id="roadsVisibleCheckbox">Näytä tieosoiteverkko</label>' +
-      '</div>' +
-      '</div>' +
-      '</div>';
+        <div class="property-boundaries-visible-wrapper">
+          <div class="checkbox">
+            <label>
+              <input type="checkbox" id="propertyBoundariesVisibleCheckbox">
+              Näytä kiinteistörajat
+            </label>
+          </div>
+        </div>
+
+        <div class="noroadaddress-visible-wrapper">
+          <div class="checkbox">
+            <label>
+              <input type="checkbox" id="unAddressedRoadsVisibleCheckbox">
+              Näytä tieosoitteettomat-linkit
+            </label>
+          </div>
+        </div>
+
+        <div class="underconstruction-visible-wrapper">
+          <div class="checkbox">
+            <label>
+              <input type="checkbox" id="underConstructionVisibleCheckbox" checked>
+              Näytä rakenteilla-linkit
+            </label>
+          </div>
+        </div>
+
+        <div class="roads-visible-wrapper">
+          <div class="checkbox">
+            <label>
+              <input type="checkbox" id="roadsVisibleCheckbox" checked>
+              Näytä tieosoiteverkko
+            </label>
+          </div>
+        </div>
+      </div>
+    `;
 
     container.append(element);
-    container.find('li').click(function (event) {
+
+    // Handle tile map selection
+    container.find('li[data-layerid]').on('click', event => {
       container.find('li.selected').removeClass('selected');
-      var selectedTileMap = $(event.target);
+      const selectedTileMap = $(event.target);
       selectedTileMap.addClass('selected');
-      eventbus.trigger('tileMap:selected', selectedTileMap.attr('data-layerid'));
+      eventbus.trigger('tileMap:selected', selectedTileMap.data('layerid'));
     });
-    $('#propertyBoundariesVisibleCheckbox').change(function () {
+
+
+    // Toggle map visibility
+    $('#toggleMapVisibility').on('click', function () {
+      const map = $('#map');
+      map.toggle();
+      const isHidden = map.is(':hidden');
+      $(this).text(isHidden ? 'Näytä kartta' : 'Piilota kartta');
+    });
+
+    $('#propertyBoundariesVisibleCheckbox').on('change', function () {
       eventbus.trigger('tileMap:togglepropertyBorder', this.checked);
     });
-    $('#unAddressedRoadsVisibleCheckbox').change(function () {
+    $('#unAddressedRoadsVisibleCheckbox').on('change', function () {
       eventbus.trigger('unAddressedRoads:toggleVisibility', this.checked);
-      eventbus.trigger("unAddressedProjectRoads:toggleVisibility", this.checked);
+      eventbus.trigger('unAddressedProjectRoads:toggleVisibility', this.checked);
     });
-    $('#underConstructionVisibleCheckbox').change(function () {
+    $('#underConstructionVisibleCheckbox').on('change', function () {
       eventbus.trigger('underConstructionRoads:toggleVisibility', this.checked);
-      eventbus.trigger("underConstructionProjectRoads:toggleVisibility", this.checked);
+      eventbus.trigger('underConstructionProjectRoads:toggleVisibility', this.checked);
     });
-    $('#roadsVisibleCheckbox').change(function () {
+    $('#roadsVisibleCheckbox').on('change', function () {
       applicationModel.toggleRoadVisibility();
       eventbus.trigger('linkProperty:visibilityChanged');
       eventbus.trigger('roadAddressProject:visibilityChanged');
-
     });
-
   };
 }(this));


### PR DESCRIPTION
Jatkoa ticketille VIITE-3541. Pienillllä näytöillä näkyy tuo alapalkki siistinä kun osa kartan asetuksista on siirretty dropdowniin. Myös  "ETRS89-TM35FIN" teksti piilotetaan kun ikkuna pienenee.