### PR TITLE
VIITE-3550 Fix complementary link id search

### DIFF
--- a/viite-UI/src/utils/LocationInputParser.js
+++ b/viite-UI/src/utils/LocationInputParser.js
@@ -16,7 +16,7 @@
     var wildLetterRegex = /^(\s*[*]*[A-Za-zÀ-ÿ].*)/;
     var roadNumberRegex = /^\s*(\d+(\s+\d+(\s+\d+(\s+\d)?)?)?)\s*$/; // road addr separated with whitespaces.
     var roadNumberRegex2= /^\s*(\d+(\/\d+(\/\d+(\/\d)?)?)?)\s*$/;    // road addr separated with slashes.
-    const linkIdRegex   = /^\s*(\w+-\w+-\w+-\w+-\w+:\d+)\s*$/;
+    const linkIdRegex   = /^\s*(\w+-\w+-\w+-\w+-\w+:[A-Za-z0-9]+)\s*$/;
 
     var matchedCoordinates = input.match(coordinateRegex);
     if      (matchedCoordinates)            {    return parseCoordinates(matchedCoordinates);  }


### PR DESCRIPTION
by allowing digits and letters after the colon in link id regex instead of just digits.