### PR TITLE
VIITE-3551 Hide tooltip box when moving node

### DIFF
--- a/viite-UI/src/less/site/map-plugins.less
+++ b/viite-UI/src/less/site/map-plugins.less
@@ -157,7 +157,7 @@
         position: absolute;
         top: 0;
         right: 10px;
-		font-size: 0px;
+		font-size: 0;
 		color: @gray-darkest;
 		text-align: right;
 
@@ -237,7 +237,6 @@
     border-width: 0;
     border-style: solid;
     border-color: @gray-darker-2;
-    background-color: @gray-lighter-2;
     background-color: rgba(red(@warning), green(@warning), blue(@warning), .85);
     pointer-events: none;
 }
@@ -294,6 +293,10 @@
 	bottom: 20px;
 	left: -50px;
 	min-width: 103px;
+
+	//Avoid text wrapping to another row, instead make container wider
+	white-space: nowrap;
+	width: auto;
 }
 
 .popup-line-div {
@@ -303,7 +306,7 @@
 }
 
 .selectable {
-  -webkit-touch-callout: all; /* iOS Safari */
+  //-webkit-touch-callout: all; /* iOS Safari */
   -webkit-user-select: all; /* Safari */
   -khtml-user-select: all; /* Konqueror HTML */
   -moz-user-select: all; /* Firefox */

--- a/viite-UI/src/view/RoadLayer.js
+++ b/viite-UI/src/view/RoadLayer.js
@@ -1,5 +1,5 @@
 (function (root) {
-  root.RoadLayer = function (map, roadCollection, selectedLinkProperty, nodeCollection) {
+  root.RoadLayer = function (map) {
     Layer.call(this, map);
 
     window.ViiteState = window.ViiteState || {}; // Global variable for trackin state like node translation
@@ -27,49 +27,61 @@
 
     map.addOverlay(overlay);
 
-    var displayRoadAddressInfo = function (event, pixel) {
-      var featureAtPixel = map.forEachFeatureAtPixel(pixel, function (feature) {
-        return feature;
-      });
-      var coordinate;
+    const displayRoadAddressInfo = (event, pixel) => {
+      const featureAtPixel = map.forEachFeatureAtPixel(pixel, (feature) => feature);
+      let coordinate;
       const popupBox = document.getElementById('popup-content').getBoundingClientRect();
+
       // Prevent update when cursor is in the box
-        if (!(event.originalEvent.clientX < popupBox.right &&
-              event.originalEvent.clientX > popupBox.left &&
-              event.originalEvent.clientY > popupBox.top &&
-              event.originalEvent.clientY < popupBox.bottom))
-      //Ignore if target feature is marker
-      if (!_.isNil(featureAtPixel) && featureAtPixel.linkData) {
-        const roadData = featureAtPixel.linkData;
-        if (infoContent !== null) {
-          if ((roadData.roadNumber !== 0 && roadData.roadPartNumber !== 0)) {
-            coordinate = map.getEventCoordinate(event.originalEvent);
-            infoContent.innerHTML =
-                '<div class="popup-line-div"><div>Tienumero:&nbsp;</div><div class="selectable">'    + roadData.roadNumber + '</div></div>' +
-                '<div class="popup-line-div"><div>Tieosanumero:&nbsp;</div><div class="selectable">' + roadData.roadPartNumber + '</div></div>' +
-                '<div class="popup-line-div"><div>Ajorata:&nbsp;</div><div class="selectable">'      + roadData.trackCode + '</div></div>' +
-                '<div class="popup-line-div"><div>AET:&nbsp;</div><div class="selectable">'          + roadData.addrMRange.start + '</div></div>' +
-                '<div class="popup-line-div"><div>LET:&nbsp;</div><div class="selectable">'          + roadData.addrMRange.end + '</div></div>' +
-                '<div class="popup-line-div"><div>Hall. luokka:&nbsp;</div><div class="selectable">' + displayAdministrativeClass(roadData.administrativeClassId) + '</div></div>';
-            const altShiftPressed = event.originalEvent.shiftKey && event.originalEvent.altKey;
-            if (altShiftPressed) {
-                infoContent.innerHTML += '<hr>';
+      if (!(event.originalEvent.clientX < popupBox.right &&
+          event.originalEvent.clientX > popupBox.left &&
+          event.originalEvent.clientY > popupBox.top &&
+          event.originalEvent.clientY < popupBox.bottom)) {
+
+        // Ignore if target feature is marker
+        if (!_.isNil(featureAtPixel) && featureAtPixel.linkData) {
+          const roadData = featureAtPixel.linkData;
+
+          if (infoContent !== null) {
+            if (roadData.roadNumber !== 0 && roadData.roadPartNumber !== 0) {
+              coordinate = map.getEventCoordinate(event.originalEvent);
+
+              infoContent.innerHTML = `
+                <div class="popup-line-div"><div>Tienumero:&nbsp;</div><div class="selectable">${roadData.roadNumber}</div></div>
+                <div class="popup-line-div"><div>Tieosanumero:&nbsp;</div><div class="selectable">${roadData.roadPartNumber}</div></div>
+                <div class="popup-line-div"><div>Ajorata:&nbsp;</div><div class="selectable">${roadData.trackCode}</div></div>
+                <div class="popup-line-div"><div>AET:&nbsp;</div><div class="selectable">${roadData.addrMRange.start}</div></div>
+                <div class="popup-line-div"><div>LET:&nbsp;</div><div class="selectable">${roadData.addrMRange.end}</div></div>
+                <div class="popup-line-div"><div>Hall. luokka:&nbsp;</div><div class="selectable">${displayAdministrativeClass(roadData.administrativeClassId)}</div></div>
+              `;
+
+              const altShiftPressed = event.originalEvent.shiftKey && event.originalEvent.altKey;
+              if (altShiftPressed) {
+                infoContent.innerHTML += `<hr>`;
+
                 if (!_.isUndefined(roadData.municipalityCode)) {
-                    infoContent.innerHTML += '<div class="popup-line-div"><div>MunicipalityCode:&nbsp;</div><div class="selectable">' + roadData.municipalityCode + '</div></div>';
+                  infoContent.innerHTML += `
+                    <div class="popup-line-div"><div>MunicipalityCode:&nbsp;</div><div class="selectable">${roadData.municipalityCode}</div></div>
+                  `;
                 }
-                infoContent.innerHTML +=
-                    '<div class="popup-line-div"><div>Ely:&nbsp;</div><div class="selectable">'                    + roadData.elyCode + '</div></div>' +
-                    '<div class="popup-line-div"><div>Link&nbsp;id:&nbsp;</div><div class="selectable">'           + roadData.linkId  + '</div></div>' +
-                    '<div class="popup-line-div"><div>LinearLocation&nbsp;id:&nbsp;</div><div class="selectable">' + roadData.linearLocationId + '</div></div>' +
-                    '<div class="popup-line-div"><div>Roadway&nbsp;id:&nbsp;</div><div class="selectable">'        + roadData.roadwayId + '</div></div>' +
-                    '<div class="popup-line-div"><div>RoadwayNumber:&nbsp;</div><div class="selectable">'          + roadData.roadwayNumber + '</div></div>';
+
+                infoContent.innerHTML += `
+                  <div class="popup-line-div"><div>Ely:&nbsp;</div><div class="selectable">${roadData.elyCode}</div></div>
+                  <div class="popup-line-div"><div>Link&nbsp;id:&nbsp;</div><div class="selectable">${roadData.linkId}</div></div>
+                  <div class="popup-line-div"><div>LinearLocation&nbsp;id:&nbsp;</div><div class="selectable">${roadData.linearLocationId}</div></div>
+                  <div class="popup-line-div"><div>Roadway&nbsp;id:&nbsp;</div><div class="selectable">${roadData.roadwayId}</div></div>
+                  <div class="popup-line-div"><div>RoadwayNumber:&nbsp;</div><div class="selectable">${roadData.roadwayNumber}</div></div>
+                `;
+              }
             }
           }
         }
       }
-       // Keep info box open with altkey
-      if (!(event.originalEvent.altKey))
+
+      // Keep info box open with altkey
+      if (!event.originalEvent.altKey) {
         overlay.setPosition(coordinate);
+      }
     };
 
     var displayAdministrativeClass = function (administrativeClassCode) {
@@ -90,97 +102,9 @@
       return administrativeClass;
     };
 
-    var displayNodeInfo = function (event, pixel) {
-      var featureAtPixel = map.forEachFeatureAtPixel(pixel, function (feature) {
-        return feature;
-      });
-      var coordinate;
-      if (!_.isUndefined(featureAtPixel) && !_.isUndefined(featureAtPixel.node)) {
-        coordinate = map.getEventCoordinate(event.originalEvent);
-        if (infoContent !== null) {
-          var nodeName = '';
-          var name = featureAtPixel.getProperties().name;
-          if (!_.isUndefined(name)) {
-            nodeName = 'Nimi: ' + _.escape(name) + '<br>';
-          }
-          infoContent.innerHTML =
-            nodeName +
-            'Solmutyyppi: ' + displayNodeType(featureAtPixel.getProperties().type) + '<br>';
-        }
-        overlay.setPosition(coordinate);
-      }
-
-    };
-
-    var displayNodeType = function (nodeTypeCode) {
-      var nodeType = _.find(ViiteEnumerations.NodeType, function (type) {
-        return type.value === nodeTypeCode;
-      });
-      return _.isUndefined(nodeType) ? ViiteEnumerations.NodeType.UnknownNodeType.description : nodeType.description;
-    };
-
-    var displayJunctionInfo = function (event, pixel) {
-      var featureAtPixel = map.forEachFeatureAtPixel(pixel, function (feature) {
-        return feature;
-      });
-      var coordinate;
-      if (!_.isUndefined(featureAtPixel) && !_.isUndefined(featureAtPixel.junction) && !_.isUndefined(featureAtPixel.junction.junctionPoints)) {
-        var junctionData = featureAtPixel.junction;
-        var junctionPointData = featureAtPixel.junction.junctionPoints;
-        var node = nodeCollection.getNodeByNodeNumber(junctionData.nodeNumber);
-        coordinate = map.getEventCoordinate(event.originalEvent);
-        var roadAddressInfo = [];
-        _.map(junctionPointData, function (point) {
-          roadAddressInfo.push({
-            road: point.roadNumber,
-            part: point.roadPartNumber,
-            track: point.track,
-            addr: point.addrM,
-            beforeAfter: point.beforeAfter
-          });
-        });
-
-        var groupedRoadAddresses = _.groupBy(roadAddressInfo, function (row) {
-          return [row.road, row.track, row.part, row.addr];
-        });
-
-        var roadAddresses = _.partition(groupedRoadAddresses, function (group) {
-          return group.length > 1;
-        });
-
-        var doubleRows = _.map(roadAddresses[0], function (junctionPoints) {
-          var first = _.head(junctionPoints); // TODO VIITE-2028 logic goes here, probably.
-          return {road: first.road, track: first.track, part: first.part, addr: first.addr};
-        });
-
-        var singleRows = _.map(roadAddresses[1], function (junctionPoint) {
-          return {
-            road: junctionPoint[0].road,
-            track: junctionPoint[0].track,
-            part: junctionPoint[0].part,
-            addr: junctionPoint[0].addr
-          };
-        });
-
-        var roadAddressContent = _.sortBy(doubleRows.concat(singleRows), ['road', 'part', 'track', 'addr']);
-
-        if (infoContent !== null) {
-          infoContent.innerHTML =
-            'Solmun&nbsp;nimi:&nbsp;' + ((node) ? node.name.replace(' ', '&nbsp;') : '') + '<br>' +
-            'Tieosoite:<br>' +
-            _.map(roadAddressContent, function (junctionPoint) {
-              return '&thinsp;' + junctionPoint.road + '&nbsp;/&nbsp;' + junctionPoint.track + '&nbsp;/&nbsp;' + junctionPoint.part + '&nbsp;/&nbsp;' + junctionPoint.addr + '<br>';
-            }).join('');
-        }
-        overlay.setPosition(coordinate);
-      }
-    };
-
     //Listen pointerMove and get pixel for displaying roadAddress feature info
     me.eventListener.listenTo(eventbus, 'overlay:update', function (event, pixel) {
       displayRoadAddressInfo(event, pixel);
-      displayNodeInfo(event, pixel);
-      displayJunctionInfo(event, pixel);
     });
 
     var handleRoadsVisibility = function () {
@@ -207,7 +131,7 @@
           case 'node':
             // Don't fetch nodes if one is currently being moved (translated)
             if (window.ViiteState && window.ViiteState.isTranslatingNode) break;
-              eventbus.trigger('nodeLayer:fetch');
+            eventbus.trigger('nodeLayer:fetch');
             break;
           default:
             break;


### PR DESCRIPTION
Aikaisemmin solmua siirrettäessä tooltippi saattoi joskus tulla tielle. Nyt tooltippi katoaa kun solmua siirtää. Lisäksi koodia refaktoroitu ja tyyliä muutettu, jotta teksti ei "wrappaa" uudelle riville, vaan sen sijaan containeri kasvaa tekstin mukana.