### PR TITLE
VIITE-3541 unaddressed links are shown on the map by default. 

### DIFF
--- a/viite-UI/src/view/TileMapSelector.js
+++ b/viite-UI/src/view/TileMapSelector.js
@@ -21,7 +21,7 @@
         <div class="noroadaddress-visible-wrapper">
           <div class="checkbox">
             <label>
-              <input type="checkbox" id="unAddressedRoadsVisibleCheckbox">
+              <input type="checkbox" id="unAddressedRoadsVisibleCheckbox" checked>
               Näytä tieosoitteettomat-linkit
             </label>
           </div>


### PR DESCRIPTION
Added the "checked" attribute to the unaddressedRoadsVisibleCheckbox