### PR TITLE
Evk/viite 3461 evk to link info

### DIFF
--- a/viite-UI/src/model/SelectedLinkProperty.js
+++ b/viite-UI/src/model/SelectedLinkProperty.js
@@ -66,7 +66,7 @@
         var verticalLevels = {verticalLevel: extractUniqueValues(selectedData, 'verticalLevel')};
         var roadPartNumbers = {roadPartNumber: extractUniqueValues(selectedData, 'roadPartNumber')};
         var elyCodes = {elyCode: extractUniqueValues(selectedData, 'elyCode')};
-
+        var evkCodes = {evkCode: extractUniqueValues(selectedData, 'evkCode')};
         // TODO Check that merge was done correctly
         var discontinuity = {discontinuity: parseInt(extractUniqueValues([endRoadOnSelection], 'discontinuity'))};
         var addrMRange = {
@@ -81,7 +81,7 @@
           roadNameSe: extractUniqueValues(selectedData, 'roadNameSe'),
           roadNameSm: extractUniqueValues(selectedData, 'roadNameSm')
         };
-        properties = _.merge(properties, latestModified, municipalityCodes, verticalLevels, roadPartNumbers, roadNames, elyCodes, addrMRange, discontinuity);
+        properties = _.merge(properties, latestModified, municipalityCodes, verticalLevels, roadPartNumbers, roadNames, elyCodes, evkCodes, addrMRange, discontinuity);
       }
       properties = _.merge(properties, roadLinkSource);
       return properties;

--- a/viite-UI/src/utils/backend-utils.js
+++ b/viite-UI/src/utils/backend-utils.js
@@ -40,7 +40,18 @@
       var zoom = params.zoom;
       var boundingBox = params.boundingBox;
       return {
-        url: 'api/viite/roadaddress?zoom=' + zoom + '&bbox=' + boundingBox
+        url: 'api/viite/roadaddress?zoom=' + zoom + '&bbox=' + boundingBox,
+        dataType: 'json',
+        // TODO, Inject mock EVK values, remove later
+        dataFilter: function (raw) {
+          try {
+            var parsed = JSON.parse(raw);
+            var transformed = addMockEvkCodes(parsed);
+            return JSON.stringify(transformed);
+          } catch (e) {
+            return raw;
+          }
+        }
       };
     });
 
@@ -48,7 +59,18 @@
       var roadNumber = params.roadNumber;
       var roadPart = params.roadPartNumber;
       return {
-        url: 'api/viite/roadlinks/wholeroadpart/?roadnumber=' + roadNumber + '&roadpart=' + roadPart
+        url: 'api/viite/roadlinks/wholeroadpart/?roadnumber=' + roadNumber + '&roadpart=' + roadPart,
+        dataType: 'json',
+        // TODO, Inject mock EVK values, remove later
+        dataFilter: function (raw) {
+          try {
+            var parsed = JSON.parse(raw);
+            var transformed = addMockEvkCodes(parsed);
+            return JSON.stringify(transformed);
+          } catch (e) {
+            return raw;
+          }
+        }
       };
     });
 
@@ -106,31 +128,41 @@
 
     this.getProjectLinkByLinkId = _.throttle(function (linkId, callback) {
       return $.getJSON('api/viite/project/roadaddress/linkid/' + linkId, function (data) {
-        return _.isFunction(callback) && callback(data);
+        // TODO Add mock EVK codes, remove this later
+        const dataWithEvk = addMockEvkCodes(data);
+        return _.isFunction(callback) && callback(dataWithEvk);
       });
     }, 1000);
 
     this.getRoadAddressByLinkId = _.throttle(function (linkId, callback) {
       return $.getJSON('api/viite/roadaddress/linkid/' + linkId, function (data) {
-        return _.isFunction(callback) && callback(data);
+        // TODO Add mock EVK codes, remove this later
+        const dataWithEvk = addMockEvkCodes(data);
+        return _.isFunction(callback) && callback(dataWithEvk);
       });
     }, 1000);
 
     this.getPrefillValuesForLink = _.throttle(function (linkId, currentProjectId, callback) {
       return $.getJSON('api/viite/roadlinks/project/prefill?linkId=' + linkId + '&currentProjectId=' + currentProjectId, function (data) {
-        return _.isFunction(callback) && callback(data);
+        // TODO Add mock EVK codes, remove this later
+        const dataWithEvk = addMockEvkCodes(data);
+        return _.isFunction(callback) && callback(dataWithEvk);
       });
     }, 1000);
 
     this.getRoadLinkByMmlId = _.throttle(function (mmlId, callback) {
       return $.getJSON('api/viite/roadlinks/mml/' + mmlId, function (data) {
-        return _.isFunction(callback) && callback(data);
+        // TODO Add mock EVK codes, remove this later
+        const dataWithEvk = addMockEvkCodes(data);
+        return _.isFunction(callback) && callback(dataWithEvk);
       });
     }, 1000);
 
     this.getRoadLinkByMtkId = _.throttle(function (mtkId, callback) {
       return $.getJSON('api/viite/roadlinks/mtkid/' + mtkId, function (data) {
-        return _.isFunction(callback) && callback(data);
+        // TODO Add mock EVK codes, remove this later
+        const dataWithEvk = addMockEvkCodes(data);
+        return _.isFunction(callback) && callback(dataWithEvk);
       });
     }, 1000);
 
@@ -139,7 +171,9 @@
       _.debounce(function (roadNumber, projectID, callback) {
         if (projectID !== 0 && roadNumber !== '') {
           return $.getJSON('api/viite/roadlinks/roadname/' + roadNumber + '/' + projectID, function (data) {
-            return _.isFunction(callback) && callback(data);
+            // TODO Add mock EVK codes, remove this later
+            const dataWithEvk = addMockEvkCodes(data);
+            return _.isFunction(callback) && callback(dataWithEvk);
           });
         } else {
           $('#roadName').val('').change();
@@ -398,7 +432,14 @@
 
       // Handle different data structures
       if (Array.isArray(data)) {
-        return data.map(addEvkToItem);
+        return data.map(function (item) {
+          // Handle array of arrays
+          if (Array.isArray(item)) {
+            return item.map(addEvkToItem);
+          }
+          // Handle regular array items
+          return addEvkToItem(item);
+        });
       } else if (data && typeof data === 'object') {
         // Handle project data with reservedInfo and formedInfo arrays
         if (data.reservedInfo && Array.isArray(data.reservedInfo)) {

--- a/viite-UI/src/view/LinkPropertyForm.js
+++ b/viite-UI/src/view/LinkPropertyForm.js
@@ -1,6 +1,17 @@
 (function (root) {
   root.LinkPropertyForm = function (selectedLinkProperty, roadNamingTool, projectListModel, roadAddressBrowser, roadAddressChangesBrowser, startupParameters, roadNetworkErrorsList, adminPanel) {
     var selectionType = ViiteEnumerations.SelectionType;
+
+    // Helper function to convert ViiteEnumerations objects so they can be used here
+    var createAttributesFromEnum = function(enumObj, useNameProperty) {
+      return _.map(enumObj, function(item) {
+        return {
+          value: item.value,
+          description: useNameProperty ? item.name : item.description
+        };
+      });
+    };
+
     var decodedAttributes = [
       {
         id: 'AJORATA',
@@ -12,37 +23,26 @@
       },
       {
         id: 'ELY',
-        attributes: [
-          {value: 1, description: "Uusimaa"},
-          {value: 2, description: "Varsinais-Suomi"},
-          {value: 3, description: "Kaakkois-Suomi"},
-          {value: 4, description: "Pirkanmaa"},
-          {value: 8, description: "Pohjois-Savo"},
-          {value: 9, description: "Keski-Suomi"},
-          {value: 10, description: "Etelä-Pohjanmaa"},
-          {value: 12, description: "Pohjois-Pohjanmaa"},
-          {value: 14, description: "Lappi"}
-        ]
+        attributes: createAttributesFromEnum(ViiteEnumerations.ElyCodes, true)
+      },
+      {
+        id: 'EVK',
+        attributes: createAttributesFromEnum(ViiteEnumerations.EVKCodes, true)
       },
       {
         id: 'HALLINNOLLINEN LUOKKA',
         attributes: [
-          {value: 1, description: "Valtio"},
-          {value: 2, description: "Kunta"},
-          {value: 3, description: "Yksityinen"},
-          {value: 99, description: "Ei määritelty"}
+          {value: ViiteEnumerations.AdministrativeClass.PublicRoad.value, description: ViiteEnumerations.AdministrativeClass.PublicRoad.textValue},
+          {value: ViiteEnumerations.AdministrativeClass.MunicipalityStreetRoad.value, description: ViiteEnumerations.AdministrativeClass.MunicipalityStreetRoad.textValue},
+          {value: ViiteEnumerations.AdministrativeClass.PrivateRoad.value, description: ViiteEnumerations.AdministrativeClass.PrivateRoad.textValue},
+          {value: ViiteEnumerations.AdministrativeClass.Unknown.value, description: ViiteEnumerations.AdministrativeClass.Unknown.description}
         ]
       },
       {
         id: 'JATKUVUUS',
-        attributes: [
-          {value: 1, description: "Tien loppu"},
-          {value: 2, description: "Epäjatkuva"},
-          {value: 3, description: "ELY:n raja"},
-          {value: 4, description: "Lievä epäjatkuvuus"},
-          {value: 5, description: "Jatkuva"},
+        attributes: createAttributesFromEnum(ViiteEnumerations.Discontinuity, false).concat([
           {value: 6, description: "Rinnakkainen linkki"} /* 5. Jatkuva (Rinnakkainen linkki) */
-        ]
+        ])
       }
     ];
 
@@ -396,6 +396,7 @@
             props.addrMRange.start = '';
           }
           props.elyCode = isNaN(parseFloat(props.elyCode)) ? '' : props.elyCode;
+          props.evkCode = isNaN(parseFloat(props.evkCode)) ? '' : props.evkCode;
           props.addrMRange.end = props.addrMRange.end || '';
           props.discontinuity = props.discontinuity || '';
           props.roadLinkType = props.roadLinkType || '';

--- a/viite-UI/src/view/LinkPropertyForm.js
+++ b/viite-UI/src/view/LinkPropertyForm.js
@@ -181,6 +181,7 @@
       var endAddress   = isOnlyOneRoadAndPartNumberSelected() ? staticField('LOPPUETÄISYYS', linkProperties.addrMRange.end) : constructField('LOPPUETÄISYYS', '');
       var combinedAddrLength = lengthDynamicField();
       var elys = selectedLinkProperty.count() === 1 ? staticField('ELY', firstSelectedLinkProperty.elyCode) : dynamicField('ELY', 'elyCode');
+      var evks = selectedLinkProperty.count() === 1 ? staticField('EVK', firstSelectedLinkProperty.evkCode) : dynamicField('EVK', 'evkCode');
       var administrativeClasses = selectedLinkProperty.count() === 1 ? staticField('HALLINNOLLINEN LUOKKA', firstSelectedLinkProperty.administrativeClassId) : dynamicField('HALLINNOLLINEN LUOKKA', 'administrativeClassId');
       var discontinuities = isOnlyOneRoadAndPartNumberSelected() ? dynamicField('JATKUVUUS', 'discontinuity') : constructField('JATKUVUUS', '');
       var startDate = isOnlyOneRoadAndPartNumberSelected() ? dateDynamicField() : constructField('ALKUPÄIVÄMÄÄRÄ', '');
@@ -212,6 +213,7 @@
         endAddress +
         combinedAddrLength +
         elys +
+        evks +
         administrativeClasses +
         discontinuities +
         startDate +


### PR DESCRIPTION
Linkin mockattu EVK arvo näkyy oikeassa valikossa, kun siitä klikkaa.

Lisätty myös **createAttributesFromEnum** toison välttämiseksi. Eli ViiteEnumerations tiedosto tarjoaa tarvittavat arvot, sen sijaan että ne oltaisiin uudelleen määritelty LinkPropertyFormissa.

Testattu linkeillä, joilla on eri ELY/EVK:
<img width="526" height="297" alt="image" src="https://github.com/user-attachments/assets/047aec4b-aab1-45fd-aff5-62da48474851" />
