### PR TITLE
Viite-3577 disable 2026 project creation

### DIFF
--- a/viite-UI/src/view/NodeForm.js
+++ b/viite-UI/src/view/NodeForm.js
@@ -1,6 +1,7 @@
 (function (root) {
   root.NodeForm = function (selectedNodesAndJunctions, roadCollection, backend, startupParameters) {
     var formCommon = new FormCommon('node-');
+    const datePickerFutureDateRestriction = new Date('2025-12-31');
     var NodeType = ViiteEnumerations.NodeType;
 
     var NODE_POINTS_TITLE = 'Solmukohdat';
@@ -817,10 +818,12 @@
 
             var nodeSD = new Date(parts_DMY[2], parts_DMY[1] - 1, parts_DMY[0]);
             var nowDate = new Date();
-            if(nodeSD.getFullYear() < nowDate.getFullYear()-20) {
+
+            if (nodeSD >= datePickerFutureDateRestriction) {
+              nodeNotificationText = 'Solmun alkupäivämäärä ei voi olla vuosi 2026 tai uudempi.';
+            } else if (nodeSD.getFullYear() < nowDate.getFullYear() - 20) {
               nodeNotificationText = 'Vanha päiväys. Solmun alkupäivämäärä yli 20 vuotta historiassa. Varmista päivämäärän oikeellisuus ennen tallennusta.';
-            }
-            else if(nodeSD.getFullYear() > nowDate.getFullYear()+1){
+            } else if (nodeSD.getFullYear() > nowDate.getFullYear() + 1) {
               nodeNotificationText = 'Tulevaisuuden päiväys. Solmun alkupäivä yli vuoden verran tulevaisuudessa. Varmista päivämäärän oikeellisuus ennen tallennusta.';
             }
             return  '<div class="form-check-date-notifications"> ' +

--- a/viite-UI/src/view/ProjectForm.js
+++ b/viite-UI/src/view/ProjectForm.js
@@ -5,6 +5,7 @@
     var formCommon = new FormCommon('');
     var ProjectStatus = ViiteEnumerations.ProjectStatus;
     var editableStatus = [ProjectStatus.Incomplete.value, ProjectStatus.Unknown.value];
+    const datePickerFutureDateRestriction = new Date('2025-12-31');
 
     // flag to keep track if the project links have been recalculated after the changes made to the project links
     var recalculatedAfterChangesFlag = false;
@@ -213,9 +214,13 @@
     };
 
     var formIsInvalid = function (rootElement) {
-      const dateRegex = /^\d{1,2}.\d{1,2}.\d{4}$/;
+      const dateRegex = /^\d{1,2}\.\d{1,2}\.\d{4}$/;
       const startDateValue = rootElement.find('#projectStartDate').val();
-      return !((rootElement.find('#nimi').val() && startDateValue !== '') && dateRegex.test(startDateValue));
+      if (!rootElement.find('#nimi').val() || startDateValue === '' || !dateRegex.test(startDateValue)) {
+        return true;
+      }
+      const newDate = new Date(dateutil.parseDate(startDateValue));
+      return newDate >= datePickerFutureDateRestriction;
     };
 
     var projDateEmpty = function (rootElement) {
@@ -283,36 +288,36 @@
       };
 
       var reservedHtmlList = function (list) {
-          return _.chain(list)
-            .filter(line => !_.isUndefined(line.currentLength))
-            .map((line, index) => `
-                <div class="form-reserved-roads-list">
-                  ${projectCollection.getDeleteButton(index, line.roadNumber, line.roadPartNumber, 'reservedList')}
-                  ${addSmallLabel(line.roadNumber)}
-                  ${addSmallLabelWithIds(line.roadPartNumber, 'reservedRoadPartNumber')}
-                  ${addSmallLabelWithIds(line.currentLength, 'reservedRoadLength')}
-                  ${addSmallLabelWithIds(line.currentDiscontinuity, 'reservedDiscontinuity')}
-                  ${addSmallLabelWithIds(line.currentEly, 'reservedEly')}
-                </div>`)
-            .join('')
-            .value();
-      };
-
-      var formedHtmlList = function (list) {
         return _.chain(list)
-          .filter(line => !_.isUndefined(line.newLength))
+          .filter(line => !_.isUndefined(line.currentLength))
           .map((line, index) => `
               <div class="form-reserved-roads-list">
-                ${projectCollection.getDeleteButton(index, line.roadNumber, line.roadPartNumber, 'formedList')}
+                ${projectCollection.getDeleteButton(index, line.roadNumber, line.roadPartNumber, 'reservedList')}
                 ${addSmallLabel(line.roadNumber)}
                 ${addSmallLabelWithIds(line.roadPartNumber, 'reservedRoadPartNumber')}
-                ${addSmallLabelWithIds(line.newLength, 'reservedRoadLength')}
-                ${addSmallLabelWithIds(line.newDiscontinuity, 'reservedDiscontinuity')}
-                ${addSmallLabelWithIds(line.newEly, 'reservedEly')}
+                ${addSmallLabelWithIds(line.currentLength, 'reservedRoadLength')}
+                ${addSmallLabelWithIds(line.currentDiscontinuity, 'reservedDiscontinuity')}
+                ${addSmallLabelWithIds(line.currentEly, 'reservedEly')}
               </div>`)
           .join('')
           .value();
-      };
+    };
+
+    var formedHtmlList = function (list) {
+      return _.chain(list)
+        .filter(line => !_.isUndefined(line.newLength))
+        .map((line, index) => `
+            <div class="form-reserved-roads-list">
+              ${projectCollection.getDeleteButton(index, line.roadNumber, line.roadPartNumber, 'formedList')}
+              ${addSmallLabel(line.roadNumber)}
+              ${addSmallLabelWithIds(line.roadPartNumber, 'reservedRoadPartNumber')}
+              ${addSmallLabelWithIds(line.newLength, 'reservedRoadLength')}
+              ${addSmallLabelWithIds(line.newDiscontinuity, 'reservedDiscontinuity')}
+              ${addSmallLabelWithIds(line.newEly, 'reservedEly')}
+            </div>`)
+        .join('')
+        .value();
+    };
 
       var toggleAdditionalControls = function () {
         rootElement.find('header').replaceWith(`
@@ -539,16 +544,21 @@
           projectNotificationText = 'Päivämäärä saa sisältää vain numeroita tai pisteitä';
         }
 
-        //Check the dat input field for dates older than 20 years or dates over 1 year in the future
-        var projectSD = new Date(parts_DMY[2], parts_DMY[1] - 1, parts_DMY[0]);
-        var nowDate = new Date();
-        if(projectSD.getFullYear() < nowDate.getFullYear()-20) {
-          projectNotificationText = 'Vanha päiväys. Projektin alkupäivämäärä yli 20 vuotta historiassa. Varmista päivämäärän oikeellisuus ennen jatkamista.';
+         // Validate project date
+        if (parts_DMY.length >= 3) {
+            var projectSD = new Date(parts_DMY[2], parts_DMY[1] - 1, parts_DMY[0]);
+            var nowDate = new Date();
+
+            if (projectSD >= datePickerFutureDateRestriction) {
+                projectNotificationText = 'Projektin alkupäivämäärä ei voi olla vuosi 2026 tai uudempi.';
+            } else if (projectSD.getFullYear() < nowDate.getFullYear() - 20) {
+                projectNotificationText = 'Vanha päiväys. Projektin alkupäivämäärä yli 20 vuotta historiassa. Varmista päivämäärän oikeellisuus ennen jatkamista.';
+            } else if (projectSD.getFullYear() > nowDate.getFullYear() + 1) {
+                projectNotificationText = 'Tulevaisuuden päiväys. Projektin alkupäivä yli vuoden verran tulevaisuudessa. Varmista päivämäärän oikeellisuus ennen jatkamista.';
+            }
         }
-        else if(projectSD.getFullYear() > nowDate.getFullYear()+1){
-          projectNotificationText = 'Tulevaisuuden päiväys. Projektin alkupäivä yli vuoden verran tulevaisuudessa. Varmista päivämäärän oikeellisuus ennen jatkamista.';
-        }
-        return   projectNotificationText;
+
+        return projectNotificationText;
       };
 
       eventbus.on('projectStartDate:notificationCheck', function (projectStartDate) {


### PR DESCRIPTION
ELY/EVK muutosten takia käyttäjät eivät saa luoda uusia tieosoiteprojekteja tai solmuja vuoden 2025 jälkeen. Nyt päivämäärät validoidaan näin, ja käyttäjälle näytetään viesti mikäli he yrittävät luoda uusia projekteja tai solmuja 2026 vuodelle tai sen jälkeen.

Testattu Chromella ja Firefoxilla, uusilla ja vanhoilla projekteilla/solmuilla..

<img width="513" height="99" alt="image" src="https://github.com/user-attachments/assets/7c74a54c-2efa-4c84-b14e-4aef3e89dadb" />


<img width="524" height="315" alt="image" src="https://github.com/user-attachments/assets/40810e0c-72ea-4d21-a12e-e135112608d8" />
