### PR TITLE
VIITE-3585 Fix wrong buttons being displayed after saving link changes

### DIFF
--- a/viite-UI/src/view/ProjectForm.js
+++ b/viite-UI/src/view/ProjectForm.js
@@ -14,6 +14,13 @@
       recalculatedAfterChangesFlag = bool;
     });
 
+    eventbus.on('roadAddressProject:projectLinkSaved', function() {
+      // Hide action buttons (Tallenna, Peruuta)
+      $('#actionButtons').empty();
+      // Show project buttons (Päivitä etäisyyslukemat, etc.)
+      $('.project-form.form-controls').html(formCommon.projectButtons());
+    });
+
     var getRecalculatedAfterChangesFlag = function () {
       return recalculatedAfterChangesFlag;
     };
@@ -145,8 +152,6 @@
         '</div></div></div></div>' +
         '<footer>' + actionButtons() + '</footer>');
     };
-
-
 
     var selectedProjectLinkTemplateDisabledButtons = function (project) {
       let devToolValidationButton = '';
@@ -590,6 +595,7 @@
         html += '<button id="saveEdit" class="save btn btn-save" disabled>Tallenna</button>' +
           '<button id="cancelEdit" class="cancel btn btn-cancel">Peruuta</button>';
         $('#actionButtons').html(html);
+        console.log("Load edit");
         eventbus.trigger("roadAddressProject:clearAndDisableInteractions");
       };
 


### PR DESCRIPTION
Korjattu bugi jonka takia kuvan mukaiset nappulat eivät tulleet näkyviin kun linkin muutokset tallennettiin:

<img width="590" height="185" alt="image" src="https://github.com/user-attachments/assets/429d089a-718d-494e-8bf3-c584af5ac265" />
