### PR TITLE
VIITE-3606 Fix critical vulnerability by updating commons-text library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,8 @@ val env: String = sys.props.getOrElse("env", "-").toLowerCase
 dependencyOverrides ++= Seq(
   "org.scala-lang.modules" %% "scala-xml" % "1.3.0",
   "org.scalactic" %% "scalactic" % "3.2.17",
-  "org.scalatest" %% "scalatest" % "3.2.17"
+  "org.scalatest" %% "scalatest" % "3.2.17",
+  "org.apache.commons" % "commons-text" % "1.10.0"
 )
 
 enablePlugins(AssemblyPlugin)


### PR DESCRIPTION
Korjattu kriittinen haavoittuvuus, ja Viitteen pääominaisuudet testattu toimivaksi. Epäselvää tosin on se, että toimiiko kyseinen ratkaisu, sillä ymmärtääkseni kyseinen haavoittuva kirjasto ei ollut suoraan Viitteen käytössä, vaan se oli niin kutsuttu "ala kirjasto".