### PR TITLE
Fix user filtering

### DIFF
--- a/viite-UI/src/view/navigationpanel/ProjectListModel.js
+++ b/viite-UI/src/view/navigationpanel/ProjectListModel.js
@@ -151,6 +151,11 @@
     }
 
     function hide() {
+      // Reset filter state
+      filterBox.visible = false;
+      $('#userNameBox').val('');
+      $('#userFilterSpan').hide();
+      
       projectList.hide();
       eventbus.trigger("roadAddressProject:startAllInteractions");
       $('.modal-overlay').remove();


### PR DESCRIPTION
Korjataan bugi projekti näkymän käyttäjä filtteröinnissä, joka ei aiemmin resetoinut kun projekti ikkunan sulki.

Tämä siis kyseessä
<img width="256" height="78" alt="image" src="https://github.com/user-attachments/assets/c92c3724-e5b3-4cbd-8ac0-87b503dc3771" />
