### PR TITLE
VIITE-3698 remove default checkbox reset

### DIFF
--- a/viite-UI/src/model/ApplicationModel.js
+++ b/viite-UI/src/model/ApplicationModel.js
@@ -175,22 +175,6 @@
       } else if (layer === 'linkProperty' && toggleStart) {
         eventbus.trigger('roadLayer:toggleProjectSelectionInForm', layer, noSave);
       }
-      const underConstructionVisibleCheckbox = $('#underConstructionVisibleCheckbox')[0];
-      if (layer !== selectedLayer || toggleStart) {
-        if (underConstructionVisibleCheckbox) {
-          $('#underConstructionVisibleCheckbox')[0].checked = true;
-          $('#underConstructionVisibleCheckbox')[0].disabled = false;
-        }
-        eventbus.trigger('underConstructionProjectRoads:toggleVisibility', true);
-      }
-      const unAddressedRoadsVisibleCheckbox = $('#unAddressedRoadsVisibleCheckbox')[0];
-      if (layer !== selectedLayer || toggleStart) {
-        if (unAddressedRoadsVisibleCheckbox) {
-          $('#unAddressedRoadsVisibleCheckbox')[0].checked = true;
-          $('#unAddressedRoadsVisibleCheckbox')[0].disabled = false;
-        }
-        eventbus.trigger("unAddressedProjectRoads:toggleVisibility", true);
-      }
     };
 
     const addSpinner = function() {


### PR DESCRIPTION
Jostain syystä vanha koodi resettasi työkalupalkin checkboxit kun jokin valikko suljettiin. Poistettiin se, jotta käyttäjän valitsemat asetukset eivät muutu eri valikkojen välillä.
<img width="804" height="33" alt="image" src="https://github.com/user-attachments/assets/ee598271-edc8-4507-ba3e-c1e8e94a9ad1" />
