### PR TITLE
VIITE-3625 Enable test automation clicks via crosshair

### DIFF
--- a/viite-UI/src/view/CrosshairToggle.js
+++ b/viite-UI/src/view/CrosshairToggle.js
@@ -1,19 +1,113 @@
-window.CrosshairToggle = function (parentElement) {
-  var crosshairToggle = $('<div class="crosshair-wrapper"><div class="checkbox"><label><input type="checkbox" name="crosshair" value="crosshair" checked="true"/> Kohdistin</label></div></div>');
+/**
+ * Creates a UI toggle and a crosshair overlay logic for OpenLayers maps. 
+ * Primarily used to facilitate E2E testing by allowing programmatic clicks 
+ * at the exact center of the map viewport.
+ * The crosshair is created at MapView.js
+ * 
+ * * E2E USAGE:
+ * Trigger click at crosshair:
+ * await page.evaluate(() => window.crosshair.click());
+ * 
+ * Capture data of the clicked feature:
+ * const data = await page.evaluate(() => window.crosshair.click());
+ */
+window.createCrosshairToggle = (parentElement, map, onFeatureClick = null) => {
+  const crosshairSelector = '.crosshair';
 
-  var render = function () {
-    parentElement.append(crosshairToggle);
+  const performClick = (callback) => {
+    const coords = getCrosshairCenter();
+    if (!coords) return;
+
+    // Extract data
+    const clickData = getFeatureDataAtAtPixel(coords.x, coords.y);
+
+    // Simulate events
+    dispatchMapEvents(coords.x, coords.y);
+
+    // Notifications
+    console.log('Crosshair Click Data:', clickData);
+    const finalCallback = callback || onFeatureClick;
+    if (typeof finalCallback === 'function') finalCallback(clickData);
+    
+    window.dispatchEvent(new CustomEvent('crosshairFeatureClick', { detail: clickData }));
   };
 
-  var bindEvents = function () {
-    $('input', crosshairToggle).change(function () {
-      $('.crosshair').toggle(this.checked);
+  // Initialization
+  const $crosshairElement = createUI();
+  
+  $(document).on('keydown', onKeyDown);
+  parentElement.append($crosshairElement);
+
+  // Returned interface API that other files can access
+  return {
+    click: () => performClick(), // Click the map at the crosshair coordinates
+    getData: () => { // Returns link data for instance
+      const coords = getCrosshairCenter();
+      return coords ? getFeatureDataAtAtPixel(coords.x, coords.y) : null;
+    },
+    destroy: () => { // Clean up unused listeners
+      $(document).off('keydown', onKeyDown);
+      $crosshairElement.remove();
+    }
+  };
+
+  // Helper functions
+
+  function getFeatureDataAtAtPixel(x, y) {
+    const viewport = map.getViewport();
+    const viewRect = viewport.getBoundingClientRect();
+    const pixel = [x - viewRect.left, y - viewRect.top];
+    const features = [];
+
+    map.forEachFeatureAtPixel(pixel, (feature, layer) => {
+      features.push({
+        feature: feature,
+        layer: layer,
+        properties: feature.getProperties(),
+        linkData: feature.linkData || null
+      });
     });
-  };
 
-  var show = function () {
-    render();
-    bindEvents();
-  };
-  show();
+    return { features, pixel, coordinate: map.getCoordinateFromPixel(pixel), hasFeatures: features.length > 0 };
+  }
+
+  // Handles the canvas click
+  function dispatchMapEvents(x, y) {
+    const viewport = map.getViewport();
+    const target = viewport.querySelector('canvas') || viewport;
+    const eventInit = { clientX: x, clientY: y, bubbles: true };
+    
+    target.dispatchEvent(new PointerEvent('pointerdown', { ...eventInit, buttons: 1 }));
+    target.dispatchEvent(new PointerEvent('pointerup', { ...eventInit, buttons: 0 }));
+  }
+
+  function getCrosshairCenter() {
+    const el = document.querySelector(crosshairSelector);
+    if (!el) return null;
+    const rect = el.getBoundingClientRect();
+    return {
+      x: rect.left + (rect.width / 2),
+      y: rect.top + (rect.height / 2)
+    };
+  }
+
+  function createUI() {
+    const $element = $(`
+      <div class="crosshair-wrapper">
+        <div class="checkbox">
+          <label><input type="checkbox" name="crosshair" checked="true"/> Kohdistin</label>
+        </div>
+      </div>
+    `);
+    $element.find('input').on('change', (e) => $(crosshairSelector).toggle(e.target.checked));
+    return $element;
+  }
+
+  // Debugging / alternate way to trigger click via shift + c
+  function onKeyDown(e) {
+    if (e.key.toUpperCase() === 'C' && e.shiftKey) {
+      e.preventDefault();
+      performClick(); //Uncomment to enable
+    }
+  }
 };

--- a/viite-UI/src/view/MapView.js
+++ b/viite-UI/src/view/MapView.js
@@ -57,7 +57,9 @@
       var zoom = zoomlevels.getViewZoom(map);
       applicationModel.setZoomLevel(zoom);
 
-      new CrosshairToggle($('.mapplugin.coordinates'));
+      // eslint-disable-next-line no-undef
+      const crosshair = createCrosshairToggle($('.mapplugin.coordinates'), map);
+      window.crosshair = crosshair; 
       isInitialized = true;
       eventbus.trigger('map:initialized', map);
     }, this);


### PR DESCRIPTION
Tämän päivityksen avulla pitäisi olla nyt helppoa klikata kartan eri elementtejä testiautomaation kautta.

Pitäisi toimia tällä: await page.evaluate(() => window.crosshair.click());
Mutta toisena vaihtoehtona klikkauksen voi myös tehdä painamalla shift + c.