### PR TITLE
Viite 3698 remove checkbox reset

### DIFF
--- a/viite-UI/src/model/ApplicationModel.js
+++ b/viite-UI/src/model/ApplicationModel.js
@@ -175,22 +175,6 @@
       } else if (layer === 'linkProperty' && toggleStart) {
         eventbus.trigger('roadLayer:toggleProjectSelectionInForm', layer, noSave);
       }
-      const underConstructionVisibleCheckbox = $('#underConstructionVisibleCheckbox')[0];
-      if (layer !== selectedLayer || toggleStart) {
-        if (underConstructionVisibleCheckbox) {
-          $('#underConstructionVisibleCheckbox')[0].checked = true;
-          $('#underConstructionVisibleCheckbox')[0].disabled = false;
-        }
-        eventbus.trigger('underConstructionProjectRoads:toggleVisibility', true);
-      }
-      const unAddressedRoadsVisibleCheckbox = $('#unAddressedRoadsVisibleCheckbox')[0];
-      if (layer !== selectedLayer || toggleStart) {
-        if (unAddressedRoadsVisibleCheckbox) {
-          $('#unAddressedRoadsVisibleCheckbox')[0].checked = true;
-          $('#unAddressedRoadsVisibleCheckbox')[0].disabled = false;
-        }
-        eventbus.trigger("unAddressedProjectRoads:toggleVisibility", true);
-      }
     };
 
     const addSpinner = function() {

--- a/viite-UI/src/view/LinkPropertyLayer.js
+++ b/viite-UI/src/view/LinkPropertyLayer.js
@@ -648,7 +648,11 @@
         showLayer();
         eventbus.trigger('linkProperty:fetch');
       }
-      me.toggleLayersVisibility(layers, applicationModel.getRoadVisibility());
+      // Exclude unAddressedRoadLayer from general visibility toggle since it has its own checkbox control
+      const layersWithoutUnAddressed = layers.filter(function(layerItem) {
+        return layerItem !== unAddressedRoadLayer;
+      });
+      me.toggleLayersVisibility(layersWithoutUnAddressed, applicationModel.getRoadVisibility());
     });
 
     var clearHighlights = function () {


### PR DESCRIPTION
Korjattu bugi, jonka takia tieosoitteettomat linkit ilmestyivät takaisin näkyviin, vaikka checkboxi olikin pois päältä