### PR TITLE
VIITE-3370 Fix direction arrow colors

### DIFF
--- a/viite-UI/src/map/LinkPropertyMarker.js
+++ b/viite-UI/src/map/LinkPropertyMarker.js
@@ -8,30 +8,26 @@
         type: "marker"
       });
 
-      var colorMap =
-        {           //comment includes legend name
-          1: '#db0e0e',         //Valtatie
-          2: '#ff6600',         //Kantatie
-          3: '#ff9955',         //Seututie
-          4: '#1414db',         //Yhdystie (dark blue)
-          5: '#10bfc4',         //Yhdystie (light blue)
-          6: '#800080',         //Numeroitu katu
-          7: '#10bfc4',         //Ramppi tai kiertoliittymä
-          8: '#fc6da0',         //Jalka tai pyörätie
-          9: '#fc6da0',         //Talvitie
-          10: '#fc6da0',        //Polku
-          11: '#888888',         //Muu tieverkko
-          12: '#FF55DD'         //Yksityistie, talvitie tai polku
+      function getDirectionMarkerColor(roadLink) {
+
+        // Use map for O(1) lookup
+        const statusColors = {
+          [ViiteEnumerations.RoadAddressChangeType.Unchanged.value]:   '#4544f7', // Blue
+          [ViiteEnumerations.RoadAddressChangeType.New.value]:         '#f680df', // Pink
+          [ViiteEnumerations.RoadAddressChangeType.Transfer.value]:    '#f64443', // Red
+          [ViiteEnumerations.RoadAddressChangeType.Terminated.value]:  '#555453', // Dark Grey
+          [ViiteEnumerations.RoadAddressChangeType.Numbering.value]:   '#a67550', // Brown
+          [ViiteEnumerations.RoadAddressChangeType.NotHandled.value]:  '#f0f663'  // Yellow
         };
 
-      var directionMarkerColor = function (roadLink) {
-        if (roadLink.status === ViiteEnumerations.RoadAddressChangeType.New.value) {
-          return '#ff55dd';
-        } else if (roadLink.roadClass in colorMap) {
-          return colorMap[roadLink.roadClass];
-        } else
-          return '#888888';
-      };
+        // Check if link status matches any of the keys in the map and return the corresponding color
+        if (statusColors[roadLink.status]) {
+          return statusColors[roadLink.status];
+        }
+
+        // Default fallback
+        return '#888888';
+      }
 
       function hex2Rgba(hex) {
         const hexa = hex.replace('#', '');
@@ -42,7 +38,7 @@
       }
 
       var boxStyleDirectional = function (rl) {
-        var markerColor = hex2Rgba(directionMarkerColor(rl));
+        var markerColor = hex2Rgba(getDirectionMarkerColor(rl));
         var directionMarker = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 258.4 387.6" width="36px"  height="22px"> <g transform="translate(-350.8,-86.2)"> <path d="M 609.2,344.6 C 609.2,215.4 480,86.2 480,86.2 c 0,0 -129.2,129.2 -129.2,258.4 0,81.8 68.9,129.2 129.2,129.2 60.3,0 129.2,-47.3 129.2,-129.2 z M 480,441.5 c -53.8,0 -96.9,-43.1 -96.9,-96.9 0,-53.8 43.1,-96.9 96.9,-96.9 53.8,0 96.9,43.1 96.9,96.9 0,53.8 -43.1,96.9 -96.9,96.9 z" fill="' + markerColor + '"/><path d="M 582.7,341.9 C 582.7,234.9 480,128 480,128 c 0,0 -102.7,106.9 -102.7,213.9 0,67.7 54.8,106.9 102.7,106.9 47.9,0 102.7,-39.2 102.7,-106.9 z" fill="rgba(255,255,255,1)"/> 	<path    d="m 556.4,345.6 c 0,-40.9 -34.5,-75.4 -75.4,-75.4 -40.9,0 -75.4,34.5 -75.4,75.4 0,40.9 34.5,75.4 75.4,75.4 40.9,0 75.4,-34.5 75.4,-75.4 z " fill="' + markerColor + '"/> </g></svg>';
         return new ol.style.Style({
           image: new ol.style.Icon({


### PR DESCRIPTION
Korjaa bugin, joka teki suuntanuolista väärän värisiä.

Ennen:
<img width="484" height="89" alt="image" src="https://github.com/user-attachments/assets/0ab468bb-d820-474f-b25a-ce3b0a775c8b" />

Jälkeen:
<img width="610" height="274" alt="image" src="https://github.com/user-attachments/assets/4155358f-748c-4f53-8648-35bd26721e8d" />
