### PR TITLE
VIITE-3721 Disable calculate distance button if errors exist

### DIFF
--- a/viite-UI/src/view/ProjectForm.js
+++ b/viite-UI/src/view/ProjectForm.js
@@ -449,7 +449,12 @@
         if (currentProject.statusCode === 10 || currentProject.statusCode === 11 || currentProject.statusCode === 12) {
           buttonsWhenInspectingUneditableProject();
         } else {
-          formCommon.setDisabledAndTitleAttributesById("recalculate-button", false, "");
+          const projectErrors = projectCollection.getProjectErrors();
+          if (projectErrors.length === 0) {
+            formCommon.setDisabledAndTitleAttributesById("recalculate-button", false, "");
+          } else {
+            formCommon.setDisabledAndTitleAttributesById("recalculate-button", true);
+          }
           formCommon.setDisabledAndTitleAttributesById("changes-button", true, "Päivitä etäisyyslukemat ensin");
           formCommon.setInformationContent();
           formCommon.setInformationContentText("Päivitä etäisyyslukemat jatkaaksesi projektia.");


### PR DESCRIPTION
Korjataan bugi, jonka takia päivitä etäisyyslukemat nappulaa pystyi klikkaamaan, kun olemassa olevan projektin avasi, joka sisälsi virheitä.