### PR TITLE
Added sequence restart

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,7 +1,10 @@
 version: '3'
-  
-dotenv: [".env"]
-set: [u, pipefail]
+
+dotenv:
+  - .env
+set:
+  - u
+  - pipefail
 
 includes:
   db:
@@ -17,17 +20,17 @@ includes:
     dir: .
 
   restore:
-      taskfile: ./taskfiles/db-restore.yml
-      dir: .
+    taskfile: ./taskfiles/db-restore.yml
+    dir: .
 
 tasks:
   default:
-    desc: Commands available. 
+    desc: Commands available.
     silent: true
     cmds:
       - |
         cat <<'EOF'
-        
+
         -- COMMON -----------------------------------
         * db:connect:                 Open SSM port-forward to DEFAULT DB (background via tmux)
         * db:disconnect:              Stop DEFAULT SSM port-forward
@@ -43,6 +46,7 @@ tasks:
         -- FLYWAY ------------------------------------
         * flyway:history:             Show flyway_schema_history
         * flyway:migrate:             Flyway migrate via DataFixture (uses tunnel unless FLYWAY_URL is set)
+        * flyway:repair:              Flyway repair via DataFixture (fix checksum metadata)
         * flyway:tunnel:start:        Open SSM port-forward to RDS (dev) via tmux
         * flyway:tunnel:stop:         Stop SSM tunnel (tmux)
 
@@ -50,5 +54,5 @@ tasks:
         * restore:connect-target:     Open SSM port-forward to TARGET DB
         * restore:disconnect-target:  Stop TARGET SSM port-forward
         * restore:restore:            Restore latest dump to TARGET
-        
+
         EOF

--- a/db/admin/db_backup.sh
+++ b/db/admin/db_backup.sh
@@ -65,6 +65,7 @@ TS="$(date -u +"%Y%m%dT%H%M%SZ")"
 
 # Include env label in filename
 DUMPFILE="$OUTDIR/backup_${ENV_LABEL}_${PGDATABASE}_${SCHEMA}_${TS}.dump"
+SEQFILE="${DUMPFILE%.dump}.sequences.sql"
 
 # Prefer PG tools if installed. Fallback to PATH if not found.
 PSQL_BIN="${PSQL_BIN:-/usr/lib/postgresql/13/bin/psql}"
@@ -106,6 +107,7 @@ echo "  psql   = $($PSQL_BIN --version)"
 echo "  pg_dump= $($PG_DUMP_BIN --version)"
 echo "Output:"
 echo "  file   = $DUMPFILE"
+echo "  seqfile= $SEQFILE"
 echo
 
 psql_src() {
@@ -153,6 +155,28 @@ echo
 echo "✅ Backup complete"
 echo "Dump file:"
 echo "  $DUMPFILE"
+echo
+
+echo "== Export source sequence values =="
+{
+  echo "-- Source sequence values snapshot"
+  echo "-- source_host=${ENV_HOST} db=${PGDATABASE} captured_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  psql_src -tA -c "
+    SELECT format(
+      'SELECT setval(%L, %s, true);',
+      format('%I.%I', schemaname, sequencename),
+      COALESCE(last_value::bigint, 1)
+    )
+    FROM pg_sequences
+    WHERE schemaname = '${SCHEMA}'
+      AND sequencename <> 'db_restore_log_id_seq'
+    ORDER BY schemaname, sequencename;
+  "
+} > "$SEQFILE"
+
+SEQ_LINES="$(grep -c '^SELECT setval(' "$SEQFILE" || true)"
+echo "  sequence statements = $SEQ_LINES"
+echo "  sequence file       = $SEQFILE"
 echo
 
 echo "== Verify: dump contains TABLE DATA entries =="

--- a/db/admin/db_restore.sh
+++ b/db/admin/db_restore.sh
@@ -54,6 +54,25 @@ if [[ "$DUMPFILE" == "__LATEST__" ]]; then
 fi
 [[ -n "$DUMPFILE" ]] || die "No dump file specified/found."
 [[ -f "$DUMPFILE" ]] || die "Dump file not found: $DUMPFILE"
+SEQFILE="${DUMPFILE%.dump}.sequences.sql"
+SEQFILE_EXISTS=0
+[[ -s "$SEQFILE" ]] && SEQFILE_EXISTS=1
+[[ "$SEQFILE_EXISTS" -eq 1 ]] || die "Missing sequence sidecar file: $SEQFILE (run backup with current db_backup.sh)"
+
+# Parse sidecar file once to a VALUES list for readable apply output.
+SEQ_VALUES_SQL="$({
+  awk -F"'" '
+    /^SELECT[[:space:]]+setval\(/ {
+      seq_name = $2
+      if (seq_name == "public.db_restore_log_id_seq") next
+      if (match($0, /,[[:space:]]*([0-9]+)[[:space:]]*,[[:space:]]*true\)[[:space:]]*;/, m)) {
+        printf "(\047%s\047, %s),\n", seq_name, m[1]
+      }
+    }
+  ' "$SEQFILE"
+} )"
+SEQ_VALUES_SQL="${SEQ_VALUES_SQL%,}"
+[[ -n "$SEQ_VALUES_SQL" ]] || die "No applicable sequence values found in sidecar: $SEQFILE"
 
 # -------------------------
 # Env + safety gates
@@ -145,6 +164,7 @@ echo "  tables  = $TABLES_FILE (${#TABLES[@]} tables)"
 echo "  target  = $DB_TARGET_NAME @ $TARGET_HOST:$TARGET_PORT (user=$DB_TARGET_USER)"
 echo "  access  = $DB_TARGET_ACCESS"
 echo "  dump    = $DUMPFILE"
+echo "  seqfile = $SEQFILE"
 echo "  source  = $SOURCE_LABEL"
 echo "  tools   = $($PSQL_BIN --version) | $($PG_RESTORE_BIN --version)"
 echo
@@ -287,6 +307,22 @@ export PGAPPNAME="db_restore_stream"
   # pg_restore may set search_path; restore it for subsequent DDL
   echo "SET search_path = ${SCHEMA}, \"\$user\";"
 
+  echo "\echo 'Apply source sequence values from sidecar...'"
+  cat <<SQL
+WITH seqs(seq_name, seq_value) AS (
+  VALUES
+  $SEQ_VALUES_SQL
+),
+applied AS (
+  SELECT seq_name, setval(seq_name::regclass, seq_value, true) AS applied_value
+  FROM seqs
+)
+SELECT
+  row_number() OVER (ORDER BY seq_name) || '. ' || seq_name || ': ' || applied_value AS sequence_value
+FROM applied
+ORDER BY seq_name;
+SQL
+
   if [[ "$FK_COUNT" -gt 0 ]]; then
     echo "\echo 'Recreate FKs NOT VALID...'"
     printf "%s\n" "$FK_CREATE_SQL"
@@ -309,6 +345,11 @@ psql_tgt -c "
     restored_at timestamptz NOT NULL DEFAULT now(),
     backup_file text NOT NULL,
     source_label text NULL
+  );
+  SELECT setval(
+    pg_get_serial_sequence('${SCHEMA}.db_restore_log', 'id'),
+    COALESCE((SELECT MAX(id) FROM ${SCHEMA}.db_restore_log), 0) + 1,
+    false
   );
   INSERT INTO ${SCHEMA}.db_restore_log(backup_file, source_label)
   VALUES ('${DUMPFILE//\'/\'\'}', '${SOURCE_LABEL//\'/\'\'}');

--- a/db/admin/db_restore.sh
+++ b/db/admin/db_restore.sh
@@ -195,7 +195,15 @@ fi
 # Safety: dump must contain only whitelisted TABLE DATA entries
 # -------------------------
 echo "== Safety: dump TABLE DATA whitelist =="
-DUMP_TABLES="$("$PG_RESTORE_BIN" -l "$DUMPFILE" \
+DUMP_LIST_RAW=""
+if ! DUMP_LIST_RAW="$("$PG_RESTORE_BIN" -l "$DUMPFILE" 2>&1)"; then
+  if printf "%s" "$DUMP_LIST_RAW" | grep -qi "unsupported version"; then
+    die "pg_restore cannot read dump format. Use a newer PG_RESTORE_BIN (dump likely created with newer pg_dump). Details: $DUMP_LIST_RAW"
+  fi
+  die "pg_restore -l failed: $DUMP_LIST_RAW"
+fi
+
+DUMP_TABLES="$(printf "%s" "$DUMP_LIST_RAW" \
   | awk -F';' '
       /TABLE DATA/ {
         line=$2
@@ -302,7 +310,9 @@ export PGAPPNAME="db_restore_stream"
   echo "$TRUNC_SQL"
 
   echo "\echo 'pg_restore data-only...'"
-  "$PG_RESTORE_BIN" --verbose --data-only --no-owner --no-privileges -f - "$DUMPFILE"
+  # pg_restore 17 emits SET transaction_timeout, which PostgreSQL 15 does not recognize.
+  "$PG_RESTORE_BIN" --verbose --data-only --no-owner --no-privileges -f - "$DUMPFILE" \
+    | sed -E '/^SET[[:space:]]+transaction_timeout[[:space:]]*=/d'
 
   # pg_restore may set search_path; restore it for subsequent DDL
   echo "SET search_path = ${SCHEMA}, \"\$user\";"
@@ -313,14 +323,30 @@ WITH seqs(seq_name, seq_value) AS (
   VALUES
   $SEQ_VALUES_SQL
 ),
-applied AS (
-  SELECT seq_name, setval(seq_name::regclass, seq_value, true) AS applied_value
+resolved AS (
+  SELECT seq_name, seq_value::bigint AS seq_value, to_regclass(seq_name) AS seq_regclass
   FROM seqs
+),
+applied AS (
+  SELECT seq_name, setval(seq_regclass, seq_value, true) AS applied_value
+  FROM resolved
+  WHERE seq_regclass IS NOT NULL
+),
+missing AS (
+  SELECT seq_name
+  FROM resolved
+  WHERE seq_regclass IS NULL
 )
 SELECT
-  row_number() OVER (ORDER BY seq_name) || '. ' || seq_name || ': ' || applied_value AS sequence_value
-FROM applied
-ORDER BY seq_name;
+  row_number() OVER (ORDER BY sort_key, seq_name) || '. ' || message AS sequence_info
+FROM (
+  SELECT 1 AS sort_key, seq_name, seq_name || ': ' || applied_value::text AS message
+  FROM applied
+  UNION ALL
+  SELECT 2 AS sort_key, seq_name, 'skipped missing sequence: ' || seq_name AS message
+  FROM missing
+) s
+ORDER BY sort_key, seq_name;
 SQL
 
   if [[ "$FK_COUNT" -gt 0 ]]; then

--- a/taskfiles/db-backup.yml
+++ b/taskfiles/db-backup.yml
@@ -1,15 +1,15 @@
-version: '3'
+version: "3"
 
 vars:
   SOURCE_TUNNEL_SESSION: db-tunnel-source
 
 tasks:
-
   # -------------------------
   # SOURCE tunnel (DB_SOURCE_*)
   # -------------------------
   connect-source:
     desc: "Open SSM port-forward to SOURCE DB (background via tmux)"
+    silent: true
     cmds:
       - |
         set -euo pipefail
@@ -26,10 +26,14 @@ tasks:
 
         echo "Starting SOURCE SSM tunnel to $DB_SOURCE_RDS_HOST:5432 on localhost:$DB_SOURCE_LOCAL_PORT"
 
-        tmux has-session -t {{.SOURCE_TUNNEL_SESSION}} 2>/dev/null && {
-          echo "Source tunnel already running."
-          exit 0
-        } || true
+        if tmux has-session -t {{.SOURCE_TUNNEL_SESSION}} 2>/dev/null; then
+          if nc -z 127.0.0.1 "$DB_SOURCE_LOCAL_PORT" 2>/dev/null; then
+            echo "SOURCE tunnel already ready: 127.0.0.1:$DB_SOURCE_LOCAL_PORT"
+            exit 0
+          fi
+          echo "Existing SOURCE tunnel session found, but port is closed. Restarting session..."
+          tmux kill-session -t {{.SOURCE_TUNNEL_SESSION}} 2>/dev/null || true
+        fi
 
         tmux new-session -d -s {{.SOURCE_TUNNEL_SESSION}} \
           "aws ssm start-session \
@@ -39,9 +43,29 @@ tasks:
             --document-name AWS-StartPortForwardingSessionToRemoteHost \
             --parameters host='$DB_SOURCE_RDS_HOST',portNumber='5432',localPortNumber='$DB_SOURCE_LOCAL_PORT'"
 
-        echo "SOURCE tunnel started."
-    status:
-      - tmux has-session -t {{.SOURCE_TUNNEL_SESSION}} 2>/dev/null
+        echo -n "Waiting for SOURCE tunnel "
+        for i in {1..30}; do
+          if nc -z 127.0.0.1 "$DB_SOURCE_LOCAL_PORT" 2>/dev/null; then
+            echo ""
+            echo "SOURCE tunnel ready: 127.0.0.1:$DB_SOURCE_LOCAL_PORT -> $DB_SOURCE_RDS_HOST:5432"
+            exit 0
+          fi
+
+          if ! tmux has-session -t {{.SOURCE_TUNNEL_SESSION}} 2>/dev/null; then
+            echo ""
+            echo "ERROR: SOURCE tunnel session exited early."
+            exit 1
+          fi
+
+          echo -n "."
+          sleep 0.5
+        done
+
+        echo ""
+        echo "ERROR: SOURCE tunnel did not open in time."
+        echo "Last session output:"
+        tmux capture-pane -p -t {{.SOURCE_TUNNEL_SESSION}} -S -120 2>/dev/null || true
+        exit 1
     requires:
       vars:
         - AWS_PROFILE
@@ -53,6 +77,7 @@ tasks:
 
   disconnect-source:
     desc: "Stop SOURCE SSM tunnel"
+    silent: true
     cmds:
       - tmux kill-session -t {{.SOURCE_TUNNEL_SESSION}} 2>/dev/null || true
 
@@ -61,11 +86,12 @@ tasks:
   # -------------------------
   backup:
     desc: "Backup SOURCE (data-only)"
+    silent: true
     deps: [connect-source]
     cmds:
       - |
         set -euo pipefail
-        cleanup() { task backup:disconnect-source || true; }
+        cleanup() { tmux kill-session -t {{.SOURCE_TUNNEL_SESSION}} 2>/dev/null || true; }
         trap cleanup EXIT
 
         echo "Running DB backup"

--- a/taskfiles/flyway.yml
+++ b/taskfiles/flyway.yml
@@ -14,10 +14,14 @@ tasks:
         set -euo pipefail
         echo "Starting SSM tunnel to $DB_HOST:$DB_PORT on localhost:$LOCAL_DB_PORT (profile: $AWS_PROFILE)"
 
-        tmux has-session -t {{.TUNNEL_SESSION}} 2>/dev/null && {
-          echo "Tunnel already running."
-          exit 0
-        } || true
+        if tmux has-session -t {{.TUNNEL_SESSION}} 2>/dev/null; then
+          if nc -z 127.0.0.1 "$LOCAL_DB_PORT" 2>/dev/null; then
+            echo "Tunnel already ready: 127.0.0.1:$LOCAL_DB_PORT"
+            exit 0
+          fi
+          echo "Existing tunnel session found, but port is closed. Restarting session..."
+          tmux kill-session -t {{.TUNNEL_SESSION}} 2>/dev/null || true
+        fi
 
         tmux new-session -d -s {{.TUNNEL_SESSION}} \
           "aws ssm start-session \
@@ -27,9 +31,29 @@ tasks:
             --document-name AWS-StartPortForwardingSessionToRemoteHost \
             --parameters host='$DB_HOST',portNumber='$DB_PORT',localPortNumber='$LOCAL_DB_PORT'"
 
-        echo "SSM tunnel started (tmux session: {{.TUNNEL_SESSION}})"
-    status:
-      - tmux has-session -t {{.TUNNEL_SESSION}} 2>/dev/null
+        echo -n "Waiting for SSM tunnel "
+        for i in {1..30}; do
+          if nc -z 127.0.0.1 "$LOCAL_DB_PORT" 2>/dev/null; then
+            echo ""
+            echo "SSM tunnel ready: 127.0.0.1:$LOCAL_DB_PORT -> $DB_HOST:$DB_PORT"
+            exit 0
+          fi
+
+          if ! tmux has-session -t {{.TUNNEL_SESSION}} 2>/dev/null; then
+            echo ""
+            echo "ERROR: Tunnel session exited early."
+            tmux capture-pane -p -t {{.TUNNEL_SESSION}} -S -120 2>/dev/null || true
+            exit 1
+          fi
+
+          echo -n "."
+          sleep 0.5
+        done
+
+        echo ""
+        echo "ERROR: Tunnel did not open in time."
+        tmux capture-pane -p -t {{.TUNNEL_SESSION}} -S -120 2>/dev/null || true
+        exit 1
     requires:
       vars:
         [AWS_PROFILE, AWS_REGION, SSM_TARGET, DB_HOST, DB_PORT, LOCAL_DB_PORT]
@@ -89,6 +113,18 @@ tasks:
         vars:
           ACTION: MIGRATE
           RUNNER_ARG: flyway_migrate
+
+  repair:
+    silent: true
+    desc: "Flyway repair via DataFixture (fix checksum metadata)"
+    deps:
+      - task: tunnel:start
+        vars: {}
+    cmds:
+      - task: _run
+        vars:
+          ACTION: REPAIR
+          RUNNER_ARG: flyway_repair
 
   history:
     desc: "Show flyway_schema_history"


### PR DESCRIPTION
- Backup now exports sequence values to a sidecar SQL file
- Restore now requires and applies that sidecar for sequence sync
- Legacy fallback sync was removed; `db_restore_log_id_seq` is handled locally to avoid PK issues