### PR TITLE
Viite-3899 Serialize-javascript patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "grunt-terser": "^1.0.0",
     "gruntify-eslint": "^5.0.0",
     "http-proxy-middleware": "^3.0.0",
-    "mocha": "10.5.2",
+    "mocha": "^11.7.5",
     "serve-index": "^1.9.1",
     "serve-static": "^1.14.1"
   },
@@ -32,6 +32,9 @@
     "pikaday": "1.8.2",
     "proj4": "2.11.0",
     "requirejs": "2.3.7"
+  },
+  "overrides": {
+    "serialize-javascript": "^7.0.3"
   },
   "engines": {
     "node": ">=20.15.0"

--- a/viite-UI/src/model/ProjectCollection.js
+++ b/viite-UI/src/model/ProjectCollection.js
@@ -525,7 +525,6 @@
           addSmallLabelWithIds(row.roadPartNumber, 'reservedRoadPartNumber') +
           addSmallLabelWithIds((row.newLength ? row.newLength : row.currentLength), 'reservedRoadLength') +
           addSmallLabelWithIds((row.newDiscontinuity ? row.newDiscontinuity : row.currentDiscontinuity), 'reservedDiscontinuity') +
-          addSmallLabelWithIds((row.newEly ? row.newEly : row.currentEly), 'reservedEly') +
           addSmallLabelWithIds((row.newEvk ? row.newEvk : row.currentEvk), 'reservedEvk') + '</div>';
       }
       );


### PR DESCRIPTION
Paikataan serialize-javascript haavoittuvuus, jota Mocha käyttää. Testattu, että frontin testit toimivat edelleen.