### PR TITLE
2 track synchronizer fixes

### DIFF
--- a/viite-UI/src/view/RoadAddressBrowserWindow.js
+++ b/viite-UI/src/view/RoadAddressBrowserWindow.js
@@ -19,6 +19,10 @@
       roadAddrBrowserWindow.append(roadAddressChangesBrowserHeader);
       roadAddrBrowserWindow.append(roadAddressBrowserForm.getRoadAddressBrowserForm());
 
+      function formatElyValue(elyValue) {
+          return (elyValue === undefined || elyValue === null || elyValue === '' || elyValue === 'undefined') ? 0 : elyValue;
+      }
+
       function createArrayOfArraysForTracks(results) {
           const array = [];
           let arrayPointer = -1;
@@ -26,7 +30,7 @@
           for (let i = 0, len = results.length; i < len; i++) {
               array[++arrayPointer] = [
                   results[i].evk,
-                  results[i].ely,
+                  formatElyValue(results[i].ely),
                   results[i].roadNumber,
                   results[i].track,
                   results[i].roadPartNumber,
@@ -66,7 +70,7 @@
           for (let i = 0, len = results.length; i < len; i++) {
               arr[++arrPointer] =`    <tr>
               <td>${results[i].evk}</td>
-                                          <td>${results[i].ely}</td>
+                                          <td>${formatElyValue(results[i].ely)}</td>
                                           <td>${results[i].roadNumber}</td>
                                           <td>${results[i].track}</td>
                                           <td>${results[i].roadPartNumber}</td>
@@ -89,7 +93,7 @@
           for (let i = 0, len = results.length; i < len; i++) {
               array[++arrayPointer] = [
                   results[i].evk,
-                  results[i].ely,
+                  formatElyValue(results[i].ely),
                   results[i].roadNumber,
                   results[i].roadPartNumber,
                   results[i].addrMRange.start,
@@ -125,7 +129,7 @@
           for (let i = 0, len = results.length; i < len; i++) {
               arr[++arrPointer] =`    <tr>
                                           <td>${results[i].evk}</td>
-                                          <td>${results[i].ely}</td>
+                                          <td>${formatElyValue(results[i].ely)}</td>
                                           <td>${results[i].roadNumber}</td>
                                           <td>${results[i].roadPartNumber}</td>
                                           <td>${results[i].addrMRange.start}</td>
@@ -146,7 +150,7 @@
           for (let i = 0, len = results.length; i < len; i++) {
               array[++arrayPointer] = [
                   results[i].evk,
-                  results[i].ely,
+                  formatElyValue(results[i].ely),
                   results[i].roadNumber,
                   results[i].roadPartNumber,
                   results[i].addrM,
@@ -189,7 +193,7 @@
           for (let i = 0, len = results.length; i < len; i++) {
               arr[++arrPointer] =`    <tr>
                                           <td>${results[i].evk}</td>
-                                          <td>${results[i].ely}</td>
+                                          <td>${formatElyValue(results[i].ely)}</td>
                                           <td>${results[i].roadNumber}</td>
                                           <td>${results[i].roadPartNumber}</td>
                                           <td>${results[i].addrM}</td>
@@ -283,7 +287,7 @@
           for (let i = 0, len = results.length; i < len; i++) {
               array[++arrayPointer] = [
                   results[i].evk,
-                  results[i].ely,
+                  formatElyValue(results[i].ely),
                   results[i].roadNumber,
                   results[i].roadName
               ];
@@ -312,7 +316,7 @@
           for (let i = 0, len = results.length; i < len; i++) {
               arr[++arrPointer] = `   <tr>
                                           <td>${results[i].evk}</td>
-                                          <td>${results[i].ely}</td>
+                                          <td>${formatElyValue(results[i].ely)}</td>
                                           <td>${results[i].roadNumber}</td>
                                           <td>${results[i].roadName}</td>
                                       </tr>`;

--- a/viite-UI/src/view/RoadAddressChangesBrowserWindow.js
+++ b/viite-UI/src/view/RoadAddressChangesBrowserWindow.js
@@ -19,6 +19,10 @@
         roadAddressChangesBrowserWindow.append(roadAddressChangesBrowserHeader);
         roadAddressChangesBrowserWindow.append(roadAddressBrowserForm.getRoadAddressChangesBrowserForm());
 
+        function formatElyValue(elyValue) {
+            return (elyValue === undefined || elyValue === null || elyValue === '' || elyValue === 'undefined') ? 0 : elyValue;
+        }
+
         // ========== Validation helpers (extracted) ==========
         function validateDate(dateString, dateElement) {
             // Check format ignoring whitespace
@@ -174,7 +178,7 @@
                 arr[++arrPointer] = `   <tr>
                                             <td>${results[i].startDate}</td>
                                             <td>${results[i].oldEvk}</td>
-                                            <td>${results[i].oldEly}</td>
+                                            <td>${formatElyValue(results[i].oldEly)}</td>
                                             <td>${results[i].oldRoadNumber}</td>
                                             <td>${results[i].oldTrack}</td>
                                             <td>${results[i].oldRoadPartNumber}</td>

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/process/strategy/AdministrativeClassTwoTrackSynchronizer.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/process/strategy/AdministrativeClassTwoTrackSynchronizer.scala
@@ -82,7 +82,7 @@ object AdministrativeClassTwoTrackSynchronizer {
   private def adminClassChangedLinksToContinuousTwoTrackSections(adminClassChangedLinks: Seq[ProjectLink]) : (Seq[Seq[ProjectLink]], Seq[Seq[ProjectLink]]) = {
     val adminClassChangedLeft = adminClassChangedLinks.filter(_.track == Track.LeftSide)
     val adminClassChangedRight = adminClassChangedLinks.filter(_.track == Track.RightSide)
-    
+
     // Group administrative class changed links into continuous sections
     val leftAdminClassChangedSections = toContinuousSectionsByAdminClassChange(adminClassChangedLeft)
     val rightAdminClassChangedSections = toContinuousSectionsByAdminClassChange(adminClassChangedRight)
@@ -126,8 +126,14 @@ object AdministrativeClassTwoTrackSynchronizer {
 
     // Adjust only the intersection where the start-of-road admin class change ends.
     if (SynchronizationUtils.areTracksCloseEnoughOnEndAddrM(lastAdminClassChangedOnLeft, lastAdminClassChangedOnRight)) {
-      val (adjustedAdminClassChangedLeft, adjustedAdminClassChangedRight, averageEnd) =
-        adjustAdminClassChangedLinksToMatchAtTheEnd(lastAdminClassChangedOnLeft, lastAdminClassChangedOnRight)
+      val averageEnd = SynchronizationUtils.clampSharedEndAddrM(
+        TwoTrackRoadUtils.calculateAverageAddrM(lastAdminClassChangedOnLeft.addrMRange.end, lastAdminClassChangedOnRight.addrMRange.end),
+        Seq(lastAdminClassChangedOnLeft, lastAdminClassChangedOnRight),
+        Seq(continuousAfterAdminClassChangedLeft, continuousAfterAdminClassChangedRight).flatten
+      )
+
+      val adjustedAdminClassChangedLeft = SynchronizationUtils.replaceEndsWith(lastAdminClassChangedOnLeft, averageEnd)
+      val adjustedAdminClassChangedRight = SynchronizationUtils.replaceEndsWith(lastAdminClassChangedOnRight, averageEnd)
 
       (continuousAfterAdminClassChangedLeft, continuousAfterAdminClassChangedRight) match {
         case (Some(leftContinuous), Some(rightContinuous)) =>
@@ -156,7 +162,7 @@ object AdministrativeClassTwoTrackSynchronizer {
     }
   }
 
-    // Helper methods for middle section administrative class change processing
+  // Helper methods for middle section administrative class change processing
   private def isMiddleSection(section: Seq[ProjectLink], maxAddrM: Long): Boolean =
     !section.exists(_.addrMRange.isRoadPartStart) &&
     !section.exists(_.originalAddrMRange.end == maxAddrM)
@@ -270,14 +276,26 @@ object AdministrativeClassTwoTrackSynchronizer {
               val firstRight = currentRightSection.minBy(_.addrMRange.start)
               val lastRight = currentRightSection.maxBy(_.addrMRange.end)
 
-              val averageStart = TwoTrackRoadUtils.calculateAverageAddrM(firstLeft.addrMRange.start, firstRight.addrMRange.start)
-              val averageEnd = TwoTrackRoadUtils.calculateAverageAddrM(lastLeft.addrMRange.end, lastRight.addrMRange.end)
+              val prevLeftLink = SynchronizationUtils.findPreviousLink(updatedProjectLinks, firstLeft, Track.RightSide)
+              val prevRightLink = SynchronizationUtils.findPreviousLink(updatedProjectLinks, firstRight, Track.LeftSide)
+
+              val nextLeftLink = SynchronizationUtils.findNextLink(updatedProjectLinks, lastLeft, Track.RightSide)
+              val nextRightLink = SynchronizationUtils.findNextLink(updatedProjectLinks, lastRight, Track.LeftSide)
+
+              val averageStart = SynchronizationUtils.clampSharedStartAddrM(
+                TwoTrackRoadUtils.calculateAverageAddrM(firstLeft.addrMRange.start, firstRight.addrMRange.start),
+                Seq(firstLeft, firstRight),
+                Seq(prevLeftLink, prevRightLink).flatten
+              )
+
+              val averageEnd = SynchronizationUtils.clampSharedEndAddrM(
+                TwoTrackRoadUtils.calculateAverageAddrM(lastLeft.addrMRange.end, lastRight.addrMRange.end),
+                Seq(lastLeft, lastRight),
+                Seq(nextLeftLink, nextRightLink).flatten
+              )
 
               val adjustedLeft = adjustSection(firstLeft, lastLeft, averageStart, averageEnd)
               val adjustedRight = adjustSection(firstRight, lastRight, averageStart, averageEnd)
-
-              val prevLeftLink = SynchronizationUtils.findPreviousLink(updatedProjectLinks, firstLeft, Track.RightSide)
-              val prevRightLink = SynchronizationUtils.findPreviousLink(updatedProjectLinks, firstRight, Track.LeftSide)
 
               val adjustedPreceding = {
                 (prevLeftLink, prevRightLink) match {
@@ -294,9 +312,6 @@ object AdministrativeClassTwoTrackSynchronizer {
                     Seq.empty[ProjectLink]
                 }
               }
-
-              val nextLeftLink = SynchronizationUtils.findNextLink(updatedProjectLinks, lastLeft, Track.RightSide)
-              val nextRightLink = SynchronizationUtils.findNextLink(updatedProjectLinks, lastRight, Track.LeftSide)
 
               val adjustedFollowing = {
                 (nextLeftLink, nextRightLink) match {
@@ -341,15 +356,28 @@ object AdministrativeClassTwoTrackSynchronizer {
         val firstRight = rightSection.minBy(_.addrMRange.start)
         val lastRight  = rightSection.maxBy(_.addrMRange.end)
 
-        val averageStart = TwoTrackRoadUtils.calculateAverageAddrM(firstLeft.addrMRange.start, firstRight.addrMRange.start)
-        val averageEnd   = TwoTrackRoadUtils.calculateAverageAddrM(lastLeft.addrMRange.end,    lastRight.addrMRange.end)
-
-        val adjustedLeft  = adjustSection(firstLeft,  lastLeft,  averageStart, averageEnd)
-        val adjustedRight = adjustSection(firstRight, lastRight, averageStart, averageEnd)
-
         // Find the link ending where the admin-class section begins on each track.
         val prevLeftLink  = SynchronizationUtils.findPreviousLink(updatedProjectLinks, firstLeft, Track.RightSide)
         val prevRightLink = SynchronizationUtils.findPreviousLink(updatedProjectLinks, firstRight, Track.LeftSide)
+
+        // Find the link starting where the admin-class section ends on each track.
+        val nextLeftLink  = SynchronizationUtils.findNextLink(updatedProjectLinks, lastLeft, Track.RightSide)
+        val nextRightLink = SynchronizationUtils.findNextLink(updatedProjectLinks, lastRight, Track.LeftSide)
+
+        val averageStart = SynchronizationUtils.clampSharedStartAddrM(
+          TwoTrackRoadUtils.calculateAverageAddrM(firstLeft.addrMRange.start, firstRight.addrMRange.start),
+          Seq(firstLeft, firstRight),
+          Seq(prevLeftLink, prevRightLink).flatten
+        )
+
+        val averageEnd = SynchronizationUtils.clampSharedEndAddrM(
+          TwoTrackRoadUtils.calculateAverageAddrM(lastLeft.addrMRange.end, lastRight.addrMRange.end),
+          Seq(lastLeft, lastRight),
+          Seq(nextLeftLink, nextRightLink).flatten
+        )
+
+        val adjustedLeft  = adjustSection(firstLeft,  lastLeft,  averageStart, averageEnd)
+        val adjustedRight = adjustSection(firstRight, lastRight, averageStart, averageEnd)
 
         val adjustedPreceding: Seq[ProjectLink] = (prevLeftLink, prevRightLink) match {
           case (Some(prevLeft), Some(prevRight)) =>
@@ -361,10 +389,6 @@ object AdministrativeClassTwoTrackSynchronizer {
           case (None, Some(prevRight)) => Seq(SynchronizationUtils.replaceEndsWith(prevRight, averageStart))
           case _                       => Seq.empty
         }
-
-        // Find the link starting where the admin-class section ends on each track.
-        val nextLeftLink  = SynchronizationUtils.findNextLink(updatedProjectLinks, lastLeft, Track.RightSide)
-        val nextRightLink = SynchronizationUtils.findNextLink(updatedProjectLinks, lastRight, Track.LeftSide)
 
         val adjustedFollowing: Seq[ProjectLink] = (nextLeftLink, nextRightLink) match {
           case (Some(nextLeft), Some(nextRight)) =>
@@ -406,7 +430,7 @@ object AdministrativeClassTwoTrackSynchronizer {
         val (leftAdminClassChangedSections, rightAdminClassChangedSections) = adminClassChangedLinksToContinuousTwoTrackSections(adminClassChangedLinks)
         val lastAdminClassChangedLeftSectionOpt   = leftAdminClassChangedSections.find(section => section.exists(_.id == lastAdminClassChangedLeft.id))
         val lastAdminClassChangedRightSectionOpt  = rightAdminClassChangedSections.find(section => section.exists(_.id == lastAdminClassChangedRight.id))
-        
+
         (lastAdminClassChangedLeftSectionOpt, lastAdminClassChangedRightSectionOpt) match {
           case (Some(leftSection), Some(rightSection)) =>
             handleTwoTrackRoadPartEndAdminClassChange(leftSection, rightSection, projectLinks)
@@ -437,17 +461,24 @@ object AdministrativeClassTwoTrackSynchronizer {
     val firstLinkOnLeftAdminClassChangedSection  = adminClassChangedLeftSection.minBy(_.addrMRange.start)
     val firstLinkOnRightAdminClassChangedSection =  adminClassChangedRightSection.minBy(_.addrMRange.start)
 
-    if ((firstLinkOnLeftAdminClassChangedSection.addrMRange.start == firstLinkOnRightAdminClassChangedSection.addrMRange.start) ||    // Address starts already match on first links of admin class change section OR
-      !SynchronizationUtils.areTracksCloseEnoughOnOriginalStartAddrM(firstLinkOnLeftAdminClassChangedSection, firstLinkOnRightAdminClassChangedSection)) { // Address starts are too far away each other
+    if ((firstLinkOnLeftAdminClassChangedSection.addrMRange.start == firstLinkOnRightAdminClassChangedSection.addrMRange.start) ||
+      !SynchronizationUtils.areTracksCloseEnoughOnOriginalStartAddrM(firstLinkOnLeftAdminClassChangedSection, firstLinkOnRightAdminClassChangedSection)) {
       // Return the project links unchanged
       projectLinks
     } else {
-      // Update the first admin class changed links of the section to match at the start
-      val (adjustedAdminClassChangedLeft, adjustedAdminClassChangedRight, averageStartForAdminClassChanged) = adjustAdminClassChangedStartToMatch(firstLinkOnLeftAdminClassChangedSection, firstLinkOnRightAdminClassChangedSection)
       // Find previous links if there are any
       val previousLeftLink  = SynchronizationUtils.findPreviousLink(projectLinks, firstLinkOnLeftAdminClassChangedSection, Track.RightSide)
       val previousRightLink = SynchronizationUtils.findPreviousLink(projectLinks, firstLinkOnRightAdminClassChangedSection, Track.LeftSide)
-      
+
+      val averageStartForAdminClassChanged = SynchronizationUtils.clampSharedStartAddrM(
+        TwoTrackRoadUtils.calculateAverageAddrM(firstLinkOnLeftAdminClassChangedSection.addrMRange.start, firstLinkOnRightAdminClassChangedSection.addrMRange.start),
+        Seq(firstLinkOnLeftAdminClassChangedSection, firstLinkOnRightAdminClassChangedSection),
+        Seq(previousLeftLink, previousRightLink).flatten
+      )
+
+      val adjustedAdminClassChangedLeft = SynchronizationUtils.replaceStartsWith(firstLinkOnLeftAdminClassChangedSection, averageStartForAdminClassChanged)
+      val adjustedAdminClassChangedRight = SynchronizationUtils.replaceStartsWith(firstLinkOnRightAdminClassChangedSection, averageStartForAdminClassChanged)
+
       (previousLeftLink, previousRightLink) match {
         case (Some(prevLeft), Some(prevRight)) =>
           // Update the previous link ends to match

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/process/strategy/AdministrativeClassTwoTrackSynchronizer.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/process/strategy/AdministrativeClassTwoTrackSynchronizer.scala
@@ -27,6 +27,9 @@ import fi.vaylavirasto.viite.util.ViiteException
  */
 object AdministrativeClassTwoTrackSynchronizer {
 
+  private def tooLargeDiffError(leftLinkId: String, rightLinkId: String): ViiteException =
+    ViiteException(s"Linkkien $leftLinkId ja $rightLinkId etäisyysarvot eroavat toisistaan yli sallitun rajan (${SynchronizationUtils.maxDiffForTracks}). Yritä tehdä hallinnollisen luokan muutos kohdista, jotka ovat pituudeltaan lähempänä toisiaan, tai ota yhteyttä Viite tukeen.")
+
   /**
    * Adjusts two track administrative class change sections to match + the surrounding links if needed.
    * @param roadPartProjectLinksWithoutNewLinks Sequence of project links to adjust on a single road part (NOTE! RoadAddressChangeType.New links NOT allowed)
@@ -158,7 +161,7 @@ object AdministrativeClassTwoTrackSynchronizer {
           SynchronizationUtils.updateProjectLinksList(Seq(adjustedAdminClassChangedLeft, adjustedAdminClassChangedRight), projectLinks)
       }
     } else {
-      projectLinks
+        throw tooLargeDiffError(lastAdminClassChangedOnLeft.linkId, lastAdminClassChangedOnRight.linkId)
     }
   }
 
@@ -276,6 +279,14 @@ object AdministrativeClassTwoTrackSynchronizer {
               val firstRight = currentRightSection.minBy(_.addrMRange.start)
               val lastRight = currentRightSection.maxBy(_.addrMRange.end)
 
+              if (!SynchronizationUtils.areTracksCloseEnoughOnOriginalStartAddrM(firstLeft, firstRight)) {
+                throw tooLargeDiffError(firstLeft.linkId, firstRight.linkId)
+              }
+
+              if (!SynchronizationUtils.areTracksCloseEnoughOnEndAddrM(lastLeft, lastRight)) {
+                throw tooLargeDiffError(lastLeft.linkId, lastRight.linkId)
+              }
+
               val prevLeftLink = SynchronizationUtils.findPreviousLink(updatedProjectLinks, firstLeft, Track.RightSide)
               val prevRightLink = SynchronizationUtils.findPreviousLink(updatedProjectLinks, firstRight, Track.LeftSide)
 
@@ -345,14 +356,17 @@ object AdministrativeClassTwoTrackSynchronizer {
     leftMiddleSections.filterNot(_.exists(link => processedLeftSectionIds.contains(link.id))).foreach { leftSection =>
       val firstLeft = leftSection.minBy(_.addrMRange.start)
       val lastLeft  = leftSection.maxBy(_.addrMRange.end)
+      val unprocessedRightSections = rightMiddleSections.filterNot(_.exists(link => processedRightSectionIds.contains(link.id)))
 
       // Find the right section whose start and end are within maxDiffForTracks of the left section.
-      rightMiddleSections.filterNot(_.exists(link => processedRightSectionIds.contains(link.id))).find { rightSection =>
+      val matchedRightSection = unprocessedRightSections.find { rightSection =>
         val firstRight = rightSection.minBy(_.addrMRange.start)
         val lastRight  = rightSection.maxBy(_.addrMRange.end)
         SynchronizationUtils.areTracksCloseEnoughOnOriginalStartAddrM(firstLeft, firstRight) &&
         SynchronizationUtils.areTracksCloseEnoughOnEndAddrM(lastLeft, lastRight)
-      }.foreach { rightSection =>
+      }
+
+      matchedRightSection.foreach { rightSection =>
         val firstRight = rightSection.minBy(_.addrMRange.start)
         val lastRight  = rightSection.maxBy(_.addrMRange.end)
 
@@ -405,6 +419,24 @@ object AdministrativeClassTwoTrackSynchronizer {
           adjustedLeft ++ adjustedRight ++ adjustedPreceding ++ adjustedFollowing,
           updatedProjectLinks
         )
+
+        processedLeftSectionIds ++= leftSection.map(_.id)
+        processedRightSectionIds ++= rightSection.map(_.id)
+      }
+
+      if (matchedRightSection.isEmpty && unprocessedRightSections.nonEmpty) {
+        val rightSection = unprocessedRightSections.head
+
+        val firstRight = rightSection.minBy(_.addrMRange.start)
+        val lastRight  = rightSection.maxBy(_.addrMRange.end)
+
+        if (!SynchronizationUtils.areTracksCloseEnoughOnOriginalStartAddrM(firstLeft, firstRight)) {
+          throw tooLargeDiffError(firstLeft.linkId, firstRight.linkId)
+        }
+
+        if (!SynchronizationUtils.areTracksCloseEnoughOnEndAddrM(lastLeft, lastRight)) {
+          throw tooLargeDiffError(lastLeft.linkId, lastRight.linkId)
+        }
       }
     }
 

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/process/strategy/TerminatedTwoTrackSectionSynchronizer.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/process/strategy/TerminatedTwoTrackSectionSynchronizer.scala
@@ -155,8 +155,14 @@ object TerminatedTwoTrackSectionSynchronizer {
     // Adjust terminated
     val processedLinks: Seq[ProjectLink] = {
       if (SynchronizationUtils.areTracksCloseEnoughOnEndAddrM(lastTerminatedOnLeftSideSection, lastTerminatedOnRightSideSection)) {
-        // Adjust the last terminated links on each track to match at the end
-        val (adjustedTerminatedLeft, adjustedTerminatedRight, averageEndAddrM) = adjustTerminatedLinksToMatchAtTheEnd(lastTerminatedOnLeftSideSection, lastTerminatedOnRightSideSection)
+        val averageEndAddrM = SynchronizationUtils.clampSharedEndAddrM(
+          TwoTrackRoadUtils.calculateAverageAddrM(lastTerminatedOnLeftSideSection.addrMRange.end, lastTerminatedOnRightSideSection.addrMRange.end),
+          Seq(lastTerminatedOnLeftSideSection, lastTerminatedOnRightSideSection),
+          Seq(continuousAfterTerminatedLeft, continuousAfterTerminatedRight).flatten
+        )
+
+        val adjustedTerminatedLeft = SynchronizationUtils.replaceEndsWith(lastTerminatedOnLeftSideSection, averageEndAddrM)
+        val adjustedTerminatedRight = SynchronizationUtils.replaceEndsWith(lastTerminatedOnRightSideSection, averageEndAddrM)
 
         if (continuousAfterTerminatedLeft.isDefined && continuousAfterTerminatedRight.isDefined) {
           // Adjust both links after the terminated section
@@ -224,7 +230,7 @@ object TerminatedTwoTrackSectionSynchronizer {
    *  0     201  230 251  450
    */
   private def handleTwoTrackMiddleTermination(terminatedLeftSections: Seq[Seq[ProjectLink]], terminatedRightSections: Seq[Seq[ProjectLink]], projectLinks: Seq[ProjectLink]): Seq[ProjectLink] = {
-    
+
     // Find pairs of minorDiscontinuity links on opposite tracks, reasonably close to each other.
     def findMinorDiscontinuityLinkPairs(minorDiscontinuityLinks: Seq[ProjectLink]): Seq[Seq[ProjectLink]] = {
       minorDiscontinuityLinks.filter(_.track == Track.LeftSide).flatMap { leftLink =>
@@ -274,8 +280,25 @@ object TerminatedTwoTrackSectionSynchronizer {
             val lastTerminatedLeft  = leftTermSect.get.maxBy(_.addrMRange.end)
             val lastTerminatedRight = rightTermSect.get.maxBy(_.addrMRange.end)
 
-            val averageStartForTermSect = TwoTrackRoadUtils.calculateAverageAddrM(firstTerminatedLeft.addrMRange.start, firstTerminatedRight.addrMRange.start)
-            val averageEndForTermSect   = TwoTrackRoadUtils.calculateAverageAddrM(lastTerminatedLeft.addrMRange.end, lastTerminatedRight.addrMRange.end)
+            val afterLeftTerminatedSection = {
+              SynchronizationUtils.findNextLink(updatedProjectLinks, lastTerminatedLeft, Track.RightSide)
+            }
+
+            val afterRightTerminatedSection = {
+              SynchronizationUtils.findNextLink(updatedProjectLinks, lastTerminatedRight, Track.LeftSide)
+            }
+
+            val averageStartForTermSect = SynchronizationUtils.clampSharedStartAddrM(
+              TwoTrackRoadUtils.calculateAverageAddrM(firstTerminatedLeft.addrMRange.start, firstTerminatedRight.addrMRange.start),
+              Seq(firstTerminatedLeft, firstTerminatedRight),
+              minorDiscontinuityLinks
+            )
+
+            val averageEndForTermSect = SynchronizationUtils.clampSharedEndAddrM(
+              TwoTrackRoadUtils.calculateAverageAddrM(lastTerminatedLeft.addrMRange.end, lastTerminatedRight.addrMRange.end),
+              Seq(lastTerminatedLeft, lastTerminatedRight),
+              Seq(afterLeftTerminatedSection, afterRightTerminatedSection).flatten
+            )
 
             def adjustTerminatedLinks(firstTerminatedLink: ProjectLink, lastTerminatedLink: ProjectLink): Seq[ProjectLink] = {
               if (firstTerminatedLink == lastTerminatedLink) {
@@ -299,13 +322,6 @@ object TerminatedTwoTrackSectionSynchronizer {
             val adjustedTerminatedLeft  = adjustTerminatedLinks(firstTerminatedLeft, lastTerminatedLeft)
             val adjustedTerminatedRight = adjustTerminatedLinks(firstTerminatedRight, lastTerminatedRight)
 
-            val afterLeftTerminatedSection = {
-              SynchronizationUtils.findNextLink(updatedProjectLinks, lastTerminatedLeft, Track.RightSide)
-            }
-
-            val afterRightTerminatedSection = {
-              SynchronizationUtils.findNextLink(updatedProjectLinks, lastTerminatedRight, Track.LeftSide)
-            }
             // Adjust links after terminated section
             val adjustedAfterTermination: Seq[ProjectLink] = {
               if (afterLeftTerminatedSection.isDefined && afterRightTerminatedSection.isDefined) {
@@ -374,16 +390,24 @@ object TerminatedTwoTrackSectionSynchronizer {
     val firstLinkOnRightTermSection =  terminatedRightSection.minBy(_.addrMRange.start)
 
     val processedLinks = {
-      if ((firstLinkOnLeftTermSection.addrMRange.start == firstLinkOnRightTermSection.addrMRange.start) ||    // Address starts already match on first links of terminated section OR
-        !SynchronizationUtils.areTracksCloseEnoughOnOriginalStartAddrM(firstLinkOnLeftTermSection, firstLinkOnRightTermSection)) { // Address starts are too far away each other
+      if ((firstLinkOnLeftTermSection.addrMRange.start == firstLinkOnRightTermSection.addrMRange.start) ||
+        !SynchronizationUtils.areTracksCloseEnoughOnOriginalStartAddrM(firstLinkOnLeftTermSection, firstLinkOnRightTermSection)) {
         // Return the project links unchanged
         projectLinks
       } else {
-        // Update the first terminated links of the section to match at the start
-        val (adjustedTermLeft, adjustedTermRight, averageStartForTerminated) = adjustTerminatedStartToMatch(firstLinkOnLeftTermSection, firstLinkOnRightTermSection)
         // Find previous links if there are any
         val previousLeftLink  = SynchronizationUtils.findPreviousLink(projectLinks, firstLinkOnLeftTermSection, Track.RightSide)
         val previousRightLink = SynchronizationUtils.findPreviousLink(projectLinks, firstLinkOnRightTermSection, Track.LeftSide)
+
+        val averageStartForTerminated = SynchronizationUtils.clampSharedStartAddrM(
+          TwoTrackRoadUtils.calculateAverageAddrM(firstLinkOnLeftTermSection.addrMRange.start, firstLinkOnRightTermSection.addrMRange.start),
+          Seq(firstLinkOnLeftTermSection, firstLinkOnRightTermSection),
+          Seq(previousLeftLink, previousRightLink).flatten
+        )
+
+        val adjustedTermLeft = SynchronizationUtils.replaceStartsWith(firstLinkOnLeftTermSection, averageStartForTerminated)
+        val adjustedTermRight = SynchronizationUtils.replaceStartsWith(firstLinkOnRightTermSection, averageStartForTerminated)
+
         if (previousLeftLink.isDefined && previousRightLink.isDefined) {
           // Update the previous link starts to match
           val (adjustedPreviousLeftLink, adjustedPreviousRightLink)  = adjustLinkEndsToMatch(previousLeftLink.get, previousRightLink.get, averageStartForTerminated)

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/util/SynchronizationUtils.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/util/SynchronizationUtils.scala
@@ -66,6 +66,23 @@ object SynchronizationUtils {
     Math.abs(leftLink.addrMRange.end - rightLink.addrMRange.end) <= maxDiffForTracks
   }
 
+  // Clamps the average start address to ensure it does not create a gap or overlap with adjacent links
+  def clampSharedStartAddrM(averageStart: Long, sectionLinks: Seq[ProjectLink], previousLinks: Seq[ProjectLink]): Long = {
+    val minAverageStart = previousLinks.map(_.addrMRange.start + 1).reduceOption(_ max _).getOrElse(averageStart)
+    val maxAverageStart = sectionLinks.map(_.addrMRange.end - 1).min
+
+    if (minAverageStart > maxAverageStart) averageStart
+    else math.max(minAverageStart, math.min(averageStart, maxAverageStart))
+  }
+
+  def clampSharedEndAddrM(averageEnd: Long, sectionLinks: Seq[ProjectLink], followingLinks: Seq[ProjectLink]): Long = {
+    val minAverageEnd = sectionLinks.map(_.addrMRange.start + 1).max
+    val maxAverageEnd = followingLinks.map(_.addrMRange.end - 1).reduceOption(_ min _).getOrElse(averageEnd)
+
+    if (minAverageEnd > maxAverageEnd) averageEnd
+    else math.max(minAverageEnd, math.min(averageEnd, maxAverageEnd))
+  }
+
   def replaceStartsWith(projectLink: ProjectLink, replacingStartAddrM: Long): ProjectLink = {
     projectLink.copy(
       addrMRange          = AddrMRange(replacingStartAddrM, projectLink.addrMRange.end),

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/process/TwoTrackSectionSynchronizerSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/process/TwoTrackSectionSynchronizerSpec.scala
@@ -234,61 +234,68 @@ class TwoTrackSectionSynchronizerSpec extends AnyFunSuite with Matchers {
     result.find(_.id == 65).get.originalAddrMRange should be(AddrMRange(45, 62))
   } }
 
-  test("Case 7 - Administrative Class Change: Synchronize road part middle with minor discontinuity") {
+  test("Case 7 - Administrative Class Change: Synchronize multiple middle sections with minor discontinuity") {
     /**
       * Before:
-      * 38   60      80                    80      100   120
-      * ----->~~~~~~~> (minor discontiniuity)~~~~~~~>-----> 
-      * 36   56      76                    76      104   126
-      * ----->~~~~~~~> (minor discontiniuity)~~~~~~~>-----> 
+      * 38   60      80                     80   90   100   120
+      * ----->~~~~~~~> (minor discontinuity) ---->~~~~~>----->
+      * 36   56      76                     76   88   104   126
+      * ----->~~~~~~~> (minor discontinuity) ---->~~~~~>----->
       *
       * After:
-      * 38   58      80                    80      102   120
-      * ----->~~~~~~~> (minor discontiniuity)~~~~~~~>-----> 
-      * 36   58      76                    76      102   126
-      * ----->~~~~~~~> (minor discontiniuity)~~~~~~~>-----> 
+      * 38   58      78                     78   89   102   120
+      * ----->~~~~~~~> (minor discontinuity) ---->~~~~~>----->
+      * 36   58      78                    78    89   102   126
+      * ----->~~~~~~~> (minor discontinuity) ---->~~~~~>----->
       *
-      * avg start = (60+56)/2 = 58  →  preceding ends snap to 58, first admin links start at 58
-      * avg end   = (100+104)/2 = 102  →  last admin links end at 102, following links start at 102
-      * internal boundary (80 / 76) is untouched
+      * Section 1 averages: start (60+56)/2 = 58, end (80+76)/2 = 78
+      * Section 2 averages: start (90+88)/2 = 89, end (100+104)/2 = 102
       */
     val links = Seq(
-      buildTestLink(70, Track.RightSide, (38, 60),  RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
-      buildTestLink(71, Track.RightSide, (60, 80),  RoadAddressChangeType.Unchanged, Discontinuity.MinorDiscontinuity, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
-      buildTestLink(72, Track.RightSide, (80, 100), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
-      buildTestLink(73, Track.RightSide, (100, 120), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
+      buildTestLink(70, Track.RightSide, (38, 60), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
+      buildTestLink(71, Track.RightSide, (60, 80), RoadAddressChangeType.Unchanged, Discontinuity.MinorDiscontinuity, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
+      buildTestLink(72, Track.RightSide, (80, 90), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
+      buildTestLink(73, Track.RightSide, (90, 100), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
+      buildTestLink(78, Track.RightSide, (100, 120), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
 
-      buildTestLink(74, Track.LeftSide, (36, 56),  RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
-      buildTestLink(75, Track.LeftSide, (56, 76),  RoadAddressChangeType.Unchanged, Discontinuity.MinorDiscontinuity, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
-      buildTestLink(76, Track.LeftSide, (76, 104), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
-      buildTestLink(77, Track.LeftSide, (104, 126), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality)
+      buildTestLink(74, Track.LeftSide, (36, 56), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
+      buildTestLink(75, Track.LeftSide, (56, 76), RoadAddressChangeType.Unchanged, Discontinuity.MinorDiscontinuity, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
+      buildTestLink(76, Track.LeftSide, (76, 88), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
+      buildTestLink(77, Track.LeftSide, (88, 104), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
+      buildTestLink(79, Track.LeftSide, (104, 126), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality)
     )
 
     val result = AdministrativeClassTwoTrackSynchronizer.adjustAdministrativeClassChanges(links)
 
-    // Preceding links: only ends are snapped, starts are preserved
+    // Preceding links for section 1: only ends are snapped, starts are preserved
     result.find(_.id == 70).get.addrMRange should be(AddrMRange(38, 58))
     result.find(_.id == 70).get.originalAddrMRange should be(AddrMRange(38, 58))
     result.find(_.id == 74).get.addrMRange should be(AddrMRange(36, 58))
     result.find(_.id == 74).get.originalAddrMRange should be(AddrMRange(36, 58))
 
-    // First admin-changed links: start averaged to 58, end (80/76) untouched
-    result.find(_.id == 71).get.addrMRange should be(AddrMRange(58, 80))
-    result.find(_.id == 71).get.originalAddrMRange should be(AddrMRange(58, 80))
-    result.find(_.id == 75).get.addrMRange should be(AddrMRange(58, 76))
-    result.find(_.id == 75).get.originalAddrMRange should be(AddrMRange(58, 76))
+    // First middle admin-changed section
+    result.find(_.id == 71).get.addrMRange should be(AddrMRange(58, 78))
+    result.find(_.id == 71).get.originalAddrMRange should be(AddrMRange(58, 78))
+    result.find(_.id == 75).get.addrMRange should be(AddrMRange(58, 78))
+    result.find(_.id == 75).get.originalAddrMRange should be(AddrMRange(58, 78))
 
-    // Last admin-changed links: start (80/76) untouched, end averaged to 102
-    result.find(_.id == 72).get.addrMRange should be(AddrMRange(80, 102))
-    result.find(_.id == 72).get.originalAddrMRange should be(AddrMRange(80, 102))
-    result.find(_.id == 76).get.addrMRange should be(AddrMRange(76, 102))
-    result.find(_.id == 76).get.originalAddrMRange should be(AddrMRange(76, 102))
+    // Unchanged middle links between sections become the preceding links of section 2
+    result.find(_.id == 72).get.addrMRange should be(AddrMRange(78, 89))
+    result.find(_.id == 72).get.originalAddrMRange should be(AddrMRange(78, 89))
+    result.find(_.id == 76).get.addrMRange should be(AddrMRange(78, 89))
+    result.find(_.id == 76).get.originalAddrMRange should be(AddrMRange(78, 89))
 
-    // Following links: starts snapped to 102
-    result.find(_.id == 73).get.addrMRange should be(AddrMRange(102, 120))
-    result.find(_.id == 73).get.originalAddrMRange should be(AddrMRange(102, 120))
-    result.find(_.id == 77).get.addrMRange should be(AddrMRange(102, 126))
-    result.find(_.id == 77).get.originalAddrMRange should be(AddrMRange(102, 126))
+    // Second middle admin-changed section
+    result.find(_.id == 73).get.addrMRange should be(AddrMRange(89, 102))
+    result.find(_.id == 73).get.originalAddrMRange should be(AddrMRange(89, 102))
+    result.find(_.id == 77).get.addrMRange should be(AddrMRange(89, 102))
+    result.find(_.id == 77).get.originalAddrMRange should be(AddrMRange(89, 102))
+
+    // Following links of section 2: starts snapped to 102
+    result.find(_.id == 78).get.addrMRange should be(AddrMRange(102, 120))
+    result.find(_.id == 78).get.originalAddrMRange should be(AddrMRange(102, 120))
+    result.find(_.id == 79).get.addrMRange should be(AddrMRange(102, 126))
+    result.find(_.id == 79).get.originalAddrMRange should be(AddrMRange(102, 126))
   }
 
   test("Case 8 - Administrative Class Change: Synchronize road part end with 1 link on track 1 and 2 links on track 2") {
@@ -420,5 +427,61 @@ class TwoTrackSectionSynchronizerSpec extends AnyFunSuite with Matchers {
     result.find(_.id == 112).get.originalAddrMRange should be(AddrMRange(82, 100))
     result.find(_.id == 115).get.addrMRange should be(AddrMRange(82, 100))
     result.find(_.id == 115).get.originalAddrMRange should be(AddrMRange(82, 100))
+  }
+
+  test("Case 11 - Administrative Class Change: Following link of 2m still synchronizes safely") {
+    /**
+      * Before:
+      * 0   50               100 102 130
+      * ---->~~~~~~~~~~~~~~~~>--->---->
+      * 0    54                 104 106 130
+      * ----->~~~~~~~~~~~~~~~~~~>--->---->
+      *
+      * Raw averages: start (50+54)/2 = 52, end (100+104)/2 = 102
+      * Because the right-side following link is only 2m (100-102), safe end clamps to 101.
+      *
+      * After:
+      * 0  52               101 102 130
+      * --->~~~~~~~~~~~~~~~~>--->---->
+      * 0  52               101   106 130
+      * --->~~~~~~~~~~~~~~~~>----->---->
+      */
+    val links = Seq(
+      buildTestLink(120, Track.RightSide, (0, 50), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
+      buildTestLink(121, Track.RightSide, (50, 100), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
+      buildTestLink(122, Track.RightSide, (100, 102), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
+      buildTestLink(123, Track.RightSide, (102, 130), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
+
+      buildTestLink(124, Track.LeftSide, (0, 54), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
+      buildTestLink(125, Track.LeftSide, (54, 104), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
+      buildTestLink(126, Track.LeftSide, (104, 106), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
+      buildTestLink(127, Track.LeftSide, (106, 130), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality)
+    )
+
+    val result = AdministrativeClassTwoTrackSynchronizer.adjustAdministrativeClassChanges(links)
+
+    // Start boundary average applies normally
+    result.find(_.id == 120).get.addrMRange should be(AddrMRange(0, 52))
+    result.find(_.id == 120).get.originalAddrMRange should be(AddrMRange(0, 52))
+    result.find(_.id == 124).get.addrMRange should be(AddrMRange(0, 52))
+    result.find(_.id == 124).get.originalAddrMRange should be(AddrMRange(0, 52))
+
+    // End boundary is clamped to 101 to keep the 2m following link valid
+    result.find(_.id == 121).get.addrMRange should be(AddrMRange(52, 101))
+    result.find(_.id == 121).get.originalAddrMRange should be(AddrMRange(52, 101))
+    result.find(_.id == 125).get.addrMRange should be(AddrMRange(52, 101))
+    result.find(_.id == 125).get.originalAddrMRange should be(AddrMRange(52, 101))
+
+    // Following links start at the clamped boundary
+    result.find(_.id == 122).get.addrMRange should be(AddrMRange(101, 102))
+    result.find(_.id == 122).get.originalAddrMRange should be(AddrMRange(101, 102))
+    result.find(_.id == 126).get.addrMRange should be(AddrMRange(101, 106))
+    result.find(_.id == 126).get.originalAddrMRange should be(AddrMRange(101, 106))
+
+    // Tail links after the tiny following links remain unchanged
+    result.find(_.id == 123).get.addrMRange should be(AddrMRange(102, 130))
+    result.find(_.id == 123).get.originalAddrMRange should be(AddrMRange(102, 130))
+    result.find(_.id == 127).get.addrMRange should be(AddrMRange(106, 130))
+    result.find(_.id == 127).get.originalAddrMRange should be(AddrMRange(106, 130))
   }
 }

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/process/TwoTrackSectionSynchronizerSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/process/TwoTrackSectionSynchronizerSpec.scala
@@ -4,6 +4,7 @@ import fi.liikennevirasto.viite.dao._
 import fi.liikennevirasto.viite.process.strategy.{TerminatedTwoTrackSectionSynchronizer, AdministrativeClassTwoTrackSynchronizer}
 import fi.vaylavirasto.viite.geometry.Point
 import fi.vaylavirasto.viite.model._
+import fi.vaylavirasto.viite.util.ViiteException
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import fi.vaylavirasto.viite.postgis.PostGISDatabaseScalikeJDBC.runWithRollback
@@ -483,5 +484,21 @@ class TwoTrackSectionSynchronizerSpec extends AnyFunSuite with Matchers {
     result.find(_.id == 123).get.originalAddrMRange should be(AddrMRange(102, 130))
     result.find(_.id == 127).get.addrMRange should be(AddrMRange(106, 130))
     result.find(_.id == 127).get.originalAddrMRange should be(AddrMRange(106, 130))
+  }
+
+  test("Case 12 - Administrative Class Change: Middle section with too large difference throws") {
+    val links = Seq(
+      buildTestLink(130, Track.RightSide, (0, 20), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
+      buildTestLink(131, Track.RightSide, (20, 40), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
+      buildTestLink(132, Track.RightSide, (40, 60), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
+
+      buildTestLink(133, Track.LeftSide, (0, 40), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
+      buildTestLink(134, Track.LeftSide, (40, 60), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
+      buildTestLink(135, Track.LeftSide, (60, 80), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality)
+    )
+
+    intercept[ViiteException] {
+      AdministrativeClassTwoTrackSynchronizer.adjustAdministrativeClassChanges(links)
+    }
   }
 }


### PR DESCRIPTION
# 3 korjausta

Korvattu undefined arvot tieosoitteiden hakutuloksista nollalla:
<img width="307" height="373" alt="image" src="https://github.com/user-attachments/assets/4dd01f0d-99d7-45a4-ac0b-ee009ffdaed1" />

Palautetaan virheilmoitus, mikäli käyttäjä yrittää tehdä hallinnollisen luokan muutosta 2ajr tiellä linkeille, joiden välinen pituus ero on enemmäin kuin 10m.
<img width="341" height="218" alt="image" src="https://github.com/user-attachments/assets/cc87e9d6-0a4a-4e7b-907f-9cf959c7bb1a" />

Täsmäytys logiikka ottaa nyt huomioon rajatapaukset, joissa täsmäytystä edeltävät ja/tai seuraavat linkit ovat hyvin lyhyitä. Aikaisemmin linkkien keskiarvoistuksesta aiheutuva "venyminen" saattoi "syödä" hyvin lyhyet linkit, jonka takia lisättiin yhden metrin minimi pituus raja.

Samalla päivitetty täsmäyttämiseen liittyviä testejä, jotka ajettu lokaalisti läpi onnistuneesti