### PR TITLE
VIITE-3941 Project link validation for  entire project

### DIFF
--- a/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
+++ b/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
@@ -990,7 +990,7 @@ class ViiteApi(val roadLinkService: RoadLinkService,           val KGVClient: Kg
           val user = userProvider.getCurrentUser.username
           projectService.revertLinks(linksToRevert.projectId, RoadPart(linksToRevert.roadNumber, linksToRevert.roadPartNumber), linksToRevert.links, linksToRevert.coordinates, user) match {
             case None =>
-              val projectErrors = projectService.validateProjectByIdHighPriorityOnly(linksToRevert.projectId).map(projectService.projectValidator.errorPartsToApi)
+              val projectErrors = projectService.validateProjectById(linksToRevert.projectId).map(projectService.projectValidator.errorPartsToApi)
               val project = projectService.getSingleProjectById(linksToRevert.projectId).get
               Map("success" -> true,
                 "publishable" -> projectErrors.isEmpty,
@@ -1047,7 +1047,7 @@ class ViiteApi(val roadLinkService: RoadLinkService,           val KGVClient: Kg
           case Some(true) =>
             val projectErrors = response.getOrElse("projectErrors", Seq).asInstanceOf[Seq[projectService.projectValidator.ValidationErrorDetails]].map(projectService.projectValidator.errorPartsToApi)
             Map("success" -> true,
-              "publishable" -> !response.contains("projectErrors"),
+              "publishable" -> projectErrors.isEmpty,
               "projectErrors" -> projectErrors,
               "errorMessage" -> response.get("errorMessage"))
           case _ => response
@@ -1108,7 +1108,7 @@ class ViiteApi(val roadLinkService: RoadLinkService,           val KGVClient: Kg
               println(s"RAN INTO AN ERROR WHILE UPDATING PROJECT LINKS ::: $errorMessage")
               Map("success" -> false, "errorMessage" -> errorMessage)}
             case None =>
-              val projectErrors = projectService.validateProjectByIdHighPriorityOnly(links.projectId).map(projectService.projectValidator.errorPartsToApi)
+              val projectErrors = projectService.validateProjectById(links.projectId).map(projectService.projectValidator.errorPartsToApi)
               val project = projectService.getSingleProjectById(links.projectId).get
               Map("success" -> true, "id" -> links.projectId,
                 "publishable" -> projectErrors.isEmpty,

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -2863,6 +2863,7 @@ def setCalibrationPoints(startCp: Long, endCp: Long, projectLinks: Seq[ProjectLi
     }
   }
 
+  // TODO: Is no longer used, safe to delete?
   def validateProjectByIdHighPriorityOnly(projectId: Long, newSession: Boolean = true): Seq[projectValidator.ValidationErrorDetails] = {
     if (newSession) {
       runWithReadOnlySession {

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/ProjectValidator.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/ProjectValidator.scala
@@ -515,6 +515,7 @@ class ProjectValidator {
 
   /** Returns the high priority validation errors found within projectLinks (i.e. those that should be addressed
    *  first by the user, before any other possible errors). */
+   // TODO: No longer used, safe to delete?
   def projectLinksHighPriorityValidation(project: Project, projectLinks: Seq[ProjectLink]): Seq[ValidationErrorDetails] = {
 
     // function to get any (high priority) validation errors for the project links


### PR DESCRIPTION
Projektilinkkien validointi ei ottanut kiinni oleellisia tapauksia, joten korvataan vanha logiikka sillä, että koko projekti validoidaan aina kun projektilinkki tallennetaan.