### PR TITLE
VIITE-3943 Fix EVK not set for dropdown

### DIFF
--- a/viite-UI/src/view/FormCommon.js
+++ b/viite-UI/src/view/FormCommon.js
@@ -214,8 +214,7 @@
           if (response.success) {
             $('#tie').val(response.roadNumber);
             $('#osa').val(response.roadPartNumber);
-            $('#ely').val(response.ely);
-            $('#elinvoimakeskus').val(response.evk);
+            $('#elinvoimakeskus').val(response.roadMaintainer);
             if (response.roadName !== '') {
               roadNameField.val(response.roadName);
               roadNameField.prop('disabled', response.roadNameSource === RoadNameSource.RoadAddressSource.value);


### PR DESCRIPTION
Korjataan bugi, jossa lakkautus + uusi toimenpiteet aiheuttivat EVK arvon katoamisen valikosta. Samalla poistettu turha ELY rivi.