### PR TITLE
Viite 3944 m value rounding

### DIFF
--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -2078,6 +2078,27 @@ def setCalibrationPoints(startCp: Long, endCp: Long, projectLinks: Seq[ProjectLi
     })
   }
 
+  private val maxDiffForOriginalAddrMAlignment = 1L
+
+  /**
+   * Workaround for occasional 1m drift between calculated addrMRange and originalAddrMRange.
+   *
+   * If either start or end differs by at most maxDiff, originalAddrMRange is aligned to addrMRange
+   * for that boundary.
+   */
+  private def alignOriginalAddrMToCalculatedAddrMWhenClose(projectLinks: Seq[ProjectLink], maxDiff: Long = maxDiffForOriginalAddrMAlignment): Seq[ProjectLink] = {
+    projectLinks.map { link =>
+      val alignedStart = if (Math.abs(link.originalAddrMRange.start - link.addrMRange.start) <= maxDiff) link.addrMRange.start else link.originalAddrMRange.start
+      val alignedEnd = if (Math.abs(link.originalAddrMRange.end - link.addrMRange.end) <= maxDiff) link.addrMRange.end else link.originalAddrMRange.end
+
+      if (alignedStart != link.originalAddrMRange.start || alignedEnd != link.originalAddrMRange.end) {
+        link.copy(originalAddrMRange = AddrMRange(alignedStart, alignedEnd))
+      } else {
+        link
+      }
+    }
+  }
+
   def recalculateProjectLinks(projectId: Long, userName: String, roadParts: Set[RoadPart] = Set()): Unit = {
 
     logger.info(s"Recalculating project $projectId, parts ${roadParts.mkString(", ")}")
@@ -2101,7 +2122,10 @@ def setCalibrationPoints(startCp: Long, endCp: Long, projectLinks: Seq[ProjectLi
           val recalculatedNonTerminated = ProjectSectionCalculator.assignAddrMValues(withoutTerminated, calibrationPoints)
 
           // Add the adjusted terminated links to the recalculated links and sort them by addrMRange.end
-          (recalculatedNonTerminated ++ adjustedTerminated).sortBy(_.addrMRange.end)
+          val recalculatedWithTerminated = (recalculatedNonTerminated ++ adjustedTerminated).sortBy(_.addrMRange.end)
+
+          // Apply rounding correction to originalAddrMRange for links where the difference between original and calculated addrM values is within the defined threshold
+          alignOriginalAddrMToCalculatedAddrMWhenClose(recalculatedWithTerminated)
       }.toSeq
 
 

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/process/strategy/AdministrativeClassTwoTrackSynchronizer.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/process/strategy/AdministrativeClassTwoTrackSynchronizer.scala
@@ -50,7 +50,7 @@ object AdministrativeClassTwoTrackSynchronizer {
     }
 
     // Check that there are administrative class changes on both tracks
-    if (existsAdminClassChangesOnParallelTracks(roadPartProjectLinksWithoutNewLinks)) {
+    val processedLinks = if (existsAdminClassChangesOnParallelTracks(roadPartProjectLinksWithoutNewLinks)) {
       val orderedProjectLinks = roadPartProjectLinksWithoutNewLinks.sortBy(_.addrMRange.start)
 
       // List of administrative class change cases
@@ -67,6 +67,8 @@ object AdministrativeClassTwoTrackSynchronizer {
       // else we return the links unchanged.
       roadPartProjectLinksWithoutNewLinks
     }
+
+    SynchronizationUtils.alignOriginalAddrMToCalculatedAddrMWhenClose(processedLinks)
   }
 
   /**

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/process/strategy/AdministrativeClassTwoTrackSynchronizer.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/process/strategy/AdministrativeClassTwoTrackSynchronizer.scala
@@ -68,7 +68,7 @@ object AdministrativeClassTwoTrackSynchronizer {
       roadPartProjectLinksWithoutNewLinks
     }
 
-    SynchronizationUtils.alignOriginalAddrMToCalculatedAddrMWhenClose(processedLinks)
+    processedLinks
   }
 
   /**

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/process/strategy/TerminatedTwoTrackSectionSynchronizer.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/process/strategy/TerminatedTwoTrackSectionSynchronizer.scala
@@ -52,7 +52,7 @@ object TerminatedTwoTrackSectionSynchronizer {
         roadPartProjectLinksWithoutNewLinks
       }
     }
-    SynchronizationUtils.alignOriginalAddrMToCalculatedAddrMWhenClose(processedLinks)
+    processedLinks
   }
 
   /**

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/process/strategy/TerminatedTwoTrackSectionSynchronizer.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/process/strategy/TerminatedTwoTrackSectionSynchronizer.scala
@@ -52,7 +52,7 @@ object TerminatedTwoTrackSectionSynchronizer {
         roadPartProjectLinksWithoutNewLinks
       }
     }
-    processedLinks
+    SynchronizationUtils.alignOriginalAddrMToCalculatedAddrMWhenClose(processedLinks)
   }
 
   /**

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/util/SynchronizationUtils.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/util/SynchronizationUtils.scala
@@ -8,6 +8,8 @@ import fi.vaylavirasto.viite.model.{AddrMRange, Track}
 
 object SynchronizationUtils {
 
+  // NOTE: If this value is changed, make sure to update the test cases in TwoTrackSectionSynchronizerSpec as well,
+  // since they rely on this threshold for determining when to align originalAddrMRange to addrMRange.
   val maxDiffForAddressChange = 20L // This number is arbitrary and may require adjustments in the future.
   val maxDiffForTracks = maxDiffForAddressChange
   val maxDiffForOriginalAddrMAlignment = 1L

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/util/SynchronizationUtils.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/util/SynchronizationUtils.scala
@@ -12,7 +12,6 @@ object SynchronizationUtils {
   // since they rely on this threshold for determining when to align originalAddrMRange to addrMRange.
   val maxDiffForAddressChange = 20L // This number is arbitrary and may require adjustments in the future.
   val maxDiffForTracks = maxDiffForAddressChange
-  val maxDiffForOriginalAddrMAlignment = 1L
 
   /**
    * Generic method to divide project links into continuous sections based on a predicate.
@@ -122,22 +121,4 @@ object SynchronizationUtils {
     links.find(pl => pl.track != trackToExclude && target.originalAddrMRange.continuesTo(pl.originalAddrMRange))
   }
 
-  /**
-   * Workaround for occasional 1m drift between calculated addrMRange and originalAddrMRange.
-   *
-   * If either start or end differs by at most maxDiff, originalAddrMRange is aligned to addrMRange
-   * for that boundary.
-   */
-  def alignOriginalAddrMToCalculatedAddrMWhenClose(projectLinks: Seq[ProjectLink], maxDiff: Long = maxDiffForOriginalAddrMAlignment): Seq[ProjectLink] = {
-    projectLinks.map { link =>
-      val alignedStart = if (Math.abs(link.originalAddrMRange.start - link.addrMRange.start) <= maxDiff) link.addrMRange.start else link.originalAddrMRange.start
-      val alignedEnd = if (Math.abs(link.originalAddrMRange.end - link.addrMRange.end) <= maxDiff) link.addrMRange.end else link.originalAddrMRange.end
-
-      if (alignedStart != link.originalAddrMRange.start || alignedEnd != link.originalAddrMRange.end) {
-        link.copy(originalAddrMRange = AddrMRange(alignedStart, alignedEnd))
-      } else {
-        link
-      }
-    }
-  }
 }

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/util/SynchronizationUtils.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/util/SynchronizationUtils.scala
@@ -8,8 +8,9 @@ import fi.vaylavirasto.viite.model.{AddrMRange, Track}
 
 object SynchronizationUtils {
 
-  val maxDiffForAddressChange = 10L // This number is arbitrary and may require adjustments in the future.
+  val maxDiffForAddressChange = 20L // This number is arbitrary and may require adjustments in the future.
   val maxDiffForTracks = maxDiffForAddressChange
+  val maxDiffForOriginalAddrMAlignment = 1L
 
   /**
    * Generic method to divide project links into continuous sections based on a predicate.
@@ -117,5 +118,24 @@ object SynchronizationUtils {
    */
   def findNextLink(links: Seq[ProjectLink], target: ProjectLink, trackToExclude: Track): Option[ProjectLink] = {
     links.find(pl => pl.track != trackToExclude && target.originalAddrMRange.continuesTo(pl.originalAddrMRange))
+  }
+
+  /**
+   * Workaround for occasional 1m drift between calculated addrMRange and originalAddrMRange.
+   *
+   * If either start or end differs by at most maxDiff, originalAddrMRange is aligned to addrMRange
+   * for that boundary.
+   */
+  def alignOriginalAddrMToCalculatedAddrMWhenClose(projectLinks: Seq[ProjectLink], maxDiff: Long = maxDiffForOriginalAddrMAlignment): Seq[ProjectLink] = {
+    projectLinks.map { link =>
+      val alignedStart = if (Math.abs(link.originalAddrMRange.start - link.addrMRange.start) <= maxDiff) link.addrMRange.start else link.originalAddrMRange.start
+      val alignedEnd = if (Math.abs(link.originalAddrMRange.end - link.addrMRange.end) <= maxDiff) link.addrMRange.end else link.originalAddrMRange.end
+
+      if (alignedStart != link.originalAddrMRange.start || alignedEnd != link.originalAddrMRange.end) {
+        link.copy(originalAddrMRange = AddrMRange(alignedStart, alignedEnd))
+      } else {
+        link
+      }
+    }
   }
 }

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/ProjectValidatorSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/ProjectValidatorSpec.scala
@@ -2178,7 +2178,8 @@ Left|      |Right
    }
  }
 
- test("Test checkTrackCodePairing When project links are created with inconsistent addr m values Then project track codes should inconsistent in middle of track") {
+// TODO: Similar tests exist already in ProjectValidatorSpec, check if this test is safe to remove
+ test("Test checkTrackCodePairing When project links are created with inconsistent addr m values Then project track codes should be inconsistent in middle of track") {
    runWithRollback {
      val (project, projectLinks) = util.setUpProjectWithLinks(RoadAddressChangeType.New, Seq(0L, 10L, 20L, 30L, 40L), changeTrack = true)
      val inconsistentLinks = projectLinks.map { l =>
@@ -2188,7 +2189,7 @@ Left|      |Right
      }
      mockEmptyRoadAddressServiceCalls()
      val validationErrors = projectValidator.checkTrackCodePairing(project, inconsistentLinks).distinct
-     validationErrors.size should be(2)
+     validationErrors.size should be(1)
    }
  }
 

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/process/TwoTrackSectionSynchronizerSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/process/TwoTrackSectionSynchronizerSpec.scala
@@ -148,32 +148,32 @@ class TwoTrackSectionSynchronizerSpec extends AnyFunSuite with Matchers {
 
   test("Case 4 - Terminations: Large gap should NOT synchronize") {
     /**
-     * Before: Large gap between terminations (> maxDiffForTracks = 10)
+     * Before: Large gap between terminations (> maxDiffForTracks = 20)
      * 0     20         50
      * ======>--------> 
      * ======>-------------->
-     * 0     40           60
+     * 0     41           60
      *
      * After: Should remain unchanged because gap is too large
      * 0     20         50
      * ======>--------> 
      * ======>-------------->
-     * 0     40           60
+     * 0     41           60
      */
     val links = Seq(
       buildTestLink(40, Track.RightSide, (0, 20), RoadAddressChangeType.Termination),
       buildTestLink(41, Track.RightSide, (20, 50), RoadAddressChangeType.Unchanged),
-      buildTestLink(42, Track.LeftSide, (0, 40), RoadAddressChangeType.Termination),
-      buildTestLink(43, Track.LeftSide, (40, 60), RoadAddressChangeType.Unchanged)
+      buildTestLink(42, Track.LeftSide, (0, 41), RoadAddressChangeType.Termination),
+      buildTestLink(43, Track.LeftSide, (41, 60), RoadAddressChangeType.Unchanged)
     )
 
     val result = TerminatedTwoTrackSectionSynchronizer.adjustTerminations(links)
 
-    // Links should remain unchanged because gap (40-20=20) > maxDiffForTracks (10)
+    // Links should remain unchanged because gap (41-20=21) > maxDiffForTracks (20)
     result.find(_.id == 40).get.addrMRange should be(AddrMRange(0, 20))
     result.find(_.id == 41).get.addrMRange should be(AddrMRange(20, 50))
-    result.find(_.id == 42).get.addrMRange should be(AddrMRange(0, 40))
-    result.find(_.id == 43).get.addrMRange should be(AddrMRange(40, 60))
+    result.find(_.id == 42).get.addrMRange should be(AddrMRange(0, 41))
+    result.find(_.id == 43).get.addrMRange should be(AddrMRange(41, 60))
   }
 
   test("Case 5 - Administrative class change: No administrative class changes should not affect links") {
@@ -492,9 +492,9 @@ class TwoTrackSectionSynchronizerSpec extends AnyFunSuite with Matchers {
       buildTestLink(131, Track.RightSide, (20, 40), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
       buildTestLink(132, Track.RightSide, (40, 60), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
 
-      buildTestLink(133, Track.LeftSide, (0, 40), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
-      buildTestLink(134, Track.LeftSide, (40, 60), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
-      buildTestLink(135, Track.LeftSide, (60, 80), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality)
+      buildTestLink(133, Track.LeftSide, (0, 41), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
+      buildTestLink(134, Track.LeftSide, (41, 61), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
+      buildTestLink(135, Track.LeftSide, (61, 80), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality)
     )
 
     intercept[ViiteException] {


### PR DESCRIPTION
Siirretty pyöristys virheen korjaus ProjectServiceen, jotta se ajetaan joka kerta projektin laskennassa, ei pelkästään hallinnollisten luokkien muutoksissa tai lakkautuksien tapauksissa.