### PR TITLE
Viite 3949 2 track new action validations

### DIFF
--- a/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
+++ b/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
@@ -1317,9 +1317,14 @@ class ViiteApi(val roadLinkService: RoadLinkService,           val KGVClient: Kg
         val invalidUnchangedLinkErrors = PostGISDatabaseScalikeJDBC.runWithTransaction {
           val project = projectService.fetchProjectById(projectId).get
           val invalidUnchangedLinkErrors = projectService.projectValidator.checkForInvalidUnchangedLinks(project, projectLinkDAO.fetchProjectLinks(projectId))
-          
+
           if (invalidUnchangedLinkErrors.isEmpty) {
-            projectService.recalculateProjectLinks(projectId, project.modifiedBy)
+            try {
+              projectService.recalculateProjectLinks(projectId, project.modifiedBy)
+            } catch {
+              case e: RoadAddressException =>
+                logger.warn(s"Recalculation failed for project $projectId during recalculate-and-validate, continuing with existing link values. ${e.getMessage}", e)
+            }
           }
           invalidUnchangedLinkErrors
         }
@@ -1331,9 +1336,6 @@ class ViiteApi(val roadLinkService: RoadLinkService,           val KGVClient: Kg
         // return validation errors
         Map("success" -> true, "validationErrors" -> validationErrors)
       } catch {
-        case ex: RoadAddressException =>
-          logger.info("Road address Exception: " + ex.getMessage)
-          Map("success" -> false, "errorMessage" -> ex.getMessage)
         case ex: ProjectValidationException =>
           Map("success" -> false, "errorMessage" -> ex.getMessage, "validationErrors" -> ex.getValidationErrors)
         case ex: Exception =>

--- a/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
+++ b/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
@@ -997,7 +997,7 @@ class ViiteApi(val roadLinkService: RoadLinkService,           val KGVClient: Kg
           val user = userProvider.getCurrentUser.username
           projectService.revertLinks(linksToRevert.projectId, RoadPart(linksToRevert.roadNumber, linksToRevert.roadPartNumber), linksToRevert.links, linksToRevert.coordinates, user) match {
             case None =>
-              val projectErrors = projectService.validateProjectById(linksToRevert.projectId).map(projectService.projectValidator.errorPartsToApi)
+              val projectErrors = projectService.validateProjectByIdHighPriorityOnly(linksToRevert.projectId).map(projectService.projectValidator.errorPartsToApi)
               val project = projectService.getSingleProjectById(linksToRevert.projectId).get
               Map("success" -> true,
                 "publishable" -> projectErrors.isEmpty,
@@ -1054,7 +1054,7 @@ class ViiteApi(val roadLinkService: RoadLinkService,           val KGVClient: Kg
           case Some(true) =>
             val projectErrors = response.getOrElse("projectErrors", Seq).asInstanceOf[Seq[projectService.projectValidator.ValidationErrorDetails]].map(projectService.projectValidator.errorPartsToApi)
             Map("success" -> true,
-              "publishable" -> projectErrors.isEmpty,
+              "publishable" -> !response.contains("projectErrors"),
               "projectErrors" -> projectErrors,
               "errorMessage" -> response.get("errorMessage"))
           case _ => response
@@ -1116,7 +1116,7 @@ class ViiteApi(val roadLinkService: RoadLinkService,           val KGVClient: Kg
               Map("success" -> false, "errorMessage" -> errorMessage)}
             case None =>
               val validationResult = try {
-                Right(projectService.validateProjectById(links.projectId).map(projectService.projectValidator.errorPartsToApi))
+                Right(projectService.validateProjectByIdHighPriorityOnly(links.projectId).map(projectService.projectValidator.errorPartsToApi))
               } catch {
                 case e: RoadAddressException =>
                   logger.warn(s"Validation failed after updating project links for project ${links.projectId}", e)

--- a/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
+++ b/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
@@ -928,7 +928,14 @@ class ViiteApi(val roadLinkService: RoadLinkService,           val KGVClient: Kg
             val projectMap = roadAddressProjectToApi(project, projectService.getProjectEvk(project.id))
             val reservedparts = project.reservedParts.map(projectReservedPartToApi)
             val formedparts = project.formedParts.map(projectFormedPartToApi(Some(project.id)))
-            val errorParts = projectService.validateProjectById(project.id)
+            val validationResult = try {
+              Right(projectService.validateProjectById(project.id))
+            } catch {
+              case e: RoadAddressException =>
+                logger.warn(s"Validation failed while opening project $projectId.", e)
+                Left(())
+            }
+            val errorParts = validationResult.getOrElse(Seq.empty)
             val publishable = errorParts.isEmpty
             Map("project" -> projectMap, "linkId" -> project.reservedParts.find(_.startingLinkId.nonEmpty).flatMap(_.startingLinkId),
               "reservedInfo" -> reservedparts, "formedInfo" -> formedparts, "publishable" -> publishable, "projectErrors" -> errorParts.map(projectService.projectValidator.errorPartsToApi))
@@ -1108,7 +1115,14 @@ class ViiteApi(val roadLinkService: RoadLinkService,           val KGVClient: Kg
               println(s"RAN INTO AN ERROR WHILE UPDATING PROJECT LINKS ::: $errorMessage")
               Map("success" -> false, "errorMessage" -> errorMessage)}
             case None =>
-              val projectErrors = projectService.validateProjectById(links.projectId).map(projectService.projectValidator.errorPartsToApi)
+              val validationResult = try {
+                Right(projectService.validateProjectById(links.projectId).map(projectService.projectValidator.errorPartsToApi))
+              } catch {
+                case e: RoadAddressException =>
+                  logger.warn(s"Validation failed after updating project links for project ${links.projectId}", e)
+                  Left(())
+              }
+              val projectErrors = validationResult.getOrElse(Seq.empty)
               val project = projectService.getSingleProjectById(links.projectId).get
               Map("success" -> true, "id" -> links.projectId,
                 "publishable" -> projectErrors.isEmpty,

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -2878,12 +2878,25 @@ def setCalibrationPoints(startCp: Long, endCp: Long, projectLinks: Seq[ProjectLi
     * @return A sequence of validation errors, can be empty.
     */
   def validateProjectById(projectId: Long, newSession: Boolean = true): Seq[projectValidator.ValidationErrorDetails] = {
+    def validateWithCalculatedLinks(): Seq[projectValidator.ValidationErrorDetails] = {
+      val project = fetchProjectById(projectId).get
+      val linksBeforeValidation = projectLinkDAO.fetchProjectLinks(projectId)
+
+      // Address-dependent validations require calculated M-values. Recalculate first if needed.
+      if (linksBeforeValidation.exists(_.isNotCalculated)) {
+        recalculateProjectLinks(projectId, project.modifiedBy)
+      }
+
+      val linksForValidation = projectLinkDAO.fetchProjectLinks(projectId)
+      projectValidator.validateProject(project, linksForValidation)
+    }
+
     if (newSession) {
-      runWithReadOnlySession {
-        projectValidator.validateProject(fetchProjectById(projectId).get, projectLinkDAO.fetchProjectLinks(projectId))
+      runWithTransaction {
+        validateWithCalculatedLinks()
       }
     } else {
-      projectValidator.validateProject(fetchProjectById(projectId).get, projectLinkDAO.fetchProjectLinks(projectId))
+      validateWithCalculatedLinks()
     }
   }
 

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -2883,8 +2883,14 @@ def setCalibrationPoints(startCp: Long, endCp: Long, projectLinks: Seq[ProjectLi
       val linksBeforeValidation = projectLinkDAO.fetchProjectLinks(projectId)
 
       // Address-dependent validations require calculated M-values. Recalculate first if needed.
+      // If recalculation fails, log a warning and continue validation with the existing links.
       if (linksBeforeValidation.exists(_.isNotCalculated)) {
-        recalculateProjectLinks(projectId, project.modifiedBy)
+        try {
+          recalculateProjectLinks(projectId, project.modifiedBy)
+        } catch {
+          case e: Exception =>
+            logger.warn(s"Recalculation failed for project $projectId during validation, continuing with existing link values. ${e.getMessage}", e)
+        }
       }
 
       val linksForValidation = projectLinkDAO.fetchProjectLinks(projectId)

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -2900,7 +2900,6 @@ def setCalibrationPoints(startCp: Long, endCp: Long, projectLinks: Seq[ProjectLi
     }
   }
 
-  // TODO: Is no longer used, safe to delete?
   def validateProjectByIdHighPriorityOnly(projectId: Long, newSession: Boolean = true): Seq[projectValidator.ValidationErrorDetails] = {
     if (newSession) {
       runWithReadOnlySession {

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/ProjectValidator.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/ProjectValidator.scala
@@ -515,7 +515,6 @@ class ProjectValidator {
 
   /** Returns the high priority validation errors found within projectLinks (i.e. those that should be addressed
    *  first by the user, before any other possible errors). */
-   // TODO: No longer used, safe to delete?
   def projectLinksHighPriorityValidation(project: Project, projectLinks: Seq[ProjectLink]): Seq[ValidationErrorDetails] = {
 
     // function to get any (high priority) validation errors for the project links


### PR DESCRIPTION
Validointi ei osannut käsitellä 2ajr keissejä, joissa toisella ajoradalla oli uusi linkki, sillä M-arvoja ei vielä tässä kohtaa laskettu niille. Korjaava ratkaisu laskee M-arvot uusille linkeille ennen validointia.

Otettiin takaisin käyttöön vain korkean prioriteetin validointi projektilinkkejä tallennettaessa, sillä joissakin tapauksissa tämä aiheutti ongelmia.

Korjattiin bugi, jossa käyttäjä ei pystynyt avaamaan projektia, jossa ilmeni laskenta virhe. Jos laskennassa ilmenee virhe, niin Viite palauttaa virheilmoituksen lisäksi myös validointi virheet.