### PR TITLE
VIITE-3952 Fix devtool to avoid sending data if not modified

### DIFF
--- a/viite-UI/src/model/ProjectCollection.js
+++ b/viite-UI/src/model/ProjectCollection.js
@@ -358,8 +358,30 @@
         ? roadAddressProjectForm.find('#newRoadwayNumber')[0].checked
         : null;
 
+      const changedFromInitial = function (id, isCheckbox) {
+        const element = document.getElementById(id);
+        if (!element || _.isUndefined(element.dataset.initialValue)) return false;
+
+        const currentValue = isCheckbox
+          ? (element.checked ? '1' : '0')
+          : String(element.value);
+
+        return currentValue !== String(element.dataset.initialValue);
+      };
+
       let devToolData = null;
-      if (hasDevRights) {
+      const devToolFieldsChanged = hasDevRights && (
+        changedFromInitial('addrStart', false) ||
+        changedFromInitial('addrEnd', false) ||
+        changedFromInitial('origAddrStart', false) ||
+        changedFromInitial('origAddrEnd', false) ||
+        changedFromInitial('startCPDropdown', false) ||
+        changedFromInitial('endCPDropdown', false) ||
+        changedFromInitial('sideCodeDropdown', false) ||
+        changedFromInitial('newRoadwayNumber', true)
+      );
+
+      if (devToolFieldsChanged) {
         devToolData = {
           startAddrMValue: startAddrMValue,
           endAddrMValue: endAddrMValue,

--- a/viite-UI/src/view/ProjectEditForm.js
+++ b/viite-UI/src/view/ProjectEditForm.js
@@ -269,6 +269,7 @@
         rootElement.html(selectedProjectLinkTemplate(currentProject.project, selectedProjectLink));
         formCommon.replaceAddressInfo(backend, selectedProjectLink, currentProject.project.id);
         updateForm();
+        setDevToolBaselineValues();
         
         // disable form interactions (action dropdown, save and cancel buttons) if change table is open
         if (projectChangeTable.isChangeTableOpen()) {
@@ -304,6 +305,30 @@
         $('#discontinuityDropdown').val(selectedDiscontinuity.toString());
       };
 
+      const setDevToolBaselineValues = () => {
+        const baselineFields = [
+          'addrStart',
+          'addrEnd',
+          'origAddrStart',
+          'origAddrEnd',
+          'startCPDropdown',
+          'endCPDropdown',
+          'sideCodeDropdown'
+        ];
+
+        baselineFields.forEach((id) => {
+          const element = document.getElementById(id);
+          if (element) {
+            element.dataset.initialValue = String(element.value);
+          }
+        });
+
+        const roadwayCheckbox = document.getElementById('newRoadwayNumber');
+        if (roadwayCheckbox) {
+          roadwayCheckbox.dataset.initialValue = roadwayCheckbox.checked ? '1' : '0';
+        }
+      };
+
       eventbus.on('projectLink:errorClicked', (selected, errorMessage) => {
         selectedProjectLink = [selected[0]];
         const currentProject = projectCollection.getCurrentProject();
@@ -311,6 +336,7 @@
         rootElement.html(selectedProjectLinkTemplate(currentProject.project, selectedProjectLink, errorMessage));
         formCommon.replaceAddressInfo(backend, selectedProjectLink);
         updateForm();
+        setDevToolBaselineValues();
       });
 
       eventbus.on('roadAddress:projectFailed', () => {


### PR DESCRIPTION
Korjattu devtoolista aiheutunut bugi, joka aiheutti päällekkäisten roadwayden bugin. Frontti lähetti siis aina devtool dataa, kun devi rooli oli käytössä, vaikka mitään muutoksia ei olisikaan devtoolilla tehty. Tämä triggeröi ProjectServicen updateProjectLinksWithDevToolData funktion, joka muutti M-arvoja, ja näin aiheutti eroavaisuuksia nykyisen tilanteen ja historian välillä. Eli nyt devtool dataa ei lähetetä, paitsi jos sillä on tehty muutoksia.