### PR TITLE
VIITE-3378 Universal averaging logic for 2track roads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ WebContent/
 /local-dev/postgis/data/
 revision.properties
 bonecp.properties
+.env
+/.db

--- a/viite-backend/base/src/main/scala/fi/vaylavirasto/viite/model/AddrMRange.scala
+++ b/viite-backend/base/src/main/scala/fi/vaylavirasto/viite/model/AddrMRange.scala
@@ -19,8 +19,8 @@ case class AddrMRange (start: Long, end: Long)// extends Ordered[AddrMRange]
 
   // throws ViiteException if requirements not met
   try {
-    require((start >= minAddrMZero && start <= maxAddrM), s"A start address must be between $minAddrMZero-$maxAddrM.")
-    require((  end >= minAddrMZero &&   end <= maxAddrM), s"An  end address must be between $minAddrMZero-$maxAddrM.")
+    require((start >= minAddrMZero && start <= maxAddrM), s"Alkuetäisyyden pitää olla $minAddrMZero-$maxAddrM. Nyt se on $start.")
+    require((  end >= minAddrMZero &&   end <= maxAddrM), s"Loppuetäisyyden pitää olla $minAddrMZero-$maxAddrM. Nyt se on $end.")
     // Calculations so far require leaving this - I think very substantial - restriction out.
     //require((  start < end || (start==0 &&  end==0)), s"A start address (now $start) must be smaller than end address (now $end), or range must be undefined (0-0).")
   } catch  {

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -2104,8 +2104,6 @@ def setCalibrationPoints(startCp: Long, endCp: Long, projectLinks: Seq[ProjectLi
     })
   }
 
-  private val maxDiffForOriginalAddrMAlignment = 1L
-
   def recalculateProjectLinks(projectId: Long, userName: String, roadParts: Set[RoadPart] = Set()): Unit = {
 
     logger.info(s"Recalculating project $projectId, parts ${roadParts.mkString(", ")}")

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -10,8 +10,7 @@ import ProjectCalibrationPointDAO.UserDefinedCalibrationPoint
 import fi.liikennevirasto.viite.dao.ProjectState._
 import fi.liikennevirasto.viite.model.{ProjectAddressLink, RoadAddressLink}
 import fi.liikennevirasto.viite.process._
-import fi.liikennevirasto.viite.process.strategy.AdministrativeClassTwoTrackSynchronizer.{adjustAdministrativeClassChanges}
-import fi.liikennevirasto.viite.process.strategy.TerminatedTwoTrackSectionSynchronizer.{adjustTerminations}
+import fi.liikennevirasto.viite.process.strategy.TwoTrackAverager.{averageTwoTrackBoundaries}
 import fi.vaylavirasto.viite.dao.{LinkDAO, ProjectLinkNameDAO, RoadName, RoadNameDAO, Sequences}
 import fi.vaylavirasto.viite.geometry.{BoundingRectangle, GeometryUtils, Point}
 import fi.vaylavirasto.viite.model.CalibrationPointType.{JunctionPointCP, NoCP, UserDefinedCP}
@@ -2107,52 +2106,52 @@ def setCalibrationPoints(startCp: Long, endCp: Long, projectLinks: Seq[ProjectLi
 
   private val maxDiffForOriginalAddrMAlignment = 1L
 
-  /**
-   * Workaround for occasional 1m drift between calculated addrMRange and originalAddrMRange.
-   *
-   * If either start or end differs by at most maxDiff, originalAddrMRange is aligned to addrMRange
-   * for that boundary.
-   */
-  private def alignOriginalAddrMToCalculatedAddrMWhenClose(projectLinks: Seq[ProjectLink], maxDiff: Long = maxDiffForOriginalAddrMAlignment): Seq[ProjectLink] = {
-    projectLinks.map { link =>
-      val alignedStart = if (Math.abs(link.originalAddrMRange.start - link.addrMRange.start) <= maxDiff) link.addrMRange.start else link.originalAddrMRange.start
-      val alignedEnd = if (Math.abs(link.originalAddrMRange.end - link.addrMRange.end) <= maxDiff) link.addrMRange.end else link.originalAddrMRange.end
-
-      if (alignedStart != link.originalAddrMRange.start || alignedEnd != link.originalAddrMRange.end) {
-        link.copy(originalAddrMRange = AddrMRange(alignedStart, alignedEnd))
-      } else {
-        link
-      }
-    }
-  }
-
   def recalculateProjectLinks(projectId: Long, userName: String, roadParts: Set[RoadPart] = Set()): Unit = {
 
     logger.info(s"Recalculating project $projectId, parts ${roadParts.mkString(", ")}")
     time(logger, "Recalculate links") {
       val projectLinks = projectLinkDAO.fetchProjectLinks(projectId)
-      val recalculated = projectLinks.groupBy(pl => {
-        (pl.roadPart)
-      }).flatMap {
-        grp =>
-          val fusedLinks = getFusedProjectLinks(grp._2)
-          val calibrationPoints = ProjectCalibrationPointDAO.fetchByRoadPart(projectId, grp._1)
-          val projectLinksWithAdjustedCalibrationPoints = adjustCalibrationPointsOnProjectLinks(fusedLinks)
-          val (newLinks, notNewLinks) = projectLinksWithAdjustedCalibrationPoints.partition(_.status == RoadAddressChangeType.New)
-          val (adjustedTerminated, adjustedNonTerminated) = adjustTerminations(notNewLinks).partition(_.status == RoadAddressChangeType.Termination)
-          
-          // Administrative class synchronization needs full non-terminated road-part context
-          // so the neighboring unchanged links can be slid with changed boundaries.
-          val adjustedAdminClassNonTerminated = adjustAdministrativeClassChanges(adjustedNonTerminated)
+      val preparedByRoadPart = projectLinks.groupBy(_.roadPart).map { case (roadPart, linksOnRoadPart) =>
+        val fusedLinks = getFusedProjectLinks(linksOnRoadPart)
+        val adjustedCalibrationPoints = adjustCalibrationPointsOnProjectLinks(fusedLinks)
+        roadPart -> adjustedCalibrationPoints
+      }
 
-          val withoutTerminated = (adjustedAdminClassNonTerminated ++ newLinks).sortBy(_.addrMRange.start)
-          val recalculatedNonTerminated = ProjectSectionCalculator.assignAddrMValues(withoutTerminated, calibrationPoints)
+      val roadPartsToSkipPreAveraging = preparedByRoadPart.collect {
+        case (roadPart, links)
+          if links.exists(_.track == Track.Combined) && links.exists(_.status == RoadAddressChangeType.New) =>
+          roadPart
+      }.toSet
 
-          // Add the adjusted terminated links to the recalculated links and sort them by addrMRange.end
-          val recalculatedWithTerminated = (recalculatedNonTerminated ++ adjustedTerminated).sortBy(_.addrMRange.end)
+      // Average all non-New links in one pass to keep boundary adjustments consistent.
+      val allNotNew = preparedByRoadPart.flatMap { case (roadPart, links) =>
+        if (roadPartsToSkipPreAveraging.contains(roadPart)) Seq.empty
+        else links.filter(_.status != RoadAddressChangeType.New)
+      }.toSeq
+      val averagedNotNewById = averageTwoTrackBoundaries(allNotNew).map(pl => pl.id -> pl).toMap
 
-          // Apply rounding correction to originalAddrMRange for links where the difference between original and calculated addrM values is within the defined threshold
-          alignOriginalAddrMToCalculatedAddrMWhenClose(recalculatedWithTerminated)
+      val recalculated = preparedByRoadPart.flatMap { case (roadPart, linksOnRoadPart) =>
+        val calibrationPoints = ProjectCalibrationPointDAO.fetchByRoadPart(projectId, roadPart)
+
+        val averagedOnRoadPart =
+          if (roadPartsToSkipPreAveraging.contains(roadPart)) linksOnRoadPart
+          else {
+            linksOnRoadPart.map { link =>
+              if (link.status == RoadAddressChangeType.New) link
+              else averagedNotNewById.getOrElse(link.id, link)
+            }
+          }
+
+        val (newLinks, notNewLinks) = averagedOnRoadPart.partition(_.status == RoadAddressChangeType.New)
+        val (adjustedTerminated, adjustedNonTerminated) = notNewLinks.partition(_.status == RoadAddressChangeType.Termination)
+
+        val withoutTerminated = (adjustedNonTerminated ++ newLinks).sortBy(_.addrMRange.start)
+        val recalculatedNonTerminated = ProjectSectionCalculator.assignAddrMValues(withoutTerminated, calibrationPoints)
+
+        // Add the adjusted terminated links to the recalculated links and sort them by addrMRange.end.
+        val recalculatedWithTerminated = (recalculatedNonTerminated ++ adjustedTerminated).sortBy(_.addrMRange.end)
+
+        recalculatedWithTerminated
       }.toSeq
 
 

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/process/strategy/AdministrativeClassTwoTrackSynchronizer.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/process/strategy/AdministrativeClassTwoTrackSynchronizer.scala
@@ -5,6 +5,8 @@ import fi.liikennevirasto.viite.util.{SynchronizationUtils, TwoTrackRoadUtils}
 import fi.vaylavirasto.viite.model.{AddrMRange, Discontinuity, RoadAddressChangeType, Track}
 import fi.vaylavirasto.viite.util.ViiteException
 
+// TODO: No longer used, safe to delete?
+
 /**
  * This object is responsible for synchronizing road address measurements on
  * two-track road parts where administrative classes are being changed. Because physical measurements for Left and Right tracks often vary slightly,

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/process/strategy/TerminatedTwoTrackSectionSynchronizer.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/process/strategy/TerminatedTwoTrackSectionSynchronizer.scala
@@ -4,6 +4,8 @@ import fi.liikennevirasto.viite.util.{SynchronizationUtils, TwoTrackRoadUtils}
 import fi.vaylavirasto.viite.model.{AddrMRange, Discontinuity, RoadAddressChangeType, RoadPart, Track}
 import fi.vaylavirasto.viite.util.ViiteException
 
+// TODO: No longer used, safe to delete?
+
 /*
 This object is responsible for synchronizing road address measurements on
 two-track road parts where tracks are being terminated. Because physical measurements for Left and Right tracks often vary slightly,

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/process/strategy/TwoTrackAverager.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/process/strategy/TwoTrackAverager.scala
@@ -1,0 +1,208 @@
+package fi.liikennevirasto.viite.process.strategy
+
+import fi.liikennevirasto.viite.dao.ProjectLink
+import fi.liikennevirasto.viite.util.{SynchronizationUtils, TwoTrackRoadUtils}
+import fi.vaylavirasto.viite.model.{RoadAddressChangeType, Track}
+import fi.vaylavirasto.viite.util.ViiteException
+
+object TwoTrackAverager {
+
+	private case class TrackSection(track: Track, links: Seq[ProjectLink]) {
+		val first: ProjectLink = links.minBy(_.originalAddrMRange.start)
+		val last: ProjectLink = links.maxBy(_.originalAddrMRange.end)
+		val originalStart: Long = first.originalAddrMRange.start
+		val originalEnd: Long = last.originalAddrMRange.end
+	}
+
+	/* 
+  Averages boundaries between paired left and right road sections that are not 
+  new or renumbered, and slides the following links to match the new values. 
+	*/
+	def averageTwoTrackBoundaries(projectLinks: Seq[ProjectLink]): Seq[ProjectLink] = {
+		val averageable = projectLinks.filter(link =>
+			link.status != RoadAddressChangeType.New && link.status != RoadAddressChangeType.Renumeration && (link.track == Track.LeftSide || link.track == Track.RightSide)
+		)
+		val rightLinks = averageable.filter(_.track == Track.RightSide)
+		val leftLinks = averageable.filter(_.track == Track.LeftSide)
+
+		if (rightLinks.isEmpty || leftLinks.isEmpty) {
+			projectLinks
+		} else {
+			val rightSections = toSections(rightLinks)
+			val leftSections = toSections(leftLinks)
+
+			val sectionPairs = pairSections(rightSections, leftSections)
+			averageSectionEnds(projectLinks, sectionPairs)
+		}
+	}
+
+	// Detects when a new section should begin by checking if road part, status, or administrative attributes change.
+	// Used to group consecutive links into sections that can be independently synchronized
+	private def startsNewSection(previous: ProjectLink, current: ProjectLink): Boolean = {
+		val roadPartChanged = previous.roadPart != current.roadPart
+		val statusChanged = previous.status != current.status
+		val administrativeClassChanged = previous.administrativeClass != current.administrativeClass
+		val notContiguous = previous.addrMRange.end != current.addrMRange.start
+
+		roadPartChanged ||
+			statusChanged ||
+			administrativeClassChanged ||
+			notContiguous
+	}
+
+	// Groups links into continuous sections by road part, status, and administrative class.
+	// Each section represents a contiguous stretch of road that can be paired with its counterpart track
+  private def toSections(trackLinks: Seq[ProjectLink]): Seq[TrackSection] = {
+
+    // Nothing to process
+    if (trackLinks.isEmpty) {
+      Seq.empty
+
+    } else {
+
+      // Sort links into deterministic road order so adjacent links
+      // belonging to the same physical section appear next to each other.
+      val ordered = trackLinks.sortBy(link => (
+        link.roadPart.roadNumber,
+        link.roadPart.partNumber,
+        link.addrMRange.start,
+        link.addrMRange.end,
+        link.originalAddrMRange.start,
+        link.originalAddrMRange.end,
+        link.id
+      ))
+
+      // Completed sections collected during iteration. Vector is used for efficient appends
+      val sections = collection.mutable.ArrayBuffer.empty[Vector[ProjectLink]]
+
+      // The section currently being built. Start with the first ordered link
+      var current = Vector(ordered.head)
+
+      // Process remaining links one by one
+      for (link <- ordered.tail) {
+
+        // If this link does not belong to the current contiguous section, close the current section and start a new one
+        if (startsNewSection(current.last, link)) {
+
+          sections += current
+          current = Vector(link)
+
+        } else {
+
+          // Link belongs to the current section, so add it to the end
+          current :+= link
+        }
+      }
+
+      // Add the final in-progress section after iteration completes
+      sections += current
+
+      // Convert grouped links into domain objects
+      sections
+        .map(links => TrackSection(links.head.track, links))
+        .toSeq
+    }
+  }
+
+	/*
+  Pairs right and left sections by matching road parts and comparing original address ranges.
+	Ensures one-to-one correspondence and throws if pairing fails, as unpaired sections indicate data issues
+	*/
+  private def pairSections(
+    rightSections: Seq[TrackSection],
+    leftSections: Seq[TrackSection]
+  ): Seq[(TrackSection, TrackSection)] = {
+
+    var remainingLeft = leftSections
+
+    val pairs = rightSections.flatMap { rightSection =>
+
+      // Build section candidates: (leftSection, startDiff)
+      val candidates =
+        remainingLeft.flatMap { leftSection =>
+
+          val sameRoadPart =
+            leftSection.first.roadPart == rightSection.first.roadPart
+
+          if (!sameRoadPart) {
+            None
+          } else {
+            val startDiff =
+              Math.abs(rightSection.originalStart - leftSection.originalStart)
+
+            if (startDiff <= SynchronizationUtils.maxDiffForTracks)
+              Some((leftSection, startDiff))
+            else
+              None
+          }
+        }
+
+      if (candidates.isEmpty) {
+        None
+      } else {
+        val (matchedLeft, _) =
+          candidates.minBy(_._2)
+
+        remainingLeft =
+          remainingLeft.filterNot(_.eq(matchedLeft))
+
+        Some((rightSection, matchedLeft))
+      }
+    }
+
+    pairs
+  }
+
+	/*
+  Averages paired section boundaries and updates following links that start at the averaged position.
+	Selectively updates originalAddrMRange: for internal boundaries (where followers exist), both current and original
+	are averaged; for terminal section ends, only current is averaged to preserve transfer recalculation idempotence.
+	*/
+  private def averageSectionEnds( initialLinks: Seq[ProjectLink], sectionPairs: Seq[(TrackSection, TrackSection)]): Seq[ProjectLink] = {
+		def replaceCurrentEnd(link: ProjectLink, endAddrM: Long, updateOriginal: Boolean): ProjectLink = {
+			val updatedCurrent = fi.vaylavirasto.viite.model.AddrMRange(link.addrMRange.start, endAddrM)
+			val updatedOriginal =
+				if (updateOriginal) fi.vaylavirasto.viite.model.AddrMRange(link.originalAddrMRange.start, endAddrM)
+				else link.originalAddrMRange
+
+			link.copy(addrMRange = updatedCurrent, originalAddrMRange = updatedOriginal)
+		}
+
+		def replaceCurrentStart(link: ProjectLink, startAddrM: Long, updateOriginal: Boolean): ProjectLink = {
+			val updatedCurrent = fi.vaylavirasto.viite.model.AddrMRange(startAddrM, link.addrMRange.end)
+			val updatedOriginal =
+				if (updateOriginal) fi.vaylavirasto.viite.model.AddrMRange(startAddrM, link.originalAddrMRange.end)
+				else link.originalAddrMRange
+
+			link.copy(addrMRange = updatedCurrent, originalAddrMRange = updatedOriginal)
+		}
+
+		sectionPairs.foldLeft(initialLinks) { case (currentLinks, (rightSection, leftSection)) =>
+			val currentRightLast = currentLinks.find(_.id == rightSection.last.id).getOrElse(rightSection.last)
+			val currentLeftLast = currentLinks.find(_.id == leftSection.last.id).getOrElse(leftSection.last)
+
+			val rightFollower = SynchronizationUtils.findNextLink(currentLinks, currentRightLast, Track.LeftSide)
+			val leftFollower = SynchronizationUtils.findNextLink(currentLinks, currentLeftLast, Track.RightSide)
+
+			val averagedEnd = SynchronizationUtils.clampSharedEndAddrM(
+				TwoTrackRoadUtils.calculateAverageAddrM(currentRightLast.addrMRange.end, currentLeftLast.addrMRange.end),
+				Seq(currentRightLast, currentLeftLast),
+				Seq(rightFollower, leftFollower).flatten
+			)
+
+			val isInternalBoundary = rightFollower.isDefined || leftFollower.isDefined
+
+			val adjustedRightLast = replaceCurrentEnd(currentRightLast, averagedEnd, updateOriginal = isInternalBoundary)
+			val adjustedLeftLast = replaceCurrentEnd(currentLeftLast, averagedEnd, updateOriginal = isInternalBoundary)
+
+			val followerUpdates = Seq(rightFollower, leftFollower).flatten.map(follower =>
+				replaceCurrentStart(follower, averagedEnd, updateOriginal = true)
+			)
+
+			SynchronizationUtils.updateProjectLinksList(
+				Seq(adjustedRightLast, adjustedLeftLast) ++ followerUpdates,
+				currentLinks
+			)
+		}
+	}
+}

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/process/strategy/TwoTrackAverager.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/process/strategy/TwoTrackAverager.scala
@@ -184,20 +184,24 @@ object TwoTrackAverager {
 			val rightFollower = SynchronizationUtils.findNextLink(currentLinks, currentRightLast, Track.LeftSide)
 			val leftFollower = SynchronizationUtils.findNextLink(currentLinks, currentLeftLast, Track.RightSide)
 
+      // Slide only if the follower link is contiguous with the current last link, otherwise it indicates a section boundary
+			val slideableRightFollower = rightFollower.filter(f => currentRightLast.addrMRange.continuesTo(f.addrMRange))
+			val slideableLeftFollower = leftFollower.filter(f => currentLeftLast.addrMRange.continuesTo(f.addrMRange))
+
 			val averagedEnd = SynchronizationUtils.clampSharedEndAddrM(
 				TwoTrackRoadUtils.calculateAverageAddrM(currentRightLast.addrMRange.end, currentLeftLast.addrMRange.end),
 				Seq(currentRightLast, currentLeftLast),
-				Seq(rightFollower, leftFollower).flatten
+				Seq(slideableRightFollower, slideableLeftFollower).flatten
 			)
 
-			val isInternalBoundary = rightFollower.isDefined || leftFollower.isDefined
+			val isInternalBoundary = slideableRightFollower.isDefined || slideableLeftFollower.isDefined
 
 			val adjustedRightLast = replaceCurrentEnd(currentRightLast, averagedEnd, updateOriginal = isInternalBoundary)
 			val adjustedLeftLast = replaceCurrentEnd(currentLeftLast, averagedEnd, updateOriginal = isInternalBoundary)
 
-			val followerUpdates = Seq(rightFollower, leftFollower).flatten.map(follower =>
+			val followerUpdates = Seq(slideableRightFollower, slideableLeftFollower).flatten.map { follower =>
 				replaceCurrentStart(follower, averagedEnd, updateOriginal = true)
-			)
+			}
 
 			SynchronizationUtils.updateProjectLinksList(
 				Seq(adjustedRightLast, adjustedLeftLast) ++ followerUpdates,

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/util/SynchronizationUtils.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/util/SynchronizationUtils.scala
@@ -3,6 +3,7 @@ package fi.liikennevirasto.viite.util
 import fi.liikennevirasto.viite.dao.ProjectLink
 import fi.vaylavirasto.viite.model.{AddrMRange, Track}
 
+// TODO: Since synchronization was moved to a single file, some of the methods in this class may be better placed directly in TwoTrackAverager
 
 // Shared utilities used by termination and administrative class 2-track synchronizers
 
@@ -111,7 +112,8 @@ object SynchronizationUtils {
   }
 
   /**
-   * Finds the link that follows the given target link. Excludes links of the opposite track.
+   * Finds the link that follows the given target link.
+   * Matches only links on the same track as the target, while still excluding the opposite track.
    *
    * @param links Sequence of project links to search in
    * @param target The target project link whose following link we seek
@@ -120,5 +122,6 @@ object SynchronizationUtils {
   def findNextLink(links: Seq[ProjectLink], target: ProjectLink, trackToExclude: Track): Option[ProjectLink] = {
     links.find(pl => pl.track != trackToExclude && target.originalAddrMRange.continuesTo(pl.originalAddrMRange))
   }
+
 
 }

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/process/TwoTrackSectionSynchronizerSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/process/TwoTrackSectionSynchronizerSpec.scala
@@ -1,10 +1,9 @@
 package fi.liikennevirasto.viite.process
 
 import fi.liikennevirasto.viite.dao._
-import fi.liikennevirasto.viite.process.strategy.{TerminatedTwoTrackSectionSynchronizer, AdministrativeClassTwoTrackSynchronizer}
+import fi.liikennevirasto.viite.process.strategy.TwoTrackAverager
 import fi.vaylavirasto.viite.geometry.Point
 import fi.vaylavirasto.viite.model._
-import fi.vaylavirasto.viite.util.ViiteException
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import fi.vaylavirasto.viite.postgis.PostGISDatabaseScalikeJDBC.runWithRollback
@@ -12,8 +11,7 @@ import fi.vaylavirasto.viite.postgis.PostGISDatabaseScalikeJDBC.runWithRollback
 
 class TwoTrackSectionSynchronizerSpec extends AnyFunSuite with Matchers {
 
-  def buildTestLink(id: Long, track: Track, addr: (Long, Long), status: RoadAddressChangeType, discontinuity: Discontinuity = Discontinuity.Continuous, adminClass: AdministrativeClass = AdministrativeClass.State, originalAdminClass: AdministrativeClass = AdministrativeClass.State): ProjectLink = {
-    val roadPart = RoadPart(99999, 1)
+  def buildTestLink(id: Long, track: Track, addr: (Long, Long), status: RoadAddressChangeType, discontinuity: Discontinuity = Discontinuity.Continuous, adminClass: AdministrativeClass = AdministrativeClass.State, originalAdminClass: AdministrativeClass = AdministrativeClass.State, roadPart: RoadPart = RoadPart(99999, 1)): ProjectLink = {
     val baseLink = ProjectLink(
       id = id, roadPart = roadPart, track = track,
       discontinuity = discontinuity,
@@ -74,7 +72,7 @@ class TwoTrackSectionSynchronizerSpec extends AnyFunSuite with Matchers {
       buildTestLink(13, Track.LeftSide, (25, 40), RoadAddressChangeType.Unchanged)
     )
 
-    val result = TerminatedTwoTrackSectionSynchronizer.adjustTerminations(links)
+    val result = TwoTrackAverager.averageTwoTrackBoundaries(links)
 
     result.find(_.id == 10).get.addrMRange should be(AddrMRange(0, 20))
     result.find(_.id == 11).get.addrMRange should be(AddrMRange(0, 20))
@@ -105,7 +103,7 @@ class TwoTrackSectionSynchronizerSpec extends AnyFunSuite with Matchers {
       buildTestLink(25, Track.LeftSide, (84, 100), RoadAddressChangeType.Unchanged)
     )
 
-    val result = TerminatedTwoTrackSectionSynchronizer.adjustTerminations(links)
+    val result = TwoTrackAverager.averageTwoTrackBoundaries(links)
 
     result.find(_.id == 20).get.addrMRange should be(AddrMRange(40, 61))
     result.find(_.id == 22).get.addrMRange should be(AddrMRange(40, 61))
@@ -137,7 +135,7 @@ class TwoTrackSectionSynchronizerSpec extends AnyFunSuite with Matchers {
       buildTestLink(33, Track.LeftSide, (135, 160), RoadAddressChangeType.Termination)
     )
 
-    val result = TerminatedTwoTrackSectionSynchronizer.adjustTerminations(links)
+    val result = TwoTrackAverager.averageTwoTrackBoundaries(links)
 
     result.find(_.id == 30).get.addrMRange should be(AddrMRange(100, 140))
     result.find(_.id == 32).get.addrMRange should be(AddrMRange(100, 140))
@@ -148,32 +146,26 @@ class TwoTrackSectionSynchronizerSpec extends AnyFunSuite with Matchers {
 
   test("Case 4 - Terminations: Large gap should NOT synchronize") {
     /**
-     * Before: Large gap between terminations (> maxDiffForTracks = 20)
-     * 0     20         50
-     * ======>--------> 
+     * Before and after
+     * 50     100         150
+     * ======>--------------> 
      * ======>-------------->
-     * 0     41           60
-     *
-     * After: Should remain unchanged because gap is too large
-     * 0     20         50
-     * ======>--------> 
-     * ======>-------------->
-     * 0     41           60
+     * 80     101           150
      */
     val links = Seq(
-      buildTestLink(40, Track.RightSide, (0, 20), RoadAddressChangeType.Termination),
-      buildTestLink(41, Track.RightSide, (20, 50), RoadAddressChangeType.Unchanged),
-      buildTestLink(42, Track.LeftSide, (0, 41), RoadAddressChangeType.Termination),
-      buildTestLink(43, Track.LeftSide, (41, 60), RoadAddressChangeType.Unchanged)
+      buildTestLink(40, Track.RightSide, (50, 100), RoadAddressChangeType.Termination),
+      buildTestLink(41, Track.RightSide, (100, 150), RoadAddressChangeType.Unchanged),
+      buildTestLink(42, Track.LeftSide, (80, 101), RoadAddressChangeType.Termination),
+      buildTestLink(43, Track.LeftSide, (101, 150), RoadAddressChangeType.Unchanged)
     )
 
-    val result = TerminatedTwoTrackSectionSynchronizer.adjustTerminations(links)
+    val result = TwoTrackAverager.averageTwoTrackBoundaries(links)
 
-    // Links should remain unchanged because gap (41-20=21) > maxDiffForTracks (20)
-    result.find(_.id == 40).get.addrMRange should be(AddrMRange(0, 20))
-    result.find(_.id == 41).get.addrMRange should be(AddrMRange(20, 50))
-    result.find(_.id == 42).get.addrMRange should be(AddrMRange(0, 41))
-    result.find(_.id == 43).get.addrMRange should be(AddrMRange(41, 60))
+    // Links should remain unchanged
+    result.find(_.id == 40).get.addrMRange should be(AddrMRange(50, 100))
+    result.find(_.id == 41).get.addrMRange should be(AddrMRange(100, 150))
+    result.find(_.id == 42).get.addrMRange should be(AddrMRange(80, 101))
+    result.find(_.id == 43).get.addrMRange should be(AddrMRange(101, 150))
   }
 
   test("Case 5 - Administrative class change: No administrative class changes should not affect links") {
@@ -182,7 +174,7 @@ class TwoTrackSectionSynchronizerSpec extends AnyFunSuite with Matchers {
       buildTestLink(101, Track.LeftSide, (0, 100), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality)
     )
 
-    val result = TerminatedTwoTrackSectionSynchronizer.adjustTerminations(links)
+    val result = TwoTrackAverager.averageTwoTrackBoundaries(links)
 
     // Links should remain unchanged
     result.find(_.id == 100).get.addrMRange should be(AddrMRange(0, 100))
@@ -194,30 +186,30 @@ class TwoTrackSectionSynchronizerSpec extends AnyFunSuite with Matchers {
       * Legend: Admin Class Changed: ~~> | Unchanged: -->
       *
       * Before:
-      * 0     15      40         60
+      * 0     15      40         61
       * ~~~~~~=>~~~~~~=>---------> 
       * ~~~~~~~~=>~~~~~~=>------->
-      * 0       25      50       62
+      * 0       25      50       61
       *
       * After:
-      * 0     15      45         60
+      * 0     15      45         61
       * ~~~~~~=>~~~~~~=>---------> 
       * ~~~~~~~~=>~~~~~~=>------->
-      * 0       25      45       62
+      * 0       25      45       61
       */
 
     runWithRollback {
-         // Test that originalAddrMRange is also updated to reflect the synchronized state, ensuring that subsequent synchronizations have correct reference values
+    // Test that originalAddrMRange is also updated to reflect the synchronized state, ensuring that subsequent synchronizations have correct reference values
     val links = Seq(
       buildTestLink(60, Track.RightSide, (0, 15), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
       buildTestLink(61, Track.RightSide, (15, 40), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
       buildTestLink(62, Track.LeftSide, (0, 25), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
       buildTestLink(63, Track.LeftSide, (25, 50), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
-      buildTestLink(64, Track.RightSide, (40, 60), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
-      buildTestLink(65, Track.LeftSide, (50, 62), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality)
+      buildTestLink(64, Track.RightSide, (40, 61), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
+      buildTestLink(65, Track.LeftSide, (50, 61), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality)
     )
 
-    val result = AdministrativeClassTwoTrackSynchronizer.adjustAdministrativeClassChanges(links)
+    val result = TwoTrackAverager.averageTwoTrackBoundaries(links)
 
     result.find(_.id == 60).get.addrMRange should be(AddrMRange(0, 15))
     result.find(_.id == 60).get.originalAddrMRange should be(AddrMRange(0, 15))
@@ -229,24 +221,25 @@ class TwoTrackSectionSynchronizerSpec extends AnyFunSuite with Matchers {
     result.find(_.id == 63).get.addrMRange should be(AddrMRange(25, 45))
     result.find(_.id == 63).get.originalAddrMRange should be(AddrMRange(25, 45))
 
-    result.find(_.id == 64).get.addrMRange should be(AddrMRange(45, 60))
-    result.find(_.id == 64).get.originalAddrMRange should be(AddrMRange(45, 60))
-    result.find(_.id == 65).get.addrMRange should be(AddrMRange(45, 62))
-    result.find(_.id == 65).get.originalAddrMRange should be(AddrMRange(45, 62))
-  } }
+    result.find(_.id == 64).get.addrMRange should be(AddrMRange(45, 61))
+    result.find(_.id == 64).get.originalAddrMRange should be(AddrMRange(45, 61))
+    result.find(_.id == 65).get.addrMRange should be(AddrMRange(45, 61))
+    result.find(_.id == 65).get.originalAddrMRange should be(AddrMRange(45, 61))
+    }
+  }
 
   test("Case 7 - Administrative Class Change: Synchronize multiple middle sections with minor discontinuity") {
     /**
       * Before:
-      * 38   60      80                     80   90   100   120
+      * 38   60      80                     80   90   100   123
       * ----->~~~~~~~> (minor discontinuity) ---->~~~~~>----->
-      * 36   56      76                     76   88   104   126
+      * 36   56      76                     76   88   104   123
       * ----->~~~~~~~> (minor discontinuity) ---->~~~~~>----->
       *
       * After:
-      * 38   58      78                     78   89   102   120
+      * 38   58      78                     78   89   102   123
       * ----->~~~~~~~> (minor discontinuity) ---->~~~~~>----->
-      * 36   58      78                    78    89   102   126
+      * 36   58      78                    78    89   102   123
       * ----->~~~~~~~> (minor discontinuity) ---->~~~~~>----->
       *
       * Section 1 averages: start (60+56)/2 = 58, end (80+76)/2 = 78
@@ -257,16 +250,16 @@ class TwoTrackSectionSynchronizerSpec extends AnyFunSuite with Matchers {
       buildTestLink(71, Track.RightSide, (60, 80), RoadAddressChangeType.Unchanged, Discontinuity.MinorDiscontinuity, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
       buildTestLink(72, Track.RightSide, (80, 90), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
       buildTestLink(73, Track.RightSide, (90, 100), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
-      buildTestLink(78, Track.RightSide, (100, 120), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
+      buildTestLink(78, Track.RightSide, (100, 123), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
 
       buildTestLink(74, Track.LeftSide, (36, 56), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
       buildTestLink(75, Track.LeftSide, (56, 76), RoadAddressChangeType.Unchanged, Discontinuity.MinorDiscontinuity, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
       buildTestLink(76, Track.LeftSide, (76, 88), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
       buildTestLink(77, Track.LeftSide, (88, 104), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
-      buildTestLink(79, Track.LeftSide, (104, 126), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality)
+      buildTestLink(79, Track.LeftSide, (104, 123), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality)
     )
 
-    val result = AdministrativeClassTwoTrackSynchronizer.adjustAdministrativeClassChanges(links)
+    val result = TwoTrackAverager.averageTwoTrackBoundaries(links)
 
     // Preceding links for section 1: only ends are snapped, starts are preserved
     result.find(_.id == 70).get.addrMRange should be(AddrMRange(38, 58))
@@ -293,10 +286,10 @@ class TwoTrackSectionSynchronizerSpec extends AnyFunSuite with Matchers {
     result.find(_.id == 77).get.originalAddrMRange should be(AddrMRange(89, 102))
 
     // Following links of section 2: starts snapped to 102
-    result.find(_.id == 78).get.addrMRange should be(AddrMRange(102, 120))
-    result.find(_.id == 78).get.originalAddrMRange should be(AddrMRange(102, 120))
-    result.find(_.id == 79).get.addrMRange should be(AddrMRange(102, 126))
-    result.find(_.id == 79).get.originalAddrMRange should be(AddrMRange(102, 126))
+    result.find(_.id == 78).get.addrMRange should be(AddrMRange(102, 123))
+    result.find(_.id == 78).get.originalAddrMRange should be(AddrMRange(102, 123))
+    result.find(_.id == 79).get.addrMRange should be(AddrMRange(102, 123))
+    result.find(_.id == 79).get.originalAddrMRange should be(AddrMRange(102, 123))
   }
 
   test("Case 8 - Administrative Class Change: Synchronize road part end with 1 link on track 1 and 2 links on track 2") {
@@ -315,8 +308,6 @@ class TwoTrackSectionSynchronizerSpec extends AnyFunSuite with Matchers {
      */
 
     runWithRollback {
-
-
       val links = Seq(
         buildTestLink(80, Track.RightSide, (100, 145), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
         buildTestLink(81, Track.RightSide, (145, 160), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
@@ -324,7 +315,7 @@ class TwoTrackSectionSynchronizerSpec extends AnyFunSuite with Matchers {
         buildTestLink(83, Track.LeftSide, (135, 160), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality)
       )
 
-      val result = AdministrativeClassTwoTrackSynchronizer.adjustAdministrativeClassChanges(links)
+      val result = TwoTrackAverager.averageTwoTrackBoundaries(links)
 
       result.find(_.id == 80).get.addrMRange should be(AddrMRange(100, 140))
       result.find(_.id == 80).get.originalAddrMRange should be(AddrMRange(100, 140))
@@ -365,7 +356,7 @@ class TwoTrackSectionSynchronizerSpec extends AnyFunSuite with Matchers {
       buildTestLink(96, Track.LeftSide, (160, 180), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality)
     )
 
-    val result = AdministrativeClassTwoTrackSynchronizer.adjustAdministrativeClassChanges(links)
+    val result = TwoTrackAverager.averageTwoTrackBoundaries(links)
 
     // Preceding links: end snapped to averaged start boundary (52)
     result.find(_.id == 90).get.addrMRange should be(AddrMRange(0, 52))
@@ -412,7 +403,7 @@ class TwoTrackSectionSynchronizerSpec extends AnyFunSuite with Matchers {
       buildTestLink(115, Track.LeftSide, (84, 100), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality)
     )
 
-    val result = AdministrativeClassTwoTrackSynchronizer.adjustAdministrativeClassChanges(links)
+    val result = TwoTrackAverager.averageTwoTrackBoundaries(links)
 
     result.find(_.id == 110).get.addrMRange should be(AddrMRange(40, 61))
     result.find(_.id == 110).get.originalAddrMRange should be(AddrMRange(40, 61))
@@ -430,75 +421,40 @@ class TwoTrackSectionSynchronizerSpec extends AnyFunSuite with Matchers {
     result.find(_.id == 115).get.originalAddrMRange should be(AddrMRange(82, 100))
   }
 
-  test("Case 11 - Administrative Class Change: Following link of 2m still synchronizes safely") {
+  test("Case 11 - Administrative Class Change: Asymmetric section pairing should rely on close start boundary") {
     /**
-      * Before:
-      * 0   50               100 102 130
-      * ---->~~~~~~~~~~~~~~~~>--->---->
-      * 0    54                 104 106 130
-      * ----->~~~~~~~~~~~~~~~~~~>--->---->
+      * Right track changed section: one link, length 120 (4155 -> 4275)
+      * Left track changed section: three links, lengths 30/50/40 (4161 -> 4191 -> 4241 -> 4281)
       *
-      * Raw averages: start (50+54)/2 = 52, end (100+104)/2 = 102
-      * Because the right-side following link is only 2m (100-102), safe end clamps to 101.
-      *
-      * After:
-      * 0  52               101 102 130
-      * --->~~~~~~~~~~~~~~~~>--->---->
-      * 0  52               101   106 130
-      * --->~~~~~~~~~~~~~~~~>----->---->
+      * Start boundary delta is 6m, while absolute end values are large.
+      * Pairing must succeed based on where averaging starts, and then slide adjacent links.
       */
     val links = Seq(
-      buildTestLink(120, Track.RightSide, (0, 50), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
-      buildTestLink(121, Track.RightSide, (50, 100), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
-      buildTestLink(122, Track.RightSide, (100, 102), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
-      buildTestLink(123, Track.RightSide, (102, 130), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
+      buildTestLink(120, Track.RightSide, (4000, 4155), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
+      buildTestLink(121, Track.RightSide, (4155, 4275), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
+      buildTestLink(122, Track.RightSide, (4275, 4400), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
 
-      buildTestLink(124, Track.LeftSide, (0, 54), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
-      buildTestLink(125, Track.LeftSide, (54, 104), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
-      buildTestLink(126, Track.LeftSide, (104, 106), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
-      buildTestLink(127, Track.LeftSide, (106, 130), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality)
+      buildTestLink(123, Track.LeftSide, (4000, 4161), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
+      buildTestLink(124, Track.LeftSide, (4161, 4191), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
+      buildTestLink(125, Track.LeftSide, (4191, 4241), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
+      buildTestLink(126, Track.LeftSide, (4241, 4281), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
+      buildTestLink(127, Track.LeftSide, (4281, 4400), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality)
     )
 
-    val result = AdministrativeClassTwoTrackSynchronizer.adjustAdministrativeClassChanges(links)
+    val result = TwoTrackAverager.averageTwoTrackBoundaries(links)
 
-    // Start boundary average applies normally
-    result.find(_.id == 120).get.addrMRange should be(AddrMRange(0, 52))
-    result.find(_.id == 120).get.originalAddrMRange should be(AddrMRange(0, 52))
-    result.find(_.id == 124).get.addrMRange should be(AddrMRange(0, 52))
-    result.find(_.id == 124).get.originalAddrMRange should be(AddrMRange(0, 52))
+    // Start boundary average: (4155 + 4161) / 2 => 4158
+    result.find(_.id == 120).get.addrMRange should be(AddrMRange(4000, 4158))
+    result.find(_.id == 123).get.addrMRange should be(AddrMRange(4000, 4158))
 
-    // End boundary is clamped to 101 to keep the 2m following link valid
-    result.find(_.id == 121).get.addrMRange should be(AddrMRange(52, 101))
-    result.find(_.id == 121).get.originalAddrMRange should be(AddrMRange(52, 101))
-    result.find(_.id == 125).get.addrMRange should be(AddrMRange(52, 101))
-    result.find(_.id == 125).get.originalAddrMRange should be(AddrMRange(52, 101))
+    // End boundary average: (4275 + 4281) / 2 => 4278
+    result.find(_.id == 121).get.addrMRange should be(AddrMRange(4158, 4278))
+    result.find(_.id == 124).get.addrMRange should be(AddrMRange(4158, 4191))
+    result.find(_.id == 125).get.addrMRange should be(AddrMRange(4191, 4241))
+    result.find(_.id == 126).get.addrMRange should be(AddrMRange(4241, 4278))
 
-    // Following links start at the clamped boundary
-    result.find(_.id == 122).get.addrMRange should be(AddrMRange(101, 102))
-    result.find(_.id == 122).get.originalAddrMRange should be(AddrMRange(101, 102))
-    result.find(_.id == 126).get.addrMRange should be(AddrMRange(101, 106))
-    result.find(_.id == 126).get.originalAddrMRange should be(AddrMRange(101, 106))
-
-    // Tail links after the tiny following links remain unchanged
-    result.find(_.id == 123).get.addrMRange should be(AddrMRange(102, 130))
-    result.find(_.id == 123).get.originalAddrMRange should be(AddrMRange(102, 130))
-    result.find(_.id == 127).get.addrMRange should be(AddrMRange(106, 130))
-    result.find(_.id == 127).get.originalAddrMRange should be(AddrMRange(106, 130))
-  }
-
-  test("Case 12 - Administrative Class Change: Middle section with too large difference throws") {
-    val links = Seq(
-      buildTestLink(130, Track.RightSide, (0, 20), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
-      buildTestLink(131, Track.RightSide, (20, 40), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
-      buildTestLink(132, Track.RightSide, (40, 60), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
-
-      buildTestLink(133, Track.LeftSide, (0, 41), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality),
-      buildTestLink(134, Track.LeftSide, (41, 61), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.State, originalAdminClass = AdministrativeClass.Municipality),
-      buildTestLink(135, Track.LeftSide, (61, 80), RoadAddressChangeType.Unchanged, adminClass = AdministrativeClass.Municipality, originalAdminClass = AdministrativeClass.Municipality)
-    )
-
-    intercept[ViiteException] {
-      AdministrativeClassTwoTrackSynchronizer.adjustAdministrativeClassChanges(links)
-    }
+    // Following links snapped to averaged end
+    result.find(_.id == 122).get.addrMRange should be(AddrMRange(4278, 4400))
+    result.find(_.id == 127).get.addrMRange should be(AddrMRange(4278, 4400))
   }
 }


### PR DESCRIPTION
Muutettu keskiarvoistus logiikkaa, jotta kaikki epäsymmetriset 2-ajorataiset osuuksien tapaukset täsmäytetään samalla tavalla (pois lukien uusi ja numerointi toimenpiteet).

Uusi systeemi perustuu yhtenäisten osioiden (section) tunnistamiseen, ja niiden häntien keskiarvoistukseen. Osio vaihtuu, mikäli tieosa, muutostyyppi tai hallinollinen luokka vaihtuvat linkkien välillä. Jos linkkien M-arvot eivät ole jatkuvia, myös tällöin osio vaihtuu. Kun osiot on löydetty molemmilta ajoradoiolta, niiden parien viimeiset linkit keskiarvoistetaan, ja seuraavat linkit liutetaan samalle kohdalle, jotta aukkoja ei synny.

Testit ajettu läpi onnistuneesti, ja QA:n testiprojektit menevät läpi.