### PR TITLE
Handle missing municipality by defaulting to EVK1

### DIFF
--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilder.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilder.scala
@@ -134,7 +134,7 @@ class RoadAddressLinkBuilder(roadwayDAO: RoadwayDAO, linearLocationDAO: LinearLo
       Some("kgv_modified"),
       RoadPart(0, 0),
       Track.Unknown.value,
-      ArealRoadMaintainer.apply(municipalityToViiteEVKMapping.getOrElse(roadLink.municipalityCode, "EVK11")), // TODO: THIS IS ONE POSSIBLE WHERE THE EVK0 BUG MIGHT ORIGINATE FROM
+      ArealRoadMaintainer.apply(municipalityToViiteEVKMapping.getOrElse(roadLink.municipalityCode, "EVK1")),
       Discontinuity.Continuous.value,
       AddrMRange(0, 0),
       "",


### PR DESCRIPTION
KGV datasta puuttui linkeiltä kuntakoodi, jonka takia linkeille asetettiin oletusarvoksi EVK11, joka päätyi "tuntematon ylläpitäjätaho" virheeseen. Tästä seurasi bugi, missä linkit eivät piirtyneet kartalle.