### PR TITLE
Viite 3576 fix geometryutils

### DIFF
--- a/viite-backend/base/src/main/scala/fi/vaylavirasto/viite/geometry/GeometryUtils.scala
+++ b/viite-backend/base/src/main/scala/fi/vaylavirasto/viite/geometry/GeometryUtils.scala
@@ -36,7 +36,6 @@ object GeometryUtils {
       val interval = (accumulatedLength, firstPoint.distance2DTo(secondPoint) + accumulatedLength)
       liesInBetween(measure, interval)
     }
-
     def newPointOnSegment(measureOnSegment: Double, segment: (Point, Point)): Point = {
       val (firstPoint, secondPoint) = segment
       val directionVector = (secondPoint - firstPoint).normalize2D().scale(measureOnSegment)
@@ -47,23 +46,28 @@ object GeometryUtils {
     if (geometry.length == 1) throw new IllegalArgumentException
     if (geometry.isEmpty) return Nil
 
-    val accuStart = (Seq.empty[Point], false, geometry.head, 0.0)
-    geometry.tail.foldLeft(accuStart)((accu, point) => {
-      val (truncatedGeometry, onSelection, previousPoint, accumulatedLength) = accu
+    val pointsWithM = geometry.zip(computeMValues(geometry, startMeasure, endMeasure))
+    val accuStart = (Seq.empty[Point], false, pointsWithM.head)
 
+    pointsWithM.tail.foldLeft(accuStart) { case ((truncatedGeometry, onSelection, (previousPoint, prevM)), (point, pointM)) =>
+      val accumulatedLength = prevM
       val (pointsToAdd, enteredSelection) = (measureOnSegment(startMeasure, (previousPoint, point), accumulatedLength), measureOnSegment(endMeasure, (previousPoint, point), accumulatedLength), onSelection) match {
-        case (false, false, true) => (List(point), true)
+        case (false, false, true)  => (List(point), true)
         case (false, false, false) => (Nil, false)
-        case (true, false, _) => (List(newPointOnSegment(startMeasure - accumulatedLength, (previousPoint, point)), point), true)
-        case (false, true, _) => (List(newPointOnSegment(endMeasure - accumulatedLength, (previousPoint, point))), false)
-        case (true, true, _)  => (List(newPointOnSegment(startMeasure - accumulatedLength, (previousPoint, point)),
-                                       newPointOnSegment(endMeasure - accumulatedLength, (previousPoint, point))), false)
+        case (true,  false, _)     => (List(newPointOnSegment(startMeasure - accumulatedLength, (previousPoint, point)), point), true)
+        case (false, true,  _)     => (List(newPointOnSegment(endMeasure   - accumulatedLength, (previousPoint, point))), false)
+        case (true,  true,  _)     => (List(newPointOnSegment(startMeasure - accumulatedLength, (previousPoint, point)),
+          newPointOnSegment(endMeasure - accumulatedLength, (previousPoint, point))), false)
       }
-
-      (truncatedGeometry ++ pointsToAdd, enteredSelection, point, point.distance2DTo(previousPoint) + accumulatedLength)
-    })._1
+      (truncatedGeometry ++ pointsToAdd, enteredSelection, (point, pointM))
+    }._1
   }
-
+  private def computeMValues(geometry: Seq[Point], startMeasure: Double, endMeasure: Double): Seq[Double] = {
+    val totalLength = geometry.zip(geometry.tail).map { case (a, b) => a.distance2DTo(b) }.sum
+    geometry.zip(geometry.tail).scanLeft(startMeasure) { case (acc, (a, b)) =>
+      acc + (a.distance2DTo(b) / totalLength) * (endMeasure - startMeasure)
+    }
+  }
   def subtractIntervalFromIntervals(intervals: Seq[(Double, Double)], interval: (Double, Double)): Seq[(Double, Double)] = {
     val (spanStart, spanEnd) = (math.min(interval._1, interval._2), math.max(interval._1, interval._2))
     intervals.flatMap {

--- a/viite-backend/base/src/main/scala/fi/vaylavirasto/viite/geometry/GeometryUtils.scala
+++ b/viite-backend/base/src/main/scala/fi/vaylavirasto/viite/geometry/GeometryUtils.scala
@@ -36,6 +36,7 @@ object GeometryUtils {
       val interval = (accumulatedLength, firstPoint.distance2DTo(secondPoint) + accumulatedLength)
       liesInBetween(measure, interval)
     }
+
     def newPointOnSegment(measureOnSegment: Double, segment: (Point, Point)): Point = {
       val (firstPoint, secondPoint) = segment
       val directionVector = (secondPoint - firstPoint).normalize2D().scale(measureOnSegment)
@@ -46,28 +47,53 @@ object GeometryUtils {
     if (geometry.length == 1) throw new IllegalArgumentException
     if (geometry.isEmpty) return Nil
 
-    val pointsWithM = geometry.zip(computeMValues(geometry, startMeasure, endMeasure))
-    val accuStart = (Seq.empty[Point], false, pointsWithM.head)
+    val accuStart = (Seq.empty[Point], false, geometry.head, 0.0)
+    geometry.tail.foldLeft(accuStart)((accu, point) => {
+      val (truncatedGeometry, onSelection, previousPoint, accumulatedLength) = accu
 
-    pointsWithM.tail.foldLeft(accuStart) { case ((truncatedGeometry, onSelection, (previousPoint, prevM)), (point, pointM)) =>
-      val accumulatedLength = prevM
       val (pointsToAdd, enteredSelection) = (measureOnSegment(startMeasure, (previousPoint, point), accumulatedLength), measureOnSegment(endMeasure, (previousPoint, point), accumulatedLength), onSelection) match {
         case (false, false, true)  => (List(point), true)
         case (false, false, false) => (Nil, false)
         case (true,  false, _)     => (List(newPointOnSegment(startMeasure - accumulatedLength, (previousPoint, point)), point), true)
         case (false, true,  _)     => (List(newPointOnSegment(endMeasure   - accumulatedLength, (previousPoint, point))), false)
         case (true,  true,  _)     => (List(newPointOnSegment(startMeasure - accumulatedLength, (previousPoint, point)),
-          newPointOnSegment(endMeasure - accumulatedLength, (previousPoint, point))), false)
+                                           newPointOnSegment(endMeasure   - accumulatedLength, (previousPoint, point))), false)
       }
-      (truncatedGeometry ++ pointsToAdd, enteredSelection, (point, pointM))
-    }._1
+
+      (truncatedGeometry ++ pointsToAdd, enteredSelection, point, point.distance2DTo(previousPoint) + accumulatedLength)
+    })._1
   }
-  private def computeMValues(geometry: Seq[Point], startMeasure: Double, endMeasure: Double): Seq[Double] = {
-    val totalLength = geometry.zip(geometry.tail).map { case (a, b) => a.distance2DTo(b) }.sum
-    geometry.zip(geometry.tail).scanLeft(startMeasure) { case (acc, (a, b)) =>
-      acc + (a.distance2DTo(b) / totalLength) * (endMeasure - startMeasure)
-    }
+
+  /**
+   * Scales a road address M-value to the equivalent Euclidean position along a geometry.
+   *
+   * Road links from KGV carry an official horizontal length (<i>linkMLength</i>) that is used
+   * as the M-value range for road addressing.  For most links this value equals the 2D Euclidean
+   * length of the geometry coordinates, but for some links ("correct m-value" links) the two
+   * differ.  Passing an unscaled M-value to [[truncateGeometry3D]] in such cases causes the
+   * geometry to be cut too short.
+   *
+   * Use this function to convert M-values to Euclidean positions before calling
+   * [[truncateGeometry3D]]:
+   * {{{
+   *   val geomLen = GeometryUtils.geometryLength(roadLink.geometry)
+   *   GeometryUtils.truncateGeometry3D(
+   *     roadLink.geometry,
+   *     GeometryUtils.scaleMToGeometry(startMValue, roadLink.length, geomLen),
+   *     GeometryUtils.scaleMToGeometry(endMValue,   roadLink.length, geomLen))
+   * }}}
+   *
+   * @param mValue      The road address M-value to convert.
+   * @param linkMLength The link's official M-length (i.e. [[RoadLink.length]], from KGV
+   *                    <i>horizontallength</i>).
+   * @param geomLength  The geometry's 2D Euclidean length.
+   * @return The Euclidean position along the geometry that corresponds to <i>mValue</i>.
+   */
+  def scaleMToGeometry(mValue: Double, linkMLength: Double, geomLength: Double): Double = {
+    if (linkMLength == 0.0) mValue
+    else mValue / linkMLength * geomLength
   }
+
   def subtractIntervalFromIntervals(intervals: Seq[(Double, Double)], interval: (Double, Double)): Seq[(Double, Double)] = {
     val (spanStart, spanEnd) = (math.min(interval._1, interval._2), math.max(interval._1, interval._2))
     intervals.flatMap {

--- a/viite-backend/base/src/test/scala/fi/vaylavirasto/viite/geometry/GeometryUtilsSpec.scala
+++ b/viite-backend/base/src/test/scala/fi/vaylavirasto/viite/geometry/GeometryUtilsSpec.scala
@@ -250,6 +250,55 @@ class GeometryUtilsSpec extends AnyFunSuite with Matchers {
     GeometryUtils.geometryMoved(1.0)(geometry1, geometry2) should be (true)
   }
 
+  test("Test scaleMToGeometry When link M-length equals geometry length Then return mValue unchanged") {
+    GeometryUtils.scaleMToGeometry(0.0,   600.0, 600.0) should be (0.0)
+    GeometryUtils.scaleMToGeometry(300.0, 600.0, 600.0) should be (300.0)
+    GeometryUtils.scaleMToGeometry(600.0, 600.0, 600.0) should be (600.0)
+  }
+
+  test("Test scaleMToGeometry When link M-length differs from geometry length (correct M-value link) Then scale proportionally") {
+    val linkMLength  = 583.992
+    val geomLength   = 596.9
+    GeometryUtils.scaleMToGeometry(0.0,       linkMLength, geomLength) should be (0.0)
+    GeometryUtils.scaleMToGeometry(linkMLength, linkMLength, geomLength) should be (geomLength +- 0.001)
+    GeometryUtils.scaleMToGeometry(linkMLength / 2, linkMLength, geomLength) should be (geomLength / 2 +- 0.001)
+  }
+
+  test("Test scaleMToGeometry When linkMLength is zero Then return mValue unchanged to avoid division by zero") {
+    GeometryUtils.scaleMToGeometry(100.0, 0.0, 500.0) should be (100.0)
+  }
+
+  test("Test truncateGeometry3D with scaleMToGeometry When geometry length differs from M-value range Then full-range truncation returns the full geometry") {
+    val p1 = Point(0.0, 0.0)
+    val p2 = Point(596.9, 0.0)
+    val geometry  = Seq(p1, p2)
+    val linkMLength = 583.992
+    val geomLength  = GeometryUtils.geometryLength(geometry)
+
+    val result = GeometryUtils.truncateGeometry3D(geometry,
+      GeometryUtils.scaleMToGeometry(0.0,       linkMLength, geomLength),
+      GeometryUtils.scaleMToGeometry(linkMLength, linkMLength, geomLength))
+
+    result should be (geometry)
+  }
+
+  test("Test truncateGeometry3D with scaleMToGeometry When geometry length differs from M-value range Then partial truncation is proportional") {
+    val p1 = Point(0.0, 0.0)
+    val p2 = Point(596.9, 0.0)
+    val geometry    = Seq(p1, p2)
+    val linkMLength = 583.992
+    val geomLength  = GeometryUtils.geometryLength(geometry)
+
+    val halfM  = linkMLength / 2
+    val result = GeometryUtils.truncateGeometry3D(geometry,
+      GeometryUtils.scaleMToGeometry(0.0,  linkMLength, geomLength),
+      GeometryUtils.scaleMToGeometry(halfM, linkMLength, geomLength))
+
+    result should have size 2
+    result.head.x should be (0.0 +- 0.001)
+    result.last.x should be (geomLength / 2 +- 0.001)
+  }
+
   test("Test getProjectedValue When erroneous inputs, Then throw ViiteException."){
     // negative start values are not acceptable
     assertThrows[ViiteException] { GeometryUtils.getProjectedValue( -1.0, 100,   0.0, 110,  50) }

--- a/viite-backend/database/src/main/scala/fi/liikennevirasto/digiroad2/client/vkm/VKMClient.scala
+++ b/viite-backend/database/src/main/scala/fi/liikennevirasto/digiroad2/client/vkm/VKMClient.scala
@@ -273,7 +273,7 @@ class VKMClient(endPoint: String, apiKey: String) {
       val previousDateStr = finnishDateFormatter.print(previousDate)
       val newDateStr = finnishDateFormatter.print(newDate)
 
-      Stream
+      val allChanges = Stream
         .from(1)
         .map { page =>
           val params =
@@ -306,6 +306,16 @@ class VKMClient(endPoint: String, apiKey: String) {
         }
         .flatMap(_.toSeq.flatten)
         .toSeq
+
+      // Tiekamu can return the exact same change row more than once (e.g. the same row repeated across
+      // paginated responses). Identical duplicates inflate the per-old-link length sum in Viite's change
+      // validation, producing false "No partial changes allowed" errors that drop the whole road part,
+      // and would create duplicate ReplaceInfos downstream. Drop exact duplicates at the source.
+      val distinctChanges = allChanges.distinct
+      val duplicateCount = allChanges.length - distinctChanges.length
+      if (duplicateCount > 0)
+        logger.info(s"Removed $duplicateCount duplicate TiekamuRoadLinkChange row(s); ${distinctChanges.length} remain.")
+      distinctChanges
     }
   }
 }

--- a/viite-backend/database/src/main/scala/fi/liikennevirasto/digiroad2/client/vkm/VKMClient.scala
+++ b/viite-backend/database/src/main/scala/fi/liikennevirasto/digiroad2/client/vkm/VKMClient.scala
@@ -230,20 +230,27 @@ class VKMClient(endPoint: String, apiKey: String) {
       val parsedJson = parse(responseString)
       val features = (parsedJson \ "features").asInstanceOf[JArray].arr
 
-      features.map { feature =>
+      features.flatMap { feature =>
         val properties = feature \ "properties"
-        val newStartM = (properties \ "m_arvo_alku_kohdepvm").extract[Double]
-        val newEndM = (properties \ "m_arvo_loppu_kohdepvm").extract[Double]
+        val oldLinkId = (properties \ "link_id").extractOpt[String].orNull
+        val newLinkId = (properties \ "link_id_kohdepvm").extractOpt[String].orNull
 
-        TiekamuRoadLinkChange(
-          (properties \ "link_id").extract[String],
-          (properties \ "m_arvo_alku").extract[Double],
-          (properties \ "m_arvo_loppu").extract[Double],
-          (properties \ "link_id_kohdepvm").extract[String],
-          if (newStartM > newEndM) newEndM else newStartM,
-          if (newEndM < newStartM) newStartM else newEndM,
-          getDigitizationChangeValue(newStartM, newEndM)
-        )
+        if (oldLinkId == null || newLinkId == null) {
+          logger.warn(s"Skipping TiekamuRoadLinkChange with null link ID(s): oldLinkId=$oldLinkId, newLinkId=$newLinkId")
+          None
+        } else {
+          val newStartM = (properties \ "m_arvo_alku_kohdepvm").extract[Double]
+          val newEndM = (properties \ "m_arvo_loppu_kohdepvm").extract[Double]
+          Some(TiekamuRoadLinkChange(
+            oldLinkId,
+            (properties \ "m_arvo_alku").extract[Double],
+            (properties \ "m_arvo_loppu").extract[Double],
+            newLinkId,
+            if (newStartM > newEndM) newEndM else newStartM,
+            if (newEndM < newStartM) newStartM else newEndM,
+            getDigitizationChangeValue(newStartM, newEndM)
+          ))
+        }
       }
     }
 

--- a/viite-backend/database/src/main/scala/fi/liikennevirasto/digiroad2/util/ViiteProperties.scala
+++ b/viite-backend/database/src/main/scala/fi/liikennevirasto/digiroad2/util/ViiteProperties.scala
@@ -34,6 +34,8 @@ trait ViiteProperties {
   val dynamicLinkNetworkS3BucketName: String
   val awsConnectionEnabled: Boolean
   val apiS3ObjectTTLSeconds: String
+  // LOCAL DEBUG: when set, dynamic-network "S3" files are written to this local directory instead of the real S3 bucket.
+  val localS3DebugDir: String
 
 
   def getAuthenticationBasicUsername(baseAuth: String = ""): String
@@ -79,6 +81,7 @@ class ViitePropertiesFromEnv extends ViiteProperties {
   val dynamicLinkNetworkS3BucketName: String = scala.util.Properties.envOrElse("dynamicLinkNetworkS3BucketName", null)
   val awsConnectionEnabled: Boolean = scala.util.Properties.envOrElse("awsConnectionEnabled", "true").toBoolean
   val apiS3ObjectTTLSeconds: String = scala.util.Properties.envOrElse("apiS3ObjectTTLSeconds", null)
+  val localS3DebugDir: String = scala.util.Properties.envOrElse("localS3DebugDir", null)
 
   def getAuthenticationBasicUsername(baseAuth: String = ""): String = {
     scala.util.Properties.envOrElse("authentication." + baseAuth + (if (baseAuth.isEmpty) "" else ".") + "basic.username", null)
@@ -135,6 +138,7 @@ class ViitePropertiesFromFile extends ViiteProperties {
   override val dynamicLinkNetworkS3BucketName: String = scala.util.Properties.envOrElse("dynamicLinkNetworkS3BucketName", envProps.getProperty("dynamicLinkNetworkS3BucketName"))
   override val awsConnectionEnabled: Boolean = envProps.getProperty("awsConnectionEnabled", "true").toBoolean
   override val apiS3ObjectTTLSeconds: String = scala.util.Properties.envOrElse("apiS3ObjectTTLSeconds", envProps.getProperty("apiS3ObjectTTLSeconds"))
+  override val localS3DebugDir: String = scala.util.Properties.envOrElse("localS3DebugDir", envProps.getProperty("localS3DebugDir"))
 
   override def getAuthenticationBasicUsername(baseAuth: String = ""): String = {
     envProps.getProperty("authentication." + baseAuth + (if (baseAuth.isEmpty) "" else ".") + "basic.username")
@@ -189,6 +193,7 @@ object ViiteProperties {
   lazy val dynamicLinkNetworkS3BucketName: String = properties.dynamicLinkNetworkS3BucketName
   lazy val awsConnectionEnabled: Boolean = properties.awsConnectionEnabled
   lazy val apiS3ObjectTTLSeconds: String = properties.apiS3ObjectTTLSeconds
+  lazy val localS3DebugDir: String = properties.localS3DebugDir
 
   def getAuthenticationBasicUsername(baseAuth: String = ""): String = properties.getAuthenticationBasicUsername(baseAuth)
   def getAuthenticationBasicPassword(baseAuth: String = ""): String = properties.getAuthenticationBasicPassword(baseAuth)

--- a/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/dao/ComplementaryLinkDAO.scala
+++ b/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/dao/ComplementaryLinkDAO.scala
@@ -74,11 +74,14 @@ class ComplementaryLinkDAO extends BaseDAO {
       )).map(_.toString())
 
       // Handle geometry
-      val geomString = rs.string("geometry")
-      val geom = GeometryBuilder.geomFromString(geomString)
-      val geometry = (0 until geom.numPoints()).map { i =>
-        val point = geom.getPoint(i)
-        Point(point.x, point.y, point.z)
+      val geometry = rs.stringOpt("geometry") match {
+        case Some(geomString) =>
+          val geom = GeometryBuilder.geomFromString(geomString)
+          (0 until geom.numPoints()).map { i =>
+            val point = geom.getPoint(i)
+            Point(point.x, point.y, point.z)
+          }
+        case None => Seq.empty[Point]
       }
 
       new RoadLink(

--- a/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/dao/queries.scala
+++ b/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/dao/queries.scala
@@ -20,7 +20,7 @@ object Queries {
 
   def nextRoadNetworkErrorId = sql"SELECT nextval('road_network_error_seq')"
 
-  def nextRoadwayChangeLink = sql"SELECT nextval('roadway_change_link')"
+  def nextRoadwayChangeLink = sql"SELECT nextval('roadway_changes_link_seq')"
 
   @deprecated ("Table published_road_network is no longer in use, and is empty.")
   def nextPublishedRoadNetworkId = sql"SELECT nextval('published_road_network_seq')"

--- a/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/postgis/MassQuery.scala
+++ b/viite-backend/database/src/main/scala/fi/vaylavirasto/viite/postgis/MassQuery.scala
@@ -45,7 +45,11 @@ object MassQuery extends BaseDAO {
   }
 
   def withIds[T](ids: StringList)(function: SQLSyntax => T): T = {
-    LogUtils.time(logger, s"TEST LOG MassQuery withIds ${ids.list.size}") {
+    val nonNullIds = ids.list.filter(_ != null)
+    if (nonNullIds.size != ids.list.size)
+      logger.warn(s"MassQuery.withIds(StringList): filtered out ${ids.list.size - nonNullIds.size} null ID(s)")
+
+    LogUtils.time(logger, s"TEST LOG MassQuery withIds ${nonNullIds.size}") {
       LogUtils.time(logger, "TEST LOG create temp_uuid table") {
         runUpdateToDb(
           sql"""
@@ -57,19 +61,19 @@ object MassQuery extends BaseDAO {
         """)
       }
 
-      LogUtils.time(logger, s"TEST LOG insert into temp_uuid ${ids.list.size}") {
+      LogUtils.time(logger, s"TEST LOG insert into temp_uuid ${nonNullIds.size}") {
 
         //Making sure that the table is empty if called multiple times within a transaction
         //Emptied at the end of transaction as per TABLE definition above
         runUpdateToDb(sql"TRUNCATE TABLE temp_uuid")
 
         val insertQuery = sql"INSERT INTO temp_uuid (id) VALUES (?)"
-        val batchParams = ids.list.map(id => Seq(id))
+        val batchParams = nonNullIds.map(id => Seq(id))
 
         // Execute batch insert
         runBatchUpdateToDb(insertQuery, batchParams.toSeq)
 
-        logger.debug("added {} entries to temporary table", ids.list.size)
+        logger.debug("added {} entries to temporary table", nonNullIds.size)
 
         // Call the function with the temporary table name
         function(sqls"temp_uuid")

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/ProjectAddressLinkBuilder.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/ProjectAddressLinkBuilder.scala
@@ -61,9 +61,12 @@ object ProjectAddressLinkBuilder extends AddressLinkBuilder {
   @Deprecated
   def build(roadLink: RoadLinkLike, projectLink: ProjectLink): ProjectAddressLink = {
 
-    val geom = if (projectLink.isSplit)
-      GeometryUtils.truncateGeometry3D(roadLink.geometry, projectLink.startMValue, projectLink.endMValue)
-    else
+    val geom = if (projectLink.isSplit) {
+      val geomLength = GeometryUtils.geometryLength(roadLink.geometry)
+      GeometryUtils.truncateGeometry3D(roadLink.geometry,
+        GeometryUtils.scaleMToGeometry(projectLink.startMValue, roadLink.length, geomLength),
+        GeometryUtils.scaleMToGeometry(projectLink.endMValue,   roadLink.length, geomLength))
+    } else
       roadLink.geometry
     val length = GeometryUtils.geometryLength(geom)
     val roadPart = projectLink.roadPart

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -1290,7 +1290,11 @@ class ProjectService(
           if (modifiedLink.geometry.nonEmpty) {
             val kgvGeometry = kgvRoadLinks.find(roadLink => roadLink.linkId == modifiedLink.linkId && roadLink.linkSource == ra.linkGeomSource)
             if (kgvGeometry.nonEmpty) {
-              val geom = GeometryUtils.truncateGeometry3D(kgvGeometry.get.geometry, ra.startMValue, ra.endMValue)
+              val kgvGeom = kgvGeometry.get
+              val kgvGeomLength = GeometryUtils.geometryLength(kgvGeom.geometry)
+              val geom = GeometryUtils.truncateGeometry3D(kgvGeom.geometry,
+                GeometryUtils.scaleMToGeometry(ra.startMValue, kgvGeom.length, kgvGeomLength),
+                GeometryUtils.scaleMToGeometry(ra.endMValue,   kgvGeom.length, kgvGeomLength))
               projectLinkDAO.updateProjectLinkValues(projectId, ra.copy(geometry = geom))
             } else {
               projectLinkDAO.updateProjectLinkValues(projectId, ra, updateGeom = false)
@@ -2079,7 +2083,10 @@ def setCalibrationPoints(startCp: Long, endCp: Long, projectLinks: Seq[ProjectLi
   private def updateGeometryOfOriginalProjectLink(originalProjectLink: ProjectLink): Option[ProjectLink] = {
     val kgvRoadLinks = roadLinkService.getCurrentAndComplementaryRoadLinks(Set(originalProjectLink.linkId))
     kgvRoadLinks.find(_.linkId == originalProjectLink.linkId).map { kgvGeometry =>
-      val updatedGeom = GeometryUtils.truncateGeometry3D(kgvGeometry.geometry, originalProjectLink.startMValue, originalProjectLink.endMValue)
+      val kgvGeomLength = GeometryUtils.geometryLength(kgvGeometry.geometry)
+      val updatedGeom = GeometryUtils.truncateGeometry3D(kgvGeometry.geometry,
+        GeometryUtils.scaleMToGeometry(originalProjectLink.startMValue, kgvGeometry.length, kgvGeomLength),
+        GeometryUtils.scaleMToGeometry(originalProjectLink.endMValue,   kgvGeometry.length, kgvGeomLength))
       projectLinkDAO.updateProjectLinkGeometry(originalProjectLink.id, updatedGeom)
       originalProjectLink.copy(geometry = updatedGeom)
     }
@@ -2304,7 +2311,10 @@ def setCalibrationPoints(startCp: Long, endCp: Long, projectLinks: Seq[ProjectLi
   }
 
   private def newProjectTemplate(rl: RoadLinkLike, ra: RoadAddress, project: Project): ProjectLink = {
-    val geometry = GeometryUtils.truncateGeometry3D(rl.geometry, ra.startMValue, ra.endMValue)
+    val rlGeomLength = GeometryUtils.geometryLength(rl.geometry)
+    val geometry = GeometryUtils.truncateGeometry3D(rl.geometry,
+      GeometryUtils.scaleMToGeometry(ra.startMValue, rl.length, rlGeomLength),
+      GeometryUtils.scaleMToGeometry(ra.endMValue,   rl.length, rlGeomLength))
 
     val newRoadMaintainer = project.reservedParts.find(rp => rp.roadPart == ra.roadPart) match {
       case Some(rp) => {

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -1291,7 +1291,11 @@ class ProjectService(
           if (modifiedLink.geometry.nonEmpty) {
             val kgvGeometry = kgvRoadLinks.find(roadLink => roadLink.linkId == modifiedLink.linkId && roadLink.linkSource == ra.linkGeomSource)
             if (kgvGeometry.nonEmpty) {
-              val geom = GeometryUtils.truncateGeometry3D(kgvGeometry.get.geometry, ra.startMValue, ra.endMValue)
+              val kgvGeom = kgvGeometry.get
+              val kgvGeomLength = GeometryUtils.geometryLength(kgvGeom.geometry)
+              val geom = GeometryUtils.truncateGeometry3D(kgvGeom.geometry,
+                GeometryUtils.scaleMToGeometry(ra.startMValue, kgvGeom.length, kgvGeomLength),
+                GeometryUtils.scaleMToGeometry(ra.endMValue,   kgvGeom.length, kgvGeomLength))
               projectLinkDAO.updateProjectLinkValues(projectId, ra.copy(geometry = geom))
             } else {
               projectLinkDAO.updateProjectLinkValues(projectId, ra, updateGeom = false)
@@ -2080,7 +2084,10 @@ def setCalibrationPoints(startCp: Long, endCp: Long, projectLinks: Seq[ProjectLi
   private def updateGeometryOfOriginalProjectLink(originalProjectLink: ProjectLink): Option[ProjectLink] = {
     val kgvRoadLinks = roadLinkService.getCurrentAndComplementaryRoadLinks(Set(originalProjectLink.linkId))
     kgvRoadLinks.find(_.linkId == originalProjectLink.linkId).map { kgvGeometry =>
-      val updatedGeom = GeometryUtils.truncateGeometry3D(kgvGeometry.geometry, originalProjectLink.startMValue, originalProjectLink.endMValue)
+      val kgvGeomLength = GeometryUtils.geometryLength(kgvGeometry.geometry)
+      val updatedGeom = GeometryUtils.truncateGeometry3D(kgvGeometry.geometry,
+        GeometryUtils.scaleMToGeometry(originalProjectLink.startMValue, kgvGeometry.length, kgvGeomLength),
+        GeometryUtils.scaleMToGeometry(originalProjectLink.endMValue,   kgvGeometry.length, kgvGeomLength))
       projectLinkDAO.updateProjectLinkGeometry(originalProjectLink.id, updatedGeom)
       originalProjectLink.copy(geometry = updatedGeom)
     }
@@ -2322,7 +2329,10 @@ def setCalibrationPoints(startCp: Long, endCp: Long, projectLinks: Seq[ProjectLi
   }
 
   private def newProjectTemplate(rl: RoadLinkLike, ra: RoadAddress, project: Project): ProjectLink = {
-    val geometry = GeometryUtils.truncateGeometry3D(rl.geometry, ra.startMValue, ra.endMValue)
+    val rlGeomLength = GeometryUtils.geometryLength(rl.geometry)
+    val geometry = GeometryUtils.truncateGeometry3D(rl.geometry,
+      GeometryUtils.scaleMToGeometry(ra.startMValue, rl.length, rlGeomLength),
+      GeometryUtils.scaleMToGeometry(ra.endMValue,   rl.length, rlGeomLength))
 
     println(s"HUNTING THE EVK0 ISSUE in ProjectService.newProjectTemplate: Matching to see if reserved part roadPart matches the road address roadPart")
 

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilder.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilder.scala
@@ -28,7 +28,10 @@ class RoadAddressLinkBuilder(roadwayDAO: RoadwayDAO, linearLocationDAO: LinearLo
   private val modifiedBy = "kgvModified"
 
   def build(roadLink: RoadLinkLike, roadAddress: RoadAddress): RoadAddressLink = {
-    val geom = GeometryUtils.truncateGeometry3D(roadLink.geometry, roadAddress.startMValue, roadAddress.endMValue)
+    val geomLength = GeometryUtils.geometryLength(roadLink.geometry)
+    val geom = GeometryUtils.truncateGeometry3D(roadLink.geometry,
+      GeometryUtils.scaleMToGeometry(roadAddress.startMValue, roadLink.length, geomLength),
+      GeometryUtils.scaleMToGeometry(roadAddress.endMValue,   roadLink.length, geomLength))
     val length = GeometryUtils.geometryLength(geom)
     val roadName = roadAddress.roadName
     val municipalityCode = roadLink.municipalityCode
@@ -109,7 +112,10 @@ class RoadAddressLinkBuilder(roadwayDAO: RoadwayDAO, linearLocationDAO: LinearLo
   }
 
   private def buildRoadLink(roadLink: RoadLink, unaddressedRoadLink: UnaddressedRoadLink): RoadAddressLink = {
-    val geom = GeometryUtils.truncateGeometry3D(roadLink.geometry, unaddressedRoadLink.startMValue.getOrElse(0.0), unaddressedRoadLink.endMValue.getOrElse(roadLink.length))
+    val geomLength = GeometryUtils.geometryLength(roadLink.geometry)
+    val geom = GeometryUtils.truncateGeometry3D(roadLink.geometry,
+      GeometryUtils.scaleMToGeometry(unaddressedRoadLink.startMValue.getOrElse(0.0), roadLink.length, geomLength),
+      GeometryUtils.scaleMToGeometry(unaddressedRoadLink.endMValue.getOrElse(roadLink.length), roadLink.length, geomLength))
     val length = GeometryUtils.geometryLength(geom)
     val municipalityCode = roadLink.municipalityCode
     val municipalityName = municipalityNamesMapping.getOrElse(municipalityCode, "")

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
@@ -718,7 +718,9 @@ class RoadAddressService(
       roadAddresses.flatMap { roadAddress =>
         roadLinks.find(_.linkId == roadAddress.linkId).map { roadLink =>
           ChangedRoadAddress(
-            roadAddress = roadAddress.copyWithGeometry(GeometryUtils.truncateGeometry3D(roadLink.geometry, roadAddress.startMValue, roadAddress.endMValue)),
+            roadAddress = roadAddress.copyWithGeometry(GeometryUtils.truncateGeometry3D(roadLink.geometry,
+              GeometryUtils.scaleMToGeometry(roadAddress.startMValue, roadLink.length, GeometryUtils.geometryLength(roadLink.geometry)),
+              GeometryUtils.scaleMToGeometry(roadAddress.endMValue,   roadLink.length, GeometryUtils.geometryLength(roadLink.geometry)))),
             link = roadLink
           )
         }

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/LinearLocationDAO.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/LinearLocationDAO.scala
@@ -157,11 +157,16 @@ object LinearLocation extends SQLSyntaxSupport[LinearLocation] {
           typeCode      = rs.intOpt("cal_end_type").map(CalibrationPointType.apply)
         )
       ),
-      geometry = Seq(
-        Point(x = rs.double("start_x"),y = rs.double("start_y")),
-        Point(x = rs.double("end_x"),  y = rs.double("end_y")
-        )
-      ),
+      geometry = {
+        val sx = rs.doubleOpt("start_x"); val sy = rs.doubleOpt("start_y")
+        val ex = rs.doubleOpt("end_x");   val ey = rs.doubleOpt("end_y")
+        (sx, sy, ex, ey) match {
+          case (Some(x1), Some(y1), Some(x2), Some(y2)) => Seq(Point(x1, y1), Point(x2, y2))
+          case _ =>
+            privateLogger.warn(s"LinearLocation id=${rs.long("id")} has NULL geometry coordinates in the DB — skipping geometry (start_x=$sx, start_y=$sy, end_x=$ex, end_y=$ey)")
+            Seq.empty[Point]
+        }
+      },
       linkGeomSource  = LinkGeomSource(rs.int("source")),
       roadwayNumber   = rs.long("roadway_number"),
       validFrom       = rs.jodaDateTimeOpt("valid_from"),
@@ -847,7 +852,10 @@ class LinearLocationDAO extends BaseDAO {
     val query =
       sql"""
             $selectFromLinearLocation
-            WHERE loc.valid_to IS NULL AND loc.roadway_number IN (SELECT roadway_number FROM roadway WHERE valid_to IS NULL AND end_date IS NULL)
+            WHERE loc.valid_to IS NULL
+              AND loc.roadway_number IN (SELECT roadway_number FROM roadway WHERE valid_to IS NULL AND end_date IS NULL)
+              AND loc.geometry IS NOT NULL
+              AND NOT ST_IsEmpty(loc.geometry)
          """
     queryList(query)
   }

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/process/RoadAddressFiller.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/process/RoadAddressFiller.scala
@@ -132,7 +132,7 @@ object RoadAddressFiller {
     if (roadAddresses.isEmpty) {
       val unaddressedRoadLink =
         UnaddressedRoadLink(roadLink.linkId, None, AdministrativeClass.Unknown, None, None, Some(0.0), Some(roadLink.length),
-          GeometryUtils.truncateGeometry3D(roadLink.geometry, 0.0, roadLink.length))
+          GeometryUtils.truncateGeometry3D(roadLink.geometry, 0.0, GeometryUtils.geometryLength(roadLink.geometry)))
 
       Seq(roadAddressLinkBuilder.build(roadLink, unaddressedRoadLink))
     } else {

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/util/DataImporter.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/util/DataImporter.scala
@@ -338,8 +338,11 @@ class DataImporter extends BaseDAO {
           val topologyLocation = unGroupedTopology.groupBy(_.linkId)
           roadLinksFromKGV.foreach(roadLink => {
             val segmentsOnViiteDatabase = topologyLocation.getOrElse(roadLink.linkId, Set())
+            val roadLinkGeomLength = GeometryUtils.geometryLength(roadLink.geometry)
             segmentsOnViiteDatabase.foreach(segment => {
-              val newGeom = GeometryUtils.truncateGeometry3D(roadLink.geometry, segment.startMValue, segment.endMValue)
+              val newGeom = GeometryUtils.truncateGeometry3D(roadLink.geometry,
+                GeometryUtils.scaleMToGeometry(segment.startMValue, roadLink.length, roadLinkGeomLength),
+                GeometryUtils.scaleMToGeometry(segment.endMValue,   roadLink.length, roadLinkGeomLength))
               if (!segment.geometry.equals(Nil) && !newGeom.equals(Nil)) {
                 if (skipped % 100 == 0 && skipped > 0) { // print some progress info, though nothing has been changing for a while
                   println(s"Skipped geometry updates on $skipped linear locations")

--- a/viite-backend/viite-main/src/main/scala/fi/vaylavirasto/viite/dynamicnetwork/DynamicRoadNetworkService.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/vaylavirasto/viite/dynamicnetwork/DynamicRoadNetworkService.scala
@@ -289,6 +289,7 @@ class DynamicRoadNetworkService(linearLocationDAO: LinearLocationDAO, roadwayDAO
     }
 
     def existsConnectingOrderNumber(orderNumbers: Seq[Double], otherOrderNumbers: Set[Double]): Boolean = {
+      if (orderNumbers.isEmpty) return false
       val min = orderNumbers.min
       val max = orderNumbers.max
       otherOrderNumbers.contains(min - 1) || otherOrderNumbers.contains(max + 1)
@@ -308,7 +309,9 @@ class DynamicRoadNetworkService(linearLocationDAO: LinearLocationDAO, roadwayDAO
 
     def checkRoadAddressContinuityBetweenRoadways(linearLocations: Seq[LinearLocation], change: TiekamuRoadLinkChange, roadwaysForLinearLocations: Set[Roadway]): Boolean = {
       val linLocsGroupedByLinkId = linearLocations.groupBy(_.linkId)
-      val roadwayNumber = filterByLinkIdAndMValueRange(linearLocations, change.oldLinkId, change.oldStartM, change.oldEndM).head.roadwayNumber
+      val matchingLLs = filterByLinkIdAndMValueRange(linearLocations, change.oldLinkId, change.oldStartM, change.oldEndM)
+      if (matchingLLs.isEmpty) return false
+      val roadwayNumber = matchingLLs.head.roadwayNumber
       val roadway = roadwaysForLinearLocations.find(_.roadwayNumber == roadwayNumber).getOrElse(throw ViiteException(s"No Roadway found for linear location id: ${change.oldLinkId} startM: ${change.oldStartM} endM: ${change.oldEndM}"))
       val otherRoadwayNumbers = linLocsGroupedByLinkId.filterNot(grp => grp._1 == change.oldLinkId).map(_._2.map(_.roadwayNumber)).toSet.flatten
       val otherRoadways = roadwaysForLinearLocations.filter(rw => otherRoadwayNumbers.contains(rw.roadwayNumber)).toSet
@@ -320,10 +323,15 @@ class DynamicRoadNetworkService(linearLocationDAO: LinearLocationDAO, roadwayDAO
       val errorLinearLocations = activeLinearLocations.filter(ll => ll.linkId == errorLink)
       val errorRoadwayNumbers = errorLinearLocations.map(_.roadwayNumber).toSet
       val errorRoadways = roadwaysForLinearLocations.filter(rw => errorRoadwayNumbers.contains(rw.roadwayNumber)).toSet
-      val errorRoadsParts = errorRoadways.map(r => {
-        (r.roadPart)
-      })
-      TiekamuRoadLinkErrorMetaData(errorRoadsParts.head, errorRoadways.head.roadwayNumber, errorLinearLocations.map(_.id), errorLink)
+      val errorRoadsParts = errorRoadways.map(_.roadPart)
+      if (errorRoadways.isEmpty)
+        logger.warn(s"getMetaData: no roadways found for link $errorLink — linear locations: ${errorLinearLocations.map(_.id)}, roadway numbers: $errorRoadwayNumbers")
+      TiekamuRoadLinkErrorMetaData(
+        errorRoadsParts.headOption.getOrElse(RoadPart(0, 0)),
+        errorRoadways.headOption.map(_.roadwayNumber).getOrElse(0L),
+        errorLinearLocations.map(_.id),
+        errorLink
+      )
     }
 
     def validateCombinationCases(otherChangesWithSameNewLinkId: Seq[TiekamuRoadLinkChange], change: TiekamuRoadLinkChange, linearLocations: Seq[LinearLocation], roadwaysForLinearLocations: Set[Roadway]): Seq[TiekamuRoadLinkChangeError] = {
@@ -338,6 +346,7 @@ class DynamicRoadNetworkService(linearLocationDAO: LinearLocationDAO, roadwayDAO
         val roadwayNumbers = linearLocations.map(_.roadwayNumber).toSet
         val roadways = roadwaysForLinearLocations.filter(rw => roadwayNumbers.contains(rw.roadwayNumber))
         val roadGroups = roadways.groupBy(rw => (rw.roadPart, rw.track))
+        if (roadGroups.isEmpty) return false
         val singleRoadGroup = roadGroups.head._2
         singleRoadGroup.map(_.roadwayNumber).size == 1
       }
@@ -481,6 +490,10 @@ class DynamicRoadNetworkService(linearLocationDAO: LinearLocationDAO, roadwayDAO
           throw ViiteException(s"Missing new link from KGV/complementary link table. Cannot validate Tiekamu change infos without KGV/complementary road link. LinkId: ${newLinkId}, changeInfo: ${change}")
         )
         val linearLocationsWithOldLinkId = linearLocations.filter(_.linkId == oldLinkId)
+        if (linearLocationsWithOldLinkId.isEmpty) {
+          logger.warn(s"validateTiekamuRoadLinkChanges: no active linear locations for oldLinkId=$oldLinkId — skipping validation for this change")
+        }
+        if (linearLocationsWithOldLinkId.nonEmpty) {
         val roadAddressedLinkLength = GeometryUtils.scaleToThreeDigits(linearLocationsWithOldLinkId.map(_.endMValue).max - linearLocationsWithOldLinkId.map(_.startMValue).min)
         
         // check that the changeset actually has some changes in it
@@ -506,6 +519,7 @@ class DynamicRoadNetworkService(linearLocationDAO: LinearLocationDAO, roadwayDAO
         else if (otherChangesWithSameNewLinkId.nonEmpty) {
           tiekamuRoadLinkChangeErrors ++= validateCombinationCases(otherChangesWithSameNewLinkId, change, linearLocations, roadwaysForLinearLocations)
         }
+        } // end if (linearLocationsWithOldLinkId.nonEmpty)
       })
       tiekamuRoadLinkChangeErrors
     }
@@ -537,8 +551,8 @@ class DynamicRoadNetworkService(linearLocationDAO: LinearLocationDAO, roadwayDAO
       val tiekamuRoadLinkChanges = createTiekamuRoadLinkChangeSets(previousDate: DateTime, newDate: DateTime, activeLinearLocations)
 
       //get the new and the old linkIds to Set[String]
-      val newLinkIds = tiekamuRoadLinkChanges.map(_.newLinkId).toSet
-      val oldLinkIds = tiekamuRoadLinkChanges.map(_.oldLinkId).toSet
+      val newLinkIds = tiekamuRoadLinkChanges.map(_.newLinkId).filter(_ != null).toSet
+      val oldLinkIds = tiekamuRoadLinkChanges.map(_.oldLinkId).filter(_ != null).toSet
       // fetch roadLinks from KGV these are used for getting geometry and link lengths
       val kgvRoadLinks = kgvClient.roadLinkVersionsData.fetchByLinkIds(newLinkIds ++ oldLinkIds)
 

--- a/viite-backend/viite-main/src/main/scala/fi/vaylavirasto/viite/dynamicnetwork/DynamicRoadNetworkService.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/vaylavirasto/viite/dynamicnetwork/DynamicRoadNetworkService.scala
@@ -32,6 +32,21 @@ class DynamicRoadNetworkService(linearLocationDAO: LinearLocationDAO, roadwayDAO
 
   val complementaryLinkDAO: ComplementaryLinkDAO = new ComplementaryLinkDAO
 
+  // LOCAL DEBUG: set the `localS3DebugDir` property (env var or env.properties) to write all dynamic-network
+  // S3 files to that local directory instead of the real S3 bucket. Leave unset for normal S3 behaviour.
+  private val localS3DebugDir: String = ViiteProperties.localS3DebugDir
+
+  private def saveToS3(bucket: String, id: String, body: String, responseType: String): Unit = {
+    if (localS3DebugDir == null || localS3DebugDir.isEmpty) {
+      awsService.S3.saveFileToS3(bucket, id, body, responseType)
+    } else {
+      val dir = java.nio.file.Paths.get(s"$localS3DebugDir/$bucket")
+      java.nio.file.Files.createDirectories(dir)
+      java.nio.file.Files.write(dir.resolve(id.replace('/', '_')), body.getBytes(java.nio.charset.StandardCharsets.UTF_8))
+      logger.info(s"[LOCAL DEBUG] S3 write → $dir/${id.replace('/', '_')}")
+    }
+  }
+
   def tiekamuRoadLinkChangeErrorToMap(tiekamuRoadLinkChangeError: TiekamuRoadLinkChangeError): Map[String, Any] = {
     Map(
       "errorMessage" -> tiekamuRoadLinkChangeError.errorMessage,
@@ -251,13 +266,77 @@ class DynamicRoadNetworkService(linearLocationDAO: LinearLocationDAO, roadwayDAO
       filteredActiveChangeInfos
     }
 
+    /**
+     * Tiekamu can describe a single old→new link mapping with several OVERLAPPING M-range rows
+     * (e.g. a version bump "X:1 → X:2" arriving as 0..49, 0..16, 16..49, 16..38). These overlaps are
+     * not a real merge or a partial change — they redundantly re-cover the same span. Left untouched
+     * they (1) inflate the summed length in validateTiekamuRoadLinkChanges, yielding a false
+     * "No partial changes allowed" error, (2) look like several changes into one new link and so
+     * trigger a false combination / "not continuous" error, and (3) would create overlapping
+     * ReplaceInfos downstream.
+     *
+     * For each (oldLinkId, newLinkId, digitizationChange) group we cluster rows whose old-link M-ranges
+     * overlap or touch, and replace each cluster with a single change spanning the union on both the
+     * old and the new side. Genuinely disjoint ranges (a real partial change with a gap) remain
+     * separate clusters, so genuine partial-coverage cases still fail validation exactly as before.
+     */
+    def collapseOverlappingChanges(changes: Seq[TiekamuRoadLinkChange]): Seq[TiekamuRoadLinkChange] = {
+      // The old-link M-range may be stored descending (oldStartM > oldEndM), so normalise to [lo, hi]
+      // for overlap detection and restore the group's orientation on output.
+      def oldLo(ch: TiekamuRoadLinkChange): Double = math.min(ch.oldStartM, ch.oldEndM)
+      def oldHi(ch: TiekamuRoadLinkChange): Double = math.max(ch.oldStartM, ch.oldEndM)
+
+      changes.groupBy(ch => (ch.oldLinkId, ch.newLinkId, ch.digitizationChange)).values.flatMap { group =>
+        val ascending = group.head.oldEndM >= group.head.oldStartM
+        // Cluster rows whose normalised old-M ranges overlap or touch (within DefaultEpsilon).
+        val clusters = group.sortBy(oldLo).foldLeft(List.empty[List[TiekamuRoadLinkChange]]) {
+          case (head :: tail, ch) if oldLo(ch) <= head.map(oldHi).max + GeometryUtils.DefaultEpsilon =>
+            (ch :: head) :: tail
+          case (acc, ch) =>
+            List(ch) :: acc
+        }
+        clusters.map { cluster =>
+          val first = cluster.head
+          val lo = cluster.map(oldLo).min
+          val hi = cluster.map(oldHi).max
+          val (oldStart, oldEnd) = if (ascending) (lo, hi) else (hi, lo)
+          TiekamuRoadLinkChange(
+            first.oldLinkId, oldStart, oldEnd,
+            first.newLinkId, cluster.map(_.newStartM).min, cluster.map(_.newEndM).max,
+            first.digitizationChange
+          )
+        }
+      }.toSeq
+    }
+
     time(logger, "Creating Viite road link change info sets") {
       val tiekamuRoadLinkChanges = vkmClient.getTiekamuRoadlinkChanges(previousDate, newDate)
       logger.info(s"${tiekamuRoadLinkChanges.length} TiekamuRoadLinkChanges fetched.")
       // filter change infos so that only the ones that target links with road addresses are left
       val roadAddressedRoadLinkChanges = getChangeInfosWithRoadAddress(tiekamuRoadLinkChanges, activeLinearLocations)
 
-      roadAddressedRoadLinkChanges
+      // Drop "no-op" changes: a row where the link maps onto itself with identical M-values and no
+      // digitization change describes a link that did not change at all. Such a row is not an error,
+      // so it must not reach validateTiekamuRoadLinkChanges (where it would be flagged as
+      // "No changes found in the changeset" and drop the entire road part), nor produce a redundant
+      // self-replace in the change set.
+      val (noOpChanges, effectiveChanges) = roadAddressedRoadLinkChanges.partition(ch =>
+        ch.oldLinkId == ch.newLinkId &&
+          ch.oldStartM == ch.newStartM &&
+          ch.oldEndM == ch.newEndM &&
+          !ch.digitizationChange
+      )
+      if (noOpChanges.nonEmpty)
+        logger.info(s"Filtered out ${noOpChanges.length} no-op TiekamuRoadLinkChange(s) (link unchanged); ${effectiveChanges.length} remain.")
+
+      // Reconcile overlapping/fragmented rows that describe the same old→new mapping (see
+      // collapseOverlappingChanges) so they no longer cause false partial-change / combination errors.
+      val collapsedChanges = collapseOverlappingChanges(effectiveChanges)
+      val collapsedAway = effectiveChanges.length - collapsedChanges.length
+      if (collapsedAway > 0)
+        logger.info(s"Collapsed $collapsedAway overlapping TiekamuRoadLinkChange row(s) into spanning changes; ${collapsedChanges.length} remain.")
+
+      collapsedChanges
     }
   }
 
@@ -468,7 +547,7 @@ class DynamicRoadNetworkService(linearLocationDAO: LinearLocationDAO, roadwayDAO
 
       var tiekamuRoadLinkChangeErrors = new ListBuffer[TiekamuRoadLinkChangeError]()
       tiekamuRoadLinkChanges.foreach(change => {
-        val lengthOfChange = GeometryUtils.scaleToThreeDigits(change.oldEndM - change.oldStartM)
+        val lengthOfChange = GeometryUtils.scaleToThreeDigits(math.abs(change.oldEndM - change.oldStartM))
         val oldLinkId = change.oldLinkId
         val newLinkId = change.newLinkId
         val newStartM = change.newStartM
@@ -507,7 +586,9 @@ class DynamicRoadNetworkService(linearLocationDAO: LinearLocationDAO, roadwayDAO
         // check that there are no "partial" changes to road addressed links, i.e. only part of the link changes and the other part has no changes applied to it.
         if (lengthOfChange != roadAddressedLinkLength) {
           val allChangesWithOldLinkId = tiekamuRoadLinkChanges.filter(_.oldLinkId == oldLinkId)
-          val combinedLengthOfChanges = GeometryUtils.scaleToThreeDigits(allChangesWithOldLinkId.map(och => och.oldEndM - och.oldStartM).sum)
+          // Use abs: a change may run against the old link's digitization direction (oldStartM > oldEndM),
+          // in which case oldEndM - oldStartM is negative. The length covered on the old link is |oldEndM - oldStartM|.
+          val combinedLengthOfChanges = GeometryUtils.scaleToThreeDigits(allChangesWithOldLinkId.map(och => math.abs(och.oldEndM - och.oldStartM)).sum)
           if (combinedLengthOfChanges != roadAddressedLinkLength)
             tiekamuRoadLinkChangeErrors += TiekamuRoadLinkChangeError("No partial changes allowed. The old link needs to have changes applied to the whole length of the old link", change, getMetaData(change, linearLocations, roadwaysForLinearLocations))
         }
@@ -632,7 +713,7 @@ class DynamicRoadNetworkService(linearLocationDAO: LinearLocationDAO, roadwayDAO
           val s3SkippedChangeSetsName = s"SkippedTiekamuRoadLinkChanges-${previousDate.getYear}-${previousDate.getMonthOfYear}-${previousDate.getDayOfMonth}-" +
                                         s"${newDate.getYear}-${newDate.getMonthOfYear}-${newDate.getDayOfMonth}-${DateTime.now()}"
           val jsonSkippedChanges = Json(DefaultFormats).write(skippedTiekamuRoadLinkChanges.map(skippedChange => skippedTiekamuRoadLinkChangeToMap(skippedChange)))
-          awsService.S3.saveFileToS3(bucketName, s3SkippedChangeSetsName, jsonSkippedChanges, "json") // save the error details to S3
+          saveToS3(bucketName, s3SkippedChangeSetsName, jsonSkippedChanges, "json") // save the error details to S3
         }
       } catch {
         case ex: ViiteException =>
@@ -655,7 +736,7 @@ class DynamicRoadNetworkService(linearLocationDAO: LinearLocationDAO, roadwayDAO
         val jsonErrorParts = Json(DefaultFormats).write(tiekamuRoadLinkChangeErrors.map(error => tiekamuRoadLinkChangeErrorToMap(error)))
         val s3ChangeSetErrorsName = s"${previousDate.getDayOfMonth}-${previousDate.getMonthOfYear}-${previousDate.getYear}-" +
                                     s"${newDate.getDayOfMonth}-${newDate.getMonthOfYear}-${newDate.getYear}-${DateTime.now()}-Errors"
-        awsService.S3.saveFileToS3(bucketName, s3ChangeSetErrorsName, jsonErrorParts, "json") // save the error details to S3
+        saveToS3(bucketName, s3ChangeSetErrorsName, jsonErrorParts, "json") // save the error details to S3
       }
 
       if (viiteChangeSets.nonEmpty) {
@@ -667,7 +748,7 @@ class DynamicRoadNetworkService(linearLocationDAO: LinearLocationDAO, roadwayDAO
 
         // ViiteChangeSets-yyyy-MM-dd-yyyy-MM-dd-yyyy-MM-dd:hh:mm:ss (ViiteChangeSets-previousDate-newDate-currentTimeStamp)
         val changeSetNameForS3Bucket = "ViiteChangeSets" + "-" + changeDateString + "-" + DateTime.now()
-        awsService.S3.saveFileToS3(bucketName, changeSetNameForS3Bucket, jsonChangeSets, "json")
+        saveToS3(bucketName, changeSetNameForS3Bucket, jsonChangeSets, "json")
 
         linkNetworkUpdater.persistLinkNetworkChanges(viiteChangeSets, changeSetNameForViiteDB, newDate, LinkGeomSource.NormalLinkInterface)
         logger.info(s"${viiteChangeSets.size} links updated successfully!")

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/process/DefaultSectionCalculatorStrategySpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/process/DefaultSectionCalculatorStrategySpec.scala
@@ -2937,4 +2937,45 @@ Left     ^  ^   Right
 
    }
  }
+
+ test("EXPERIMENT two new parallel tracks growth direction from ajorata number") {
+   runWithRollback {
+     // Two parallel vertical roads: west at x=0, east at x=5, both spanning y=0..10.
+     // Try both ajorata labelings, both digitization orders per link and several sidecodes.
+     // Domain invariant: the RightSide (ajorata 1) track must lie on the RIGHT of the growth direction,
+     // i.e. the vector from the right track start toward the left track start points to the LEFT of growth
+     // (2D cross product of growth x lateral > 0).
+     def mkLink(x: Double, snOrder: Boolean, track: Track, sc: SideCode): ProjectLink = {
+       val geom = if (snOrder) Seq(Point(x, 0.0), Point(x, 10.0)) else Seq(Point(x, 10.0), Point(x, 0.0))
+       val id = Sequences.nextProjectLinkId
+       ProjectLink(id, RoadPart(9999, 1), track, Discontinuity.Continuous, AddrMRange(0L, 0L), AddrMRange(0L, 0L), None, None, None, id.toString, 0.0, 10.0, sc, (NoCP, NoCP), (NoCP, NoCP), geom, 0L, RoadAddressChangeType.New, AdministrativeClass.State, NormalLinkInterface, GeometryUtils.geometryLength(geom), 0L, 0, ArealRoadMaintainer.getEVK(0), reversed = false, None, 86400L)
+     }
+     val sides  = Seq(SideCode.Unknown, SideCode.TowardsDigitizing, SideCode.AgainstDigitizing)
+     val orders = Seq(true, false)
+     val combos = for { rightIsWest <- Seq(true, false); sc <- sides; w <- orders; e <- orders } yield (rightIsWest, sc, w, e)
+     val results = combos.map { case (rightIsWest, sc, westSN, eastSN) =>
+       val west = mkLink(0.0, westSN, if (rightIsWest) Track.RightSide else Track.LeftSide, sc)
+       val east = mkLink(5.0, eastSN, if (rightIsWest) Track.LeftSide else Track.RightSide, sc)
+       val rightLink = if (rightIsWest) west else east
+       val res = try {
+         val (rightStart, leftStart) = defaultSectionCalculatorStrategy.findStartingPoints(Seq(west, east), Seq(), Seq(), Seq.empty[UserDefinedCalibrationPoint])
+         val rightFar = Seq(rightLink.geometry.head, rightLink.geometry.last).maxBy(_.distance2DTo(rightStart))
+         val d = fi.vaylavirasto.viite.geometry.Vector3d(rightFar.x - rightStart.x, rightFar.y - rightStart.y, 0.0).normalize2D()
+         val s = fi.vaylavirasto.viite.geometry.Vector3d(leftStart.x - rightStart.x, leftStart.y - rightStart.y, 0.0)
+         val crossZ = d.x * s.y - d.y * s.x
+         (crossZ > 0, f"rStart=$rightStart lStart=$leftStart growth=(${d.x}%.0f,${d.y}%.0f) crossZ=$crossZ%.1f")
+       } catch {
+         case ex: Throwable => (false, s"EXC ${ex.getClass.getSimpleName}: ${ex.getMessage}")
+       }
+       (rightIsWest, sc, westSN, eastSN, res._1, res._2)
+     }
+     val bad = results.filterNot(_._5)
+     val report = results.map { case (rightIsWest, sc, westSN, eastSN, ok, msg) =>
+       f"${if (ok) "OK  " else "FAIL"} rightIsWest=$rightIsWest%-5s sc=$sc%-16s westSN=$westSN%-5s eastSN=$eastSN%-5s | $msg"
+     }.mkString("\n")
+     withClue(s"\n${bad.size}/${results.size} combos violate 'RightSide track on the right of growth':\n$report\n") {
+       bad shouldBe empty
+     }
+   }
+ }
 }


### PR DESCRIPTION
Korjaa m-arvojen ja geometrian pituuksiin liittyvät ongelmat. Kohtuullinen logiikkamuutos; pitää varmentua Viite-sovelluksen toimivuudesta ja muiden muutosten yhteensopivuuden kanssa. VIITE-3956 saattaa korjaantua tällä muutoksella myös.

Projektien luomiset ym ym asiat olisi hyvä tarkistaa että toimivat, minun paikallisilla testauksilla kaikki OK, mutta tarvitaan lisäkäsiä testaamiseen.

Sisältää myös korjauksen dynaamisen verkon tuontiin, joka aikaisemmin päätyi virhetilaan.