### PR TITLE
VIITE-3962 Fix continiuity validation for past dates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,5 @@ WebContent/
 revision.properties
 bonecp.properties
 .env
+.env*
 /.db

--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,5 @@ WebContent/
 revision.properties
 bonecp.properties
 .env
-.env*
+.env.*
 /.db

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
@@ -582,12 +582,12 @@ class RoadAddressService(
     * Gets all the valid road address in the given road number and project start date
     *
     * @param roadNumber The road number
-    * @param startDate  The project start date
+    * @param projectStartDate  The project start date
     * @return Returns road addresses filtered given section
     */
-  def getValidRoadAddressParts(roadNumber: Long, startDate: DateTime): Seq[Long] = {
+  def getValidRoadAddressParts(roadNumber: Long, projectStartDate: DateTime): Seq[Long] = {
     runWithReadOnlySession {
-      roadwayDAO.getValidRoadParts(roadNumber, startDate)
+      roadwayDAO.getValidRoadParts(roadNumber, projectStartDate)
     }
   }
 

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/RoadwayDAO.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/RoadwayDAO.scala
@@ -1070,7 +1070,7 @@ class RoadwayDAO extends BaseDAO {
         SELECT DISTINCT ra.road_part_number
         FROM roadway ra
         WHERE road_number = $roadNumber AND valid_to IS NULL AND START_DATE <= $startDate
-            AND end_date IS NULL
+            AND (end_date IS NULL OR end_date >= $startDate)
             AND ra.road_part_number NOT IN (
         SELECT DISTINCT pl.road_part_number
         FROM project_link pl

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/RoadwayDAO.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/RoadwayDAO.scala
@@ -1062,26 +1062,27 @@ class RoadwayDAO extends BaseDAO {
    * Said delay is no longer present in AWS.
    * TODO: Refactor this function as it's no longer needed.
    * @param roadNumber
-   * @param startDate
+   * @param projectStartDate
    * @return
    */
-  def getValidRoadParts(roadNumber: Long, startDate: DateTime): List[Long] = {
+  def getValidRoadParts(roadNumber: Long, projectStartDate: DateTime): List[Long] = {
     val query = sql"""
-        SELECT DISTINCT ra.road_part_number
-        FROM roadway ra
-        WHERE road_number = $roadNumber AND valid_to IS NULL AND START_DATE <= $startDate
-            AND (end_date IS NULL OR end_date >= $startDate)
-            AND ra.road_part_number NOT IN (
-        SELECT DISTINCT pl.road_part_number
-        FROM project_link pl
-            WHERE (
-            SELECT count(DISTINCT pl2.status)
-            FROM project_link pl2
-            WHERE pl2.road_part_number = ra.road_part_number
-            AND pl2.road_number = ra.road_number
-            AND pl.road_number = pl2.road_number)
-         = 1
-         AND pl.status = 5)
+      SELECT DISTINCT ra.road_part_number
+      FROM roadway ra
+      WHERE road_number = $roadNumber AND valid_to IS NULL AND START_DATE <= $projectStartDate
+          AND (end_date IS NULL OR end_date >= $projectStartDate)
+          AND ra.road_part_number NOT IN (
+              SELECT DISTINCT pl.road_part_number
+              FROM project_link pl
+              WHERE (
+                  SELECT count(DISTINCT pl2.status)
+                  FROM project_link pl2
+                  WHERE pl2.road_part_number = ra.road_part_number
+                    AND pl2.road_number = ra.road_number
+                    AND pl.road_number = pl2.road_number
+              ) = 1
+              AND pl.status = 5
+          )
       """
     runSelectQuery(query.map(_.long(1)))
   }


### PR DESCRIPTION
Korjattu getValidRoadParts-kyselyn end_date IS NULL -ehto ottamaan huomioon myös tieosat, joiden päättymispäivä on projektin alkupäivämäärän jälkeen, jolloin validaattori ei enää ohita tieverkolla projektin alkupäivänä voimassa olleita tieosia.