### PR TITLE
VIITE-3963 No validation on cancel

### DIFF
--- a/viite-UI/src/view/ProjectEditForm.js
+++ b/viite-UI/src/view/ProjectEditForm.js
@@ -442,12 +442,9 @@
         selectedProjectLinkProperty.clean();
         $('.wrapper').remove();
         
-        // Trigger cleanup events
-        [
-          'roadAddress:projectLinksEdited',
-          'roadAddressProject:toggleEditingRoad',
-          'roadAddressProject:reOpenCurrent'
-        ].forEach(event => eventbus.trigger(event, event.includes('toggleEditingRoad') ? true : undefined));
+        eventbus.trigger('roadAddress:projectLinksEdited');
+        eventbus.trigger('roadAddressProject:toggleEditingRoad', true);
+        eventbus.trigger('roadAddressProject:reOpenCurrent', true);
       };
 
       eventbus.on('roadAddressProject:discardChanges', cancelChanges);

--- a/viite-UI/src/view/ProjectEditForm.js
+++ b/viite-UI/src/view/ProjectEditForm.js
@@ -368,7 +368,7 @@
         selectedProjectLinkProperty.cleanIds();
         
         const { projectErrors } = response;
-        const containsFormedLinks = dataJson?.linkIds.length > 0 || dataJson?.ids.length > 0;
+        const containsFormedLinks = (dataJson && dataJson.linkIds && dataJson.linkIds.length > 0) || (dataJson && dataJson.ids && dataJson.ids.length > 0);
         rootElement.html(emptyTemplateDisabledButtons(projectCollection.getCurrentProject().project));
         if (Object.keys(projectErrors).length === 0) {
           // if no (high priority) validation errors are present, then show recalculate button and remove title

--- a/viite-UI/src/view/ProjectEditForm.js
+++ b/viite-UI/src/view/ProjectEditForm.js
@@ -368,14 +368,11 @@
         selectedProjectLinkProperty.cleanIds();
         
         const { projectErrors } = response;
-        const containsProjectLinks = !!(dataJson && (dataJson.linkIds && dataJson.linkIds.length || dataJson.ids && dataJson.ids.length));
-
-        // show disabled buttons
+        const containsFormedLinks = dataJson?.linkIds.length > 0 || dataJson?.ids.length > 0;
         rootElement.html(emptyTemplateDisabledButtons(projectCollection.getCurrentProject().project));
-        
         if (Object.keys(projectErrors).length === 0) {
           // if no (high priority) validation errors are present, then show recalculate button and remove title
-          formCommon.setDisabledAndTitleAttributesById("recalculate-button", !containsProjectLinks, "");
+          formCommon.setDisabledAndTitleAttributesById("recalculate-button", !containsFormedLinks, "");
           formCommon.setInformationContent();
           formCommon.setInformationContentText("Päivitä etäisyyslukemat jatkaaksesi projektia.");
         } else {
@@ -385,11 +382,7 @@
         // changes made to project links, set recalculated flag to false
         eventbus.trigger('roadAddressProject:setRecalculatedAfterChangesFlag', false);
         applicationModel.removeSpinner();
-        if (typeof response !== 'undefined' && typeof response.publishable !== 'undefined' && response.publishable) {
-          eventbus.trigger('roadAddressProject:projectLinkSaved', containsProjectLinks);
-        } else {
-          eventbus.trigger('roadAddressProject:projectLinkSaved', containsProjectLinks);
-        }
+        eventbus.trigger('roadAddressProject:projectLinkSaved', response.id, response.publishable, containsFormedLinks);
       });
 
       eventbus.on('roadAddress:projectSentSuccess', () => {

--- a/viite-UI/src/view/ProjectForm.js
+++ b/viite-UI/src/view/ProjectForm.js
@@ -476,8 +476,10 @@
        * Set attributes (disabled, title) of the recalculate, changes & send buttons when project link changes are cancelled
        * ("Peruuta" button is clicked or clicking anywhere on the map when project edit form is open (i.e. closing the form))
        * */
-      var buttonsWhenReOpenCurrent = function (projectErrors, highPriorityProjectErrors) {
-        eventbus.trigger('roadAddressProject:writeProjectErrors');
+      var buttonsWhenReOpenCurrent = function (projectErrors, highPriorityProjectErrors, wasCancelled) {
+        if (!wasCancelled) {
+          eventbus.trigger('roadAddressProject:writeProjectErrors');
+        }
         if (highPriorityProjectErrors.length === 0) {
           if ($('.change-table-frame').css('display') === "block") {
             formCommon.setDisabledAndTitleAttributesById("recalculate-button", true, "Etäisyyslukemia ei voida päivittää yhteenvetotaulukon ollessa auki");
@@ -631,8 +633,8 @@
         applicationModel.removeSpinner();
       });
 
-      eventbus.on('roadAddressProject:reOpenCurrent', function () {
-        reOpenCurrent();
+      eventbus.on('roadAddressProject:reOpenCurrent', function (wasCancelled) {
+        reOpenCurrent(wasCancelled);
       });
 
       eventbus.on('roadAddressProject:writeProjectErrors', function () {
@@ -864,19 +866,24 @@
         $('.wrapper').remove();
         eventbus.trigger('roadAddress:projectLinksEdited');
         eventbus.trigger('roadAddressProject:toggleEditingRoad', true);
-        eventbus.trigger('roadAddressProject:reOpenCurrent');
+        eventbus.trigger('roadAddressProject:reOpenCurrent', true);
       };
 
-      var reOpenCurrent = function () {
+      var reOpenCurrent = function (wasCancelled) {
         rootElement.empty();
         selectedProjectLinkProperty.setDirty(false);
-        nextStage();
+        if (wasCancelled) {
+          currentProject.isDirty = false;
+          rootElement.html(selectedProjectLinkTemplateDisabledButtons(currentProject));
+        } else {
+          nextStage();
+        }
         if (currentProject.statusCode === 10 || currentProject.statusCode === 11 || currentProject.statusCode === 12) {
           buttonsWhenInspectingUneditableProject();
         } else {
           var projectErrors = projectCollection.getProjectErrors();
           var highPriorityProjectErrors = projectErrors.filter((error) => error.errorCode === 8);  // errorCode 8 means there are projectLinks in the project with status "NotHandled"
-          buttonsWhenReOpenCurrent(projectErrors, highPriorityProjectErrors);
+          buttonsWhenReOpenCurrent(projectErrors, highPriorityProjectErrors, wasCancelled);
         }
         toggleAdditionalControls();
         eventbus.trigger('roadAddressProject:enableInteractions');

--- a/viite-UI/src/view/ProjectForm.js
+++ b/viite-UI/src/view/ProjectForm.js
@@ -15,14 +15,13 @@
       recalculatedAfterChangesFlag = bool;
     });
 
-    eventbus.on('roadAddressProject:projectLinkSaved', function(containsProjectLinks) {
+    eventbus.on('roadAddressProject:projectLinkSaved', function(projectId, isPublishable, containsFormedLinks) {
       // Get the current state of the validate button if it exists
       $('#actionButtons').empty();
       const $buttons = $('.project-form.form-controls');
       const $validateButton = $buttons.find('#validate-button');
       const hasValidationButton = $validateButton.length > 0;
       const isValidationButtonVisible = hasValidationButton && $validateButton.is(':visible');
-
 
       // Rebuild the buttons with proper states
       let buttonsHtml = '';
@@ -49,9 +48,8 @@
       // Update button states based on the same logic as in buttonsWhenReOpenCurrent
       const isChangeTableOpen = $('.change-table-frame').is(':visible');
       const hasRecalculated = getRecalculatedAfterChangesFlag();
-      const hasNoProjectLinks = !containsProjectLinks;
 
-      if (hasNoProjectLinks) {
+      if (!containsFormedLinks) {
         formCommon.setDisabledAndTitleAttributesById("recalculate-button", true, "Projektilla ei ole linkkejä");
         formCommon.setDisabledAndTitleAttributesById("changes-button", true, "Projektin tulee läpäistä validoinnit");
         formCommon.setDisabledAndTitleAttributesById("send-button", true, "Projektin tulee läpäistä validoinnit");
@@ -447,7 +445,7 @@
       };
 
       var hasNoProjectLinks = function () {
-        return projectCollection.getReservedParts().length === 0 && projectCollection.getFormedParts().length === 0;
+        return projectCollection.getReservedParts()?.length === 0 && projectCollection.getFormedParts()?.length === 0;
       };
 
       /**
@@ -476,10 +474,8 @@
        * Set attributes (disabled, title) of the recalculate, changes & send buttons when project link changes are cancelled
        * ("Peruuta" button is clicked or clicking anywhere on the map when project edit form is open (i.e. closing the form))
        * */
-      var buttonsWhenReOpenCurrent = function (projectErrors, highPriorityProjectErrors, wasCancelled) {
-        if (!wasCancelled) {
-          eventbus.trigger('roadAddressProject:writeProjectErrors');
-        }
+      var buttonsWhenReOpenCurrent = function (projectErrors, highPriorityProjectErrors) {
+        eventbus.trigger('roadAddressProject:writeProjectErrors');
         if (highPriorityProjectErrors.length === 0) {
           if ($('.change-table-frame').css('display') === "block") {
             formCommon.setDisabledAndTitleAttributesById("recalculate-button", true, "Etäisyyslukemia ei voida päivittää yhteenvetotaulukon ollessa auki");
@@ -883,7 +879,7 @@
         } else {
           var projectErrors = projectCollection.getProjectErrors();
           var highPriorityProjectErrors = projectErrors.filter((error) => error.errorCode === 8);  // errorCode 8 means there are projectLinks in the project with status "NotHandled"
-          buttonsWhenReOpenCurrent(projectErrors, highPriorityProjectErrors, wasCancelled);
+          buttonsWhenReOpenCurrent(projectErrors, highPriorityProjectErrors);
         }
         toggleAdditionalControls();
         eventbus.trigger('roadAddressProject:enableInteractions');

--- a/viite-UI/src/view/ProjectForm.js
+++ b/viite-UI/src/view/ProjectForm.js
@@ -445,7 +445,9 @@
       };
 
       var hasNoProjectLinks = function () {
-        return projectCollection.getReservedParts()?.length === 0 && projectCollection.getFormedParts()?.length === 0;
+        var reservedParts = projectCollection.getReservedParts();
+        var formedParts = projectCollection.getFormedParts();
+        return (!reservedParts || reservedParts.length === 0) && (!formedParts || formedParts.length === 0);
       };
 
       /**

--- a/viite-UI/src/view/ProjectLinkLayer.js
+++ b/viite-UI/src/view/ProjectLinkLayer.js
@@ -390,7 +390,7 @@
     me.eventListener.listenTo(eventbus, 'projectLink:revertedChanges', function (response) {
       isNotEditingData = true;
       selectedProjectLinkProperty.setDirty(false);
-      eventbus.trigger('roadAddress:projectLinksUpdated', response);
+      eventbus.trigger('roadAddress:projectLinksUpdated', response, { linkIds: response.formedInfo || [] });
       projectCollection.fetch(map.getView().calculateExtent(map.getSize()).join(','), zoomlevels.getViewZoom(map) + 1, undefined, projectCollection.getPublishableStatus());
     });
 


### PR DESCRIPTION
Aikaisemmin viite triggeröi projektin validoinnin kun käytäjä painoi linkin muokkaus valikossa "peruuta" nappia. Näin ei kuuluisi tapahtua, joten nyt validointi skipataan peruutuksen yhteydessä