### PR TITLE
VIITE-3965 Do not allow user to access processed project links

### DIFF
--- a/viite-UI/src/less/core/forms.less
+++ b/viite-UI/src/less/core/forms.less
@@ -332,9 +332,13 @@ form.roadAddressProject .form-control.small-input{
   width: 70px !important;
 }
 
-form.roadAddressProject .form-control,
-form.roadAddressProject .action-select{
+form.roadAddressProject .form-control {
   width: 190px !important;
+  margin-top: 6px !important;
+}
+
+form.roadAddressProject .action-select {
+  width: 240px !important;
   margin-top: 6px !important;
 }
 

--- a/viite-UI/src/model/ProjectCollection.js
+++ b/viite-UI/src/model/ProjectCollection.js
@@ -215,7 +215,19 @@
 
     this.revertChangesRoadlink = function (links) {
       if (!_.isEmpty(links)) {
-        applicationModel.addSpinner();
+        // Existing project links are tracked by numeric id, while newly created unsaved links only
+        // have a linkId. Keep both lists so the reverted links stay locked until the refetch redraws them.
+        var revertedLinkIds = _.uniq(
+          links
+            .filter(function (link) { return !(link.id > 0); })
+            .map(function (link) { return link.linkId; })
+        );
+
+        var revertedIds = _.uniq(
+          links
+            .filter(function (link) { return link.id > 0; })
+            .map(function (link) { return link.id; })
+        );
         var coordinates = applicationModel.getUserGeoLocation();
         var data = {
           'projectId': currentProject.project.id,
@@ -232,7 +244,7 @@
             publishableProject = response.publishable;
             me.setAndWriteProjectErrorsToUser(response.projectErrors);
             me.setFormedParts(response.formedInfo);
-            eventbus.trigger('projectLink:revertedChanges', response);
+            eventbus.trigger('projectLink:revertedChanges', response, { ids: revertedIds, linkIds: revertedLinkIds });
           } else {
             if (response.status === INTERNAL_SERVER_ERROR_500 || response.status === BAD_REQUEST_400) {
               eventbus.trigger('roadAddress:projectLinksUpdateFailed', response.status);
@@ -247,7 +259,6 @@
     var createOrUpdate = function (dataJson) {
       if ((!_.isEmpty(dataJson.linkIds) || !_.isEmpty(dataJson.ids)) && typeof dataJson.projectId !== 'undefined' && dataJson.projectId !== 0) {
         if (dataJson.roadNumber !== 0 && dataJson.roadPartNumber !== 0) {
-          applicationModel.addSpinner();
           resetEditedDistance();
           var ids = dataJson.ids;
           if (dataJson.roadAddressChangeType === RoadAddressChangeType.New.value && ids.length === 0) {
@@ -263,7 +274,6 @@
                 }
               } else {
                 new ModalConfirm(successObject.errorMessage);
-                applicationModel.removeSpinner();
               }
             });
           } else {
@@ -275,7 +285,6 @@
                 eventbus.trigger('roadAddress:projectLinksUpdated', successObject, dataJson);
               } else {
                 new ModalConfirm(successObject.errorMessage);
-                applicationModel.removeSpinner();
               }
             });
           }
@@ -417,7 +426,6 @@
       };
       if (dataJson.trackCode === Track.Unknown.value) {
         new ModalConfirm("Tarkista ajoratakoodi");
-        applicationModel.removeSpinner();
       }
 
       var changedLink = _.chain(changedLinks).uniq().sortBy(function (cl) {

--- a/viite-UI/src/view/ProjectEditForm.js
+++ b/viite-UI/src/view/ProjectEditForm.js
@@ -381,7 +381,7 @@
         formCommon.toggleAdditionalControls();
         // changes made to project links, set recalculated flag to false
         eventbus.trigger('roadAddressProject:setRecalculatedAfterChangesFlag', false);
-        applicationModel.removeSpinner();
+        eventbus.trigger('roadAddressProject:lockLinks', dataJson.ids, dataJson.linkIds); // Lock the saved links against interaction until the background re-fetch redraws them
         eventbus.trigger('roadAddressProject:projectLinkSaved', response.id, response.publishable, containsFormedLinks);
       });
 
@@ -472,12 +472,40 @@
           const linksToSave = projectCollection.getTmpDirty().length > 0 
             ? projectCollection.getTmpDirty() 
             : selectedProjectLink;
+
+          const lockedIds = _.chain(linksToSave)
+            .map(link => link.id)
+            .filter(id => _.isNumber(id) && id > 0)
+            .uniq()
+            .value();
+          const lockedLinkIds = _.chain(linksToSave)
+            .map(link => link.linkId)
+            .filter(linkId => !_.isUndefined(linkId) && linkId !== null)
+            .uniq()
+            .value();
+
+          // Lock exactly the links being saved so only those links are blocked/cursor-marked.
+          eventbus.trigger('roadAddressProject:lockLinks', lockedIds, lockedLinkIds);
+
           const isEndDistanceModified = projectCollection.getTmpDirty().length > 0 
             ? isEndDistanceTouched() 
             : false;
             
           projectCollection.saveProjectLinks(linksToSave, changeType.value, isEndDistanceModified);
         }
+        projectLinkLayer.clearHighlights();
+        selectedProjectLinkProperty.setCurrent([]);
+        selectedProjectLinkProperty.cleanIds();
+        selectedProjectLinkProperty.clean();
+        selectedProjectLinkProperty.setDirty(false);
+        selectedProjectLink = false;
+        // Close the edit form immediately so the user sees the map without waiting for the HTTP response
+
+        const currentProject = projectCollection.getCurrentProject().project;
+        rootElement.html(emptyTemplateDisabledButtons(currentProject));
+        formCommon.toggleAdditionalControls();
+        // Signal that a save is in-flight so footer buttons go to disabled state
+        eventbus.trigger('roadAddressProject:linksSaving');
         return true;
       };
 

--- a/viite-UI/src/view/ProjectForm.js
+++ b/viite-UI/src/view/ProjectForm.js
@@ -10,6 +10,8 @@
 
     // flag to keep track if the project links have been recalculated after the changes made to the project links
     var recalculatedAfterChangesFlag = false;
+    // flag to distinguish a post-save fetch from a regular project-open fetch
+    var isSaveInFlight = false;
 
     eventbus.on('roadAddressProject:setRecalculatedAfterChangesFlag', function (bool) {
       recalculatedAfterChangesFlag = bool;
@@ -72,6 +74,9 @@
         formCommon.setDisabledAndTitleAttributesById("changes-button", true, "Projektin tulee läpäistä validoinnit");
         formCommon.setDisabledAndTitleAttributesById("send-button", true, "Projektin tulee läpäistä validoinnit");
       }
+
+      // Recalculate must stay disabled during project link processing
+      formCommon.setDisabledAndTitleAttributesById("recalculate-button", true, "Projektilinkkien käsittely kesken, odota hetki");
 
       // Rebind event handlers
       if (typeof bindEvents === 'function') {
@@ -637,8 +642,33 @@
 
       eventbus.on('roadAddressProject:writeProjectErrors', function () {
         $('#project-errors').html(errorsList());
-        applicationModel.removeSpinner();
       });
+
+      // Rebuild the footer immediately with disabled recalculate/changes/send buttons when a save is in-flight.
+      // This replaces the Save/Cancel buttons (from emptyTemplateDisabledButtons) before the HTTP response arrives.
+      eventbus.on('roadAddressProject:linksSaving', function () {
+        isSaveInFlight = true;
+        const recalcBtnTitle = 'Projektilinkkien tallennus kesken, odota hetki';
+        const $buttons = $('.project-form.form-controls');
+        const isValidationButtonVisible = $buttons.find('#validate-button').is(':visible');
+        const validateBtn = _.includes(startupParameters.roles, 'dev')
+          ? `<button id="validate-button" title="" class="validate btn btn-block btn-recalculate"${isValidationButtonVisible ? '' : ' hidden="true"'}>Validoi projekti</button>`
+          : '';
+        $buttons.html(`${validateBtn}
+          <button disabled id="recalculate-button" title="${recalcBtnTitle}" class="recalculate btn btn-block btn-recalculate">Päivitä etäisyyslukemat</button>
+          <button disabled id="changes-button" class="show-changes btn btn-block btn-show-changes">Avaa projektin yhteenvetotaulukko</button>
+          <button disabled id="send-button" class="send btn btn-block btn-send">Hyväksy tieosoitemuutokset</button>`);
+      });
+
+      // Re-evaluate button states once the fetch after a save has completed.
+      // Guard with isSaveInFlight so regular project-open fetches don't override the existing button state.
+      eventbus.on('roadAddressProject:fetched', function () {
+        if (currentProject && isSaveInFlight) {
+          isSaveInFlight = false;
+          buttonsWhenOpenProject();
+        }
+      });
+
 
       rootElement.on('click', '#editProjectSpan', currentProject, function () {
         applicationModel.setSelectedTool(ViiteEnumerations.Tool.Default.value);

--- a/viite-UI/src/view/ProjectLinkLayer.js
+++ b/viite-UI/src/view/ProjectLinkLayer.js
@@ -10,6 +10,17 @@
     var lifecycleStatus = ViiteEnumerations.lifecycleStatus;
     var isNotEditingData = true;
     var isActiveLayer = false;
+    var isSaveInFlight = false;
+
+    // IDs of links currently being saved; locked against selection until the next fetch completes
+    var lockedLinkIds = [];
+    var isLocked = function (linkData) {
+      if (!linkData || lockedLinkIds.length === 0) return false;
+      return _.includes(lockedLinkIds, linkData.id) || _.includes(lockedLinkIds, linkData.linkId);
+    };
+    var isLockedId = function (id) {
+      return lockedLinkIds.length > 0 && _.includes(lockedLinkIds, id);
+    };
 
     var projectLinkStyler = new ProjectLinkStyler();
 
@@ -144,6 +155,10 @@
             projectRoadAddressChangeTypeIn(selectionTarget.linkData, possibleStatusForSelection) || selectionTarget.linkData.roadClass === RoadClass.NoClass.value);
         else return false;
       });
+      if (selection && isLocked(selection.linkData)) {
+        selectSingleClick.getFeatures().remove(selection);
+        return;
+      }
       if (modPressed) {
         showDoubleClickChanges(modPressed, selection);
       } else if (isNotEditingData) {
@@ -160,7 +175,12 @@
     var showSingleClickChanges = function (ctrlPressed, selection) {
       if (ctrlPressed && !_.isUndefined(selection) && !_.isUndefined(selectedProjectLinkProperty.get())) {
         if (canBeAddedToSelection(selection.linkData)) {
-          var clickedIds = projectCollection.getMultiProjectLinks(getSelectedId(selection.linkData));
+
+          // Filter locked links out of selection group
+          var clickedIds = projectCollection
+            .getMultiProjectLinks(getSelectedId(selection.linkData))
+            .filter(id => !isLockedId(id));
+            
           var selectedLinkIds = _.map(selectedProjectLinkProperty.get(), function (selected) {
             return getSelectedId(selected);
           });
@@ -176,7 +196,16 @@
         selectedProjectLinkProperty.clean();
         projectCollection.setTmpDirty([]);
         projectCollection.setDirty([]);
-        selectedProjectLinkProperty.open(getSelectedId(selection.linkData), true);
+        var selectedId = getSelectedId(selection.linkData);
+        var groupIds = projectCollection.getMultiProjectLinks(selectedId);
+        var unlockedGroupIds = _.reject(groupIds, isLockedId);
+        if (unlockedGroupIds.length === 0) {
+          return; // entire group is locked
+        } else if (unlockedGroupIds.length === groupIds.length) {
+          selectedProjectLinkProperty.open(selectedId, true);
+        } else {
+          selectedProjectLinkProperty.openCtrl(unlockedGroupIds);
+        }
       } else {
         eventbus.trigger('roadAddressProject:discardChanges'); // Background map was clicked so discard changes
       }
@@ -205,6 +234,10 @@
             selectionTarget.linkData.lifecycleStatus === lifecycleStatus.UnderConstruction.value)
         );
       });
+      if (selection && isLocked(selection.linkData)) {
+        selectDoubleClick.getFeatures().remove(selection);
+        return;
+      }
       if (isNotEditingData) {
         showDoubleClickChanges(ctrlPressed, selection);
       } else {
@@ -338,6 +371,16 @@
         return;
       }
       eventbus.trigger('overlay:update', event, pixel);
+
+      // Set mouse cursor to loading animation if hovering over locked links
+      if (lockedLinkIds.length > 0) {
+        var hasLockedFeature = map.forEachFeatureAtPixel(pixel, function (feature) {
+          return feature.linkData && isLocked(feature.linkData);
+        });
+        map.getViewport().style.cursor = hasLockedFeature ? 'wait' : '';
+      } else {
+        map.getViewport().style.cursor = '';
+      }
     });
 
     var showLayer = function () {
@@ -387,10 +430,10 @@
       projectCollection.fetch(map.getView().calculateExtent(map.getSize()).join(','), zoomlevels.getViewZoom(map) + 1, undefined, projectCollection.getPublishableStatus());
     });
 
-    me.eventListener.listenTo(eventbus, 'projectLink:revertedChanges', function (response) {
+    me.eventListener.listenTo(eventbus, 'projectLink:revertedChanges', function (response, revertedLinks) {
       isNotEditingData = true;
       selectedProjectLinkProperty.setDirty(false);
-      eventbus.trigger('roadAddress:projectLinksUpdated', response, { linkIds: response.formedInfo || [] });
+      eventbus.trigger('roadAddress:projectLinksUpdated', response, revertedLinks || { ids: [], linkIds: [] });
       projectCollection.fetch(map.getView().calculateExtent(map.getSize()).join(','), zoomlevels.getViewZoom(map) + 1, undefined, projectCollection.getPublishableStatus());
     });
 
@@ -510,11 +553,18 @@
       projectCollection.fetch(map.getView().calculateExtent(map.getSize()).join(','), zoomlevels.getViewZoom(map) + 1, projectId, projectCollection.getPublishableStatus());
     });
 
+    me.eventListener.listenTo(eventbus, 'roadAddressProject:lockLinks', function (ids, linkIds) {
+      lockedLinkIds = (ids || []).concat(linkIds || []);
+    });
+
     me.eventListener.listenTo(eventbus, 'roadAddressProject:fetched', function () {
+      isSaveInFlight = false;
       eventbus.trigger('layers:removeViewModeFeaturesFromTheLayers'); // view mode features should not be shown to user in project mode
       me.redraw();
       _.defer(function () {
         highlightFeatures();
+        lockedLinkIds = [];
+        map.getViewport().style.cursor = '';
       });
     });
 
@@ -557,6 +607,11 @@
 
     me.eventListener.listenTo(eventbus, 'roadAddressProject:enableInteractions', function () {
       addSelectInteractions();
+    });
+
+    me.eventListener.listenTo(eventbus, 'roadAddressProject:linksSaving', function () {
+      isSaveInFlight = true;
+      clearHighlights();
     });
 
     me.eventListener.listenTo(eventbus, 'roadAddressProject:clearOnClose', function () {


### PR DESCRIPTION
Poistettu spinneri overlay, joka ei muutenkaan estänyt projektilinkin tupla muokkausta. Nyt muokatut linkit "lukitaan", kunnes ne on backendissa käsitelty. Testattu eri toimenpiteillä ja projekteilla.