### PR TITLE
VIITE-3968 Fix project link form numbering state and validate form based on action type

### DIFF
--- a/viite-UI/src/view/ProjectEditForm.js
+++ b/viite-UI/src/view/ProjectEditForm.js
@@ -466,6 +466,57 @@
           }
         }
 
+        // For "Ennallaan" and "Numerointi", enforce action-specific field constraints.
+        if (changeType.value === RoadAddressChangeType.Unchanged.value || changeType.value === RoadAddressChangeType.Numbering.value) {
+          
+          const isUnchanged = changeType.value === RoadAddressChangeType.Unchanged.value;
+          const isNumbering = changeType.value === RoadAddressChangeType.Numbering.value;
+
+          const currentRoadNumber = Number($('#tie').val());
+          const currentRoadPartNumber = Number($('#osa').val());
+          const currentTrackCode = Number($('#trackCodeDropdown').val());
+
+          const uniqueValues = (key) =>
+            _.chain(selectedProjectLink)
+              .map(link => Number(link[key]))
+              .uniq()
+              .value();
+
+          const expectedRoadNumbers = uniqueValues('roadNumber');
+          const expectedRoadPartNumbers = uniqueValues('roadPartNumber');
+          const expectedTrackCodes = uniqueValues('trackCode');
+
+          const roadNumberMismatch = isUnchanged && !expectedRoadNumbers.includes(currentRoadNumber);
+          const roadPartNumberMismatch = isUnchanged && !expectedRoadPartNumbers.includes(currentRoadPartNumber);
+          const trackCodeMismatch = !expectedTrackCodes.includes(currentTrackCode);
+
+          const hasMismatch = roadNumberMismatch || roadPartNumberMismatch || trackCodeMismatch;
+
+          if (hasMismatch) {
+            const formatExpected = (values) => values.length === 1 ? values[0] : values.join(' / ');
+
+            const changes = [roadPartNumberMismatch &&
+                `Muuta osa ${currentRoadPartNumber} -> ${formatExpected(expectedRoadPartNumbers)}`,
+
+              roadNumberMismatch &&
+                `Muuta tie ${currentRoadNumber} -> ${formatExpected(expectedRoadNumbers)}`,
+
+              trackCodeMismatch &&
+                `Muuta ajr ${currentTrackCode} -> ${formatExpected(expectedTrackCodes)}`
+            ].filter(Boolean);
+
+            console.log(`Validation failed with the following changes: ${changes.join('; ')}`);
+
+            return new ModalConfirm(
+              `${
+                isUnchanged
+                  ? 'Ennallaan-toimenpiteellä tie, osa ja ajr eivät saa muuttua.'
+                  : 'Numerointi-toimenpiteellä ajr ei saa muuttua.'
+              }<br>${changes.join('<br>')}`
+            );
+          }
+        }
+
         if (changeType.value === RoadAddressChangeType.Revert.value) {
           projectCollection.revertChangesRoadlink(selectedProjectLink);
         } else {
@@ -621,6 +672,8 @@
           case RoadAddressChangeType.Numbering.description:
             uiElements.devTool.prop('hidden', false);
             new ModalConfirm("Numerointi koskee kokonaista tieosaa. Valintaasi on tarvittaessa laajennettu koko tieosalle.");
+            formControls.tie.prop('disabled', false);
+            formControls.osa.prop('disabled', false);
             formControls.trackCode.prop('disabled', true);
             formControls.discontinuity.prop('disabled', false);
             formControls.adminClass.prop('disabled', true);


### PR DESCRIPTION
Kun projektilinkin muutoksia yritetään tallentaa, validoidaan, että muutokset vastaavat muutostyyppiä. Jos ei, annetaan käyttäjälle varoitus:
<img width="317" height="179" alt="image" src="https://github.com/user-attachments/assets/80580593-1652-4175-a97c-5695ab02a125" />

<img width="314" height="118" alt="image" src="https://github.com/user-attachments/assets/1dfde8e4-ab75-4584-88e2-cb3706f04448" />


Sen lisäksi korjattu bugi, missä ennallaan -> numerointi toiminnot aiheuttivat tieosan ja tien disabloinnin.

