### PR TITLE
VIITE-3970 Fix project edit layer switch

### DIFF
--- a/viite-UI/src/router.js
+++ b/viite-UI/src/router.js
@@ -111,12 +111,17 @@
         var linkIdUrl = linkId ? '/' + linkId : '';
         router.navigate(baseUrl + linkIdUrl);
         var initialCenter = map.getView().getCenter();
+        var alreadyInProjectMode = applicationModel.getSelectedLayer() === 'roadAddressProject';
         if (!_.isUndefined(project.coordX) && project.coordX !== 0 && !_.isUndefined(project.coordY) && project.coordY !== 0 && !_.isUndefined(project.zoomLevel) && project.zoomLevel !== 0) {
-          applicationModel.selectLayer('linkProperty', false);
+          if (!alreadyInProjectMode) {
+            applicationModel.selectLayer('linkProperty', false);
+          }
           map.getView().setCenter([project.coordX, project.coordY]);
           map.getView().setZoom(project.zoomLevel);
         } else if (typeof linkId !== 'undefined') {
-          applicationModel.selectLayer('linkProperty', false);
+          if (!alreadyInProjectMode) {
+            applicationModel.selectLayer('linkProperty', false);
+          }
           backend.getProjectLinkByLinkId(linkId, function (response) {
             map.getView().setCenter([response.middlePoint.x, response.middlePoint.y]);
           });

--- a/viite-UI/src/view/ProjectForm.js
+++ b/viite-UI/src/view/ProjectForm.js
@@ -564,11 +564,13 @@
         disableAutoComplete();
       });
 
-      eventbus.on('roadAddress:openProject', function (result) {
+      eventbus.on('roadAddress:openProject', function (result, isEdited) {
         currentProject = result.project;
         projectCollection.setAndWriteProjectErrorsToUser(result.projectErrors);
         currentProject.isDirty = false;
-        projectCollection.clearRoadAddressProjects();
+        if (!isEdited) {
+          projectCollection.clearRoadAddressProjects();
+        }
         disableAutoComplete();
         projectCollection.setCurrentProject(result);
         projectCollection.setReservedParts(result.reservedInfo);
@@ -678,7 +680,8 @@
           rootElement.empty();
           setTimeout(function () {
           }, 0);
-          eventbus.trigger('roadAddress:openProject', result);
+          const isEdited = true;
+          eventbus.trigger('roadAddress:openProject', result, isEdited);
           if (applicationModel.isReadOnly()) {
             $('.edit-mode-btn:visible').click();
           }


### PR DESCRIPTION
Korjattu bugi, missä projektin muokkaus napin painaminen vaihtoi OpenLayers kerroksen väärin, joka sekoitti Viitteen projekti menun.