### PR TITLE
Viite 3968 fix project link action state and validation

### DIFF
--- a/viite-UI/src/view/ProjectEditForm.js
+++ b/viite-UI/src/view/ProjectEditForm.js
@@ -149,6 +149,25 @@
     const isProjectPublishable = () => projectCollection.getPublishableStatus();
     const isProjectEditable = () => _.includes(editableStatus, projectCollection.getCurrentProject().project.statusCode);
 
+    const originalLinksStorageKey = (projectId) => `original_links_${projectId}`;
+
+    // Used for form validation
+    const getStoredOriginalLinks = (projectId) => {
+      // Original link values contains road part, number and track code for each link in the project when it was first opened in the edit form.
+      const originalLinkValues = sessionStorage.getItem(originalLinksStorageKey(projectId));
+      if (!originalLinkValues) return {};
+      try {
+        const parsed = JSON.parse(originalLinkValues);
+        return _.isObject(parsed) ? parsed : {};
+      } catch (e) {
+        return {};
+      }
+    };
+
+    const setStoredOriginalLinks = (projectId, linksByLinkId) => {
+      sessionStorage.setItem(originalLinksStorageKey(projectId), JSON.stringify(linksByLinkId));
+    };
+
     const checkInputs = () => {
       const rootElement = $('#feature-attributes');
       const inputs = rootElement.find('input');
@@ -327,6 +346,30 @@
         if (roadwayCheckbox) {
           roadwayCheckbox.dataset.initialValue = roadwayCheckbox.checked ? '1' : '0';
         }
+
+        // Store original road address values in one sessionStorage object per project.
+        // Persist only once per link so later re-open/saves do not overwrite originals.
+        if (selectedProjectLink && selectedProjectLink.length > 0) {
+          const currentProjectId = projectCollection.getCurrentProject().project.id;
+          const storedOriginalLinks = getStoredOriginalLinks(currentProjectId);
+          let hasChanges = false;
+
+          // If any of the selected links are not yet stored in sessionStorage, add them with their current values.
+          _.each(selectedProjectLink, (link) => {
+            if (!storedOriginalLinks[link.linkId]) {
+              storedOriginalLinks[link.linkId] = {
+                roadNumber: link.roadNumber,
+                roadPartNumber: link.roadPartNumber,
+                trackCode: link.trackCode
+              };
+              hasChanges = true;
+            }
+          });
+
+          if (hasChanges) {
+            setStoredOriginalLinks(currentProjectId, storedOriginalLinks);
+          }
+        }
       };
 
       eventbus.on('projectLink:errorClicked', (selected, errorMessage) => {
@@ -479,14 +522,33 @@
           const currentRoadPartNumber = Number($('#osa').val());
           const currentTrackCode = Number($('#trackCodeDropdown').val());
 
-          const uniqueValues = (key) => _.chain(selectedProjectLink)
-              .map(link => Number(link[key]))
-              .uniq()
-              .value();
+          // Get original values for all selected links from sessionStorage.
+          const currentProjectId = projectCollection.getCurrentProject().project.id;
+          const storedOriginalLinks = getStoredOriginalLinks(currentProjectId);
+          const storedOriginals = selectedProjectLink.map((link) => {
+            const stored = storedOriginalLinks[link.linkId];
 
-          const expectedRoadNumbers = uniqueValues('roadNumber');
-          const expectedRoadPartNumbers = uniqueValues('roadPartNumber');
-          const expectedTrackCodes = uniqueValues('trackCode');
+            if (stored) { return stored; }
+
+            return {
+              roadNumber: link.roadNumber,
+              roadPartNumber: link.roadPartNumber,
+              trackCode: link.trackCode
+            };
+          });
+
+          const expectedRoadNumbers = _.chain(storedOriginals)
+            .map(original => Number(original.roadNumber))
+            .uniq()
+            .value();
+          const expectedRoadPartNumbers = _.chain(storedOriginals)
+            .map(original => Number(original.roadPartNumber))
+            .uniq()
+            .value();
+          const expectedTrackCodes = _.chain(storedOriginals)
+            .map(original => Number(original.trackCode))
+            .uniq()
+            .value();
 
           const roadNumberMismatch = isUnchanged && !expectedRoadNumbers.includes(currentRoadNumber);
           const roadPartNumberMismatch = isUnchanged && !expectedRoadPartNumbers.includes(currentRoadPartNumber);
@@ -506,8 +568,6 @@
               trackCodeMismatch &&
                 `Muuta ajr ${currentTrackCode} -> ${formatExpected(expectedTrackCodes)}`
             ].filter(Boolean);
-
-            console.log(`Validation failed with the following changes: ${changes.join('; ')}`);
 
             return new ModalConfirm(
               `${

--- a/viite-UI/src/view/ProjectEditForm.js
+++ b/viite-UI/src/view/ProjectEditForm.js
@@ -466,6 +466,57 @@
           }
         }
 
+        // For "Ennallaan" and "Numerointi", enforce action-specific field constraints.
+        if (changeType.value === RoadAddressChangeType.Unchanged.value || changeType.value === RoadAddressChangeType.Numbering.value) {
+          
+          const isUnchanged = changeType.value === RoadAddressChangeType.Unchanged.value;
+          const isNumbering = changeType.value === RoadAddressChangeType.Numbering.value;
+
+          const currentRoadNumber = Number($('#tie').val());
+          const currentRoadPartNumber = Number($('#osa').val());
+          const currentTrackCode = Number($('#trackCodeDropdown').val());
+
+          const uniqueValues = (key) =>
+            _.chain(selectedProjectLink)
+              .map(link => Number(link[key]))
+              .uniq()
+              .value();
+
+          const expectedRoadNumbers = uniqueValues('roadNumber');
+          const expectedRoadPartNumbers = uniqueValues('roadPartNumber');
+          const expectedTrackCodes = uniqueValues('trackCode');
+
+          const roadNumberMismatch = isUnchanged && !expectedRoadNumbers.includes(currentRoadNumber);
+          const roadPartNumberMismatch = isUnchanged && !expectedRoadPartNumbers.includes(currentRoadPartNumber);
+          const trackCodeMismatch = !expectedTrackCodes.includes(currentTrackCode);
+
+          const hasMismatch = roadNumberMismatch || roadPartNumberMismatch || trackCodeMismatch;
+
+          if (hasMismatch) {
+            const formatExpected = (values) => values.length === 1 ? values[0] : values.join(' / ');
+
+            const changes = [roadPartNumberMismatch &&
+                `Muuta osa ${currentRoadPartNumber} -> ${formatExpected(expectedRoadPartNumbers)}`,
+
+              roadNumberMismatch &&
+                `Muuta tie ${currentRoadNumber} -> ${formatExpected(expectedRoadNumbers)}`,
+
+              trackCodeMismatch &&
+                `Muuta ajr ${currentTrackCode} -> ${formatExpected(expectedTrackCodes)}`
+            ].filter(Boolean);
+
+            console.log(`Validation failed with the following changes: ${changes.join('; ')}`);
+
+            return new ModalConfirm(
+              `${
+                isUnchanged
+                  ? 'Ennallaan-toimenpiteellä tie, osa ja ajr eivät saa muuttua.'
+                  : 'Numerointi-toimenpiteellä ajr ei saa muuttua.'
+              }<br>${changes.join('<br>')}`
+            );
+          }
+        }
+
         if (changeType.value === RoadAddressChangeType.Revert.value) {
           projectCollection.revertChangesRoadlink(selectedProjectLink);
         } else {
@@ -621,6 +672,8 @@
           case RoadAddressChangeType.Numbering.description:
             uiElements.devTool.prop('hidden', false);
             new ModalConfirm("Numerointi koskee kokonaista tieosaa. Valintaasi on tarvittaessa laajennettu koko tieosalle.");
+            formControls.tie.prop('disabled', false);
+            formControls.osa.prop('disabled', false);
             formControls.trackCode.prop('disabled', true);
             formControls.discontinuity.prop('disabled', false);
             formControls.adminClass.prop('disabled', true);


### PR DESCRIPTION
Jokaiselle projektille tallennetaan ID:n perusteella oma objekti session storageen, johon lisätään käyttäjän valitsemien linkkien ID:t ja niiden tie, osa ja ajr tiedot. Tällöin toimenpide validointi "muistaa" oikeat alkuperäisarvot, vaikka käyttäjä päivittäisi sivun.