### PR TITLE
VIITE-3972 Fix numbering validation

### DIFF
--- a/db/admin/Get-ProjectLinks.ps1
+++ b/db/admin/Get-ProjectLinks.ps1
@@ -1,0 +1,71 @@
+<#
+.SYNOPSIS
+    Query project_link rows for a given project name from the local viite database.
+.PARAMETER ProjectName
+    Project name to search for (case-insensitive, partial match).
+.PARAMETER Csv
+    Output results as CSV instead of aligned table.
+.EXAMPLE
+    .\Get-ProjectLinks.ps1 "Vt4 parannus"
+    .\Get-ProjectLinks.ps1 "Vt4" -Csv
+#>
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [string]$ProjectName,
+
+    [switch]$Csv
+)
+
+$container = 'postgis-viite'
+
+$running = docker inspect --format "{{.State.Running}}" $container 2>$null
+if ($LASTEXITCODE -ne 0 -or $running -ne 'true') {
+    Write-Error "Container '$container' is not running. Start it with:`n  docker compose -f local-dev/postgis/docker-compose.yaml up -d"
+    exit 1
+}
+
+# Escape single quotes so project names with apostrophes don't break the query
+$safeName = $ProjectName -replace "'", "''"
+
+$sql = @"
+SELECT
+  p.name                                               AS project_name,
+  pl.road_number,
+  pl.road_part_number,
+  CASE pl.track
+    WHEN 0  THEN '0-Yhdistetty'  WHEN 1  THEN '1-Oikea'
+    WHEN 2  THEN '2-Vasen'       WHEN 99 THEN '99-Tuntematon'
+    ELSE pl.track::text END                            AS track,
+  pl.start_addr_m,
+  pl.end_addr_m,
+  pl.original_start_addr_m,
+  pl.original_end_addr_m,
+  CASE pl.status
+    WHEN 0  THEN '0-Kasittelematon'  WHEN 1  THEN '1-Ennallaan'
+    WHEN 2  THEN '2-Uusi'            WHEN 3  THEN '3-Siirto'
+    WHEN 4  THEN '4-Numerointi'      WHEN 5  THEN '5-Lakkautus'
+    WHEN 99 THEN '99-Tuntematon'
+    ELSE pl.status::text END                           AS status,
+  CASE pl.discontinuity_type
+    WHEN 1 THEN '1-Tien loppu'        WHEN 2 THEN '2-Epajatkuva'
+    WHEN 3 THEN '3-EVK-raja'          WHEN 4 THEN '4-Lieva epajatkuvuus'
+    WHEN 5 THEN '5-Jatkuva'
+    ELSE pl.discontinuity_type::text END               AS discontinuity,
+  pl.link_id,
+  pl.start_measure,
+  pl.end_measure,
+  pl.reversed,
+  pl.created_by,
+  pl.modified_by,
+  pl.modified_date
+FROM project_link pl
+JOIN project p ON p.id = pl.project_id
+WHERE p.name ILIKE '%$safeName%'
+ORDER BY pl.road_number, pl.road_part_number, pl.track, pl.start_addr_m;
+"@
+
+if ($Csv) {
+    $sql | docker exec -i $container psql -U viite -d viite --csv
+} else {
+    $sql | docker exec -i $container psql -U viite -d viite
+}

--- a/viite-UI/src/view/ProjectChangeTable.js
+++ b/viite-UI/src/view/ProjectChangeTable.js
@@ -191,7 +191,6 @@
     }
 
     function showChangeTable(projectChangeData) {
-      console.log(projectChangeData);
       var htmlTable = "";
       var warningM = projectChangeData.warningMessage;
       var hasLengthMismatch = false;

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -1780,7 +1780,6 @@ def setCalibrationPoints(startCp: Long, endCp: Long, projectLinks: Seq[ProjectLi
             } else
               Seq.empty[ProjectCalibrationPoint]
           })
-
           roadAddressChangeType match {
             case RoadAddressChangeType.Termination =>
               if (devToolData.isDefined) {
@@ -1807,7 +1806,7 @@ def setCalibrationPoints(startCp: Long, endCp: Long, projectLinks: Seq[ProjectLi
                   throw new ProjectValidationException(ErrorMultipleRoadNumbersOrParts)
                 }
                 // Check for conflicting actions on the same original road part.
-                val originalRoadPart = toUpdateLinks.head.roadAddressRoadPart
+                val originalRoadPart = toUpdateLinks.head.roadAddressRoadPart.getOrElse(toUpdateLinks.head.roadPart)
                 val roadPartLinks = projectLinkDAO.fetchProjectLinksByOriginalRoadPart(originalRoadPart, projectId)
                 if (roadPartLinks.exists(rpl => rpl.status != RoadAddressChangeType.Renumeration && rpl.status != RoadAddressChangeType.NotHandled)) {
                   throw new ProjectValidationException(ErrorOtherActionWithNumbering)

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -1780,7 +1780,7 @@ def setCalibrationPoints(startCp: Long, endCp: Long, projectLinks: Seq[ProjectLi
             } else
               Seq.empty[ProjectCalibrationPoint]
           })
-        println(s"${roadAddressChangeType}")
+
           roadAddressChangeType match {
             case RoadAddressChangeType.Termination =>
               if (devToolData.isDefined) {
@@ -1806,8 +1806,10 @@ def setCalibrationPoints(startCp: Long, endCp: Long, projectLinks: Seq[ProjectLi
                     roadAddresses.map(ra => (ra.roadPart)).distinct.lengthCompare(1) != 0) {
                   throw new ProjectValidationException(ErrorMultipleRoadNumbersOrParts)
                 }
-                val roadPartLinks = projectLinkDAO.fetchProjectLinksByProjectRoadPart(toUpdateLinks.head.roadPart, projectId)
-                if (roadPartLinks.exists(rpl => rpl.status == RoadAddressChangeType.Unchanged || rpl.status == RoadAddressChangeType.Transfer || rpl.status == RoadAddressChangeType.New || rpl.status == RoadAddressChangeType.Termination)) {
+                // Check for conflicting actions on the same original road part.
+                val originalRoadPart = toUpdateLinks.head.roadAddressRoadPart
+                val roadPartLinks = projectLinkDAO.fetchProjectLinksByOriginalRoadPart(originalRoadPart, projectId)
+                if (roadPartLinks.exists(rpl => rpl.status != RoadAddressChangeType.Renumeration && rpl.status != RoadAddressChangeType.NotHandled)) {
                   throw new ProjectValidationException(ErrorOtherActionWithNumbering)
                 }
                 val (reservationNotNeeded, oldRoadPart) = checkAndMakeReservation(projectId, newRoadPart, RoadAddressChangeType.Renumeration, toUpdateLinks)

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/ProjectLinkDAO.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/ProjectLinkDAO.scala
@@ -807,6 +807,23 @@ class ProjectLinkDAO extends BaseDAO {
     }
   }
 
+  /** Fetches all project links in the given project whose ORIGINAL road part (from the roadway table)
+    * matches the given roadPart. This finds links regardless of whether they have been moved to a
+    * different current road part via Transfer or Renumeration. */
+  def fetchProjectLinksByOriginalRoadPart(roadPart: RoadPart, projectId: Long): Seq[ProjectLink] = {
+    time(logger, "Get project links by original road part") {
+      val query =
+        sql"""
+              $projectLinkQueryBase
+              WHERE roadway.road_number = ${roadPart.roadNumber}
+              AND roadway.road_part_number = ${roadPart.partNumber}
+              AND project_link.project_id = $projectId
+              ORDER BY project_link.road_number, project_link.road_part_number, project_link.end_addr_m
+              """
+      listQuery(query)
+    }
+  }
+
   def fetchByProjectRoadPart(roadPart: RoadPart, projectId: Long): Seq[ProjectLink] = {
     time(logger, "Fetch project links by project road part") {
       val filter = sqls"project_link.road_number = ${roadPart.roadNumber} AND project_link.road_part_number = ${roadPart.partNumber} AND"

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/process/ProjectDeltaCalculator.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/process/ProjectDeltaCalculator.scala
@@ -210,7 +210,9 @@ object ProjectDeltaCalculator {
     else {
       val sortedProjectLinks = pls.sortBy(_.originalAddrMRange.start)
       val terminatedProjectLinks = sortedProjectLinks.takeWhile {_.status == RoadAddressChangeType.Termination}
-      if (terminatedProjectLinks.nonEmpty)
+      // Only return a boundary link if the terminated section starts at the road-part start (addr 0).
+      // A track whose terminated links begin mid-part must NOT be paired for averaging, because the two tracks cover different address ranges.
+      if (terminatedProjectLinks.nonEmpty && terminatedProjectLinks.head.originalAddrMRange.isRoadPartStart)
         Seq(terminatedProjectLinks.last)
       else
         Seq()


### PR DESCRIPTION
Alkuperäinen koodi teki numerointi validoinnin perustuen nykyisten projektilinkkien tienumeroon, jolloin tieosaa siirrettyjä linkkejä ei huomioitu. Muutosten myötä validointi löytää myös siirretyt projektilinkit.

Testit ajettu läpi.