### PR TITLE
Changes to road address fetching for browser. 

### DIFF
--- a/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
+++ b/viite-backend/api/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
@@ -13,7 +13,7 @@ import fi.liikennevirasto.viite.model._
 import fi.liikennevirasto.viite.util.DigiroadSerializers
 import fi.vaylavirasto.viite.dao.{RoadName, RoadNameForRoadAddressBrowser}
 import fi.vaylavirasto.viite.geometry.{BoundingRectangle, GeometryUtils, Point}
-import fi.vaylavirasto.viite.model.ArealRoadMaintainer.{getELYNumber, getEVKNumber, isEVK}
+import fi.vaylavirasto.viite.model.ArealRoadMaintainer.{getELYNumber, getEVKNumber}
 import fi.vaylavirasto.viite.model.{AddrMRange, AdministrativeClass, ArealRoadMaintainer, BeforeAfter, Discontinuity, LinkGeomSource, NodePointType, NodeType, RoadAddressChangeType, RoadPart, Track}
 import fi.vaylavirasto.viite.postgis.PostGISDatabaseScalikeJDBC
 import fi.vaylavirasto.viite.util.DateTimeFormatters.{ISOdateFormatter, dateSlashFormatter, finnishDateCommaTimeFormatter, finnishDateFormatter}

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/AddressLinkBuilder.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/AddressLinkBuilder.scala
@@ -15,17 +15,13 @@ trait AddressLinkBuilder {
 
   /** Viite municipality to EVK code mapping */
   def municipalityToViiteEVKMapping: Map[Long, String] = {
-   // println(s"Fetching municipality to EVK mapping from database")
-    val result = runWithReadOnlySession {
+  runWithReadOnlySession {
       MunicipalityDAO.getViiteMunicipalityToEvkMapping
     }
-   // println(s"Fetched ${result.size} municipality to EVK mappings from database")
-   // result.foreach(r => println(s"Municipality code: ${r._1}, EVK code: ${r._2}"))
-    result
   }
 
   def municipalityNamesMapping: Map[Long, String] = {
-    runWithReadOnlySession {
+  runWithReadOnlySession {
       MunicipalityDAO.getMunicipalityNames
     }
   }

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -4,13 +4,13 @@ import fi.liikennevirasto.digiroad2.DigiroadEventBus
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.util.{RoadAddressException, RoadPartReservedException}
 import fi.liikennevirasto.digiroad2.util.LogUtils.time
-import fi.liikennevirasto.viite.ProjectAddressLinkBuilder.{municipalityToViiteELYMapping, municipalityToViiteEVKMapping}
+import fi.liikennevirasto.viite.ProjectAddressLinkBuilder.municipalityToViiteEVKMapping
 import fi.liikennevirasto.viite.dao._
 import ProjectCalibrationPointDAO.UserDefinedCalibrationPoint
 import fi.liikennevirasto.viite.dao.ProjectState._
 import fi.liikennevirasto.viite.model.{ProjectAddressLink, RoadAddressLink}
 import fi.liikennevirasto.viite.process._
-import fi.liikennevirasto.viite.process.strategy.TwoTrackAverager.{averageTwoTrackBoundaries}
+import fi.liikennevirasto.viite.process.strategy.TwoTrackAverager.averageTwoTrackBoundaries
 import fi.vaylavirasto.viite.dao.{LinkDAO, ProjectLinkNameDAO, RoadName, RoadNameDAO, Sequences}
 import fi.vaylavirasto.viite.geometry.{BoundingRectangle, GeometryUtils, Point}
 import fi.vaylavirasto.viite.model.CalibrationPointType.{JunctionPointCP, NoCP, UserDefinedCP}
@@ -22,8 +22,7 @@ import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
 
 import java.sql.SQLException
-import scala.collection.mutable.ListBuffer
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
@@ -301,7 +300,7 @@ class ProjectService(
     * If it does not then we check if this project is able to reserve the combination.
     * If the combination is already reserved in this project we simply return their parts, if not we validate the project date with the dates of the road parts.
     * If the validation of the date passes then we return these road parts.
-    * IN ANY OTHER INSTANCE we return a error message detailing what the problem was
+    * IN ANY OTHER INSTANCE we return an error message detailing what the problem was
     *
     * @param roadNumber  : Long
     * @param startPart   : Long - road part number of the start of the reservation
@@ -686,7 +685,7 @@ class ProjectService(
     * @param linkIds   the linkIds to process
     * @param roadPart  the roadPart to apply/was applied to said linkIds
     * @param newLinks  new project links for this ramp
-    * @return the projectLinks with a assigned SideCode
+    * @return the projectLinks with an assigned SideCode
     */
   private def fillRampGrowthDirection(linkIds: Set[String], roadPart: RoadPart, newLinks: Seq[ProjectLink], firstLinkId: String, existingLinks: Seq[ProjectLink]) = {
     if (newLinks.exists(nl => existingLinks.exists(pl => pl.status != RoadAddressChangeType.Termination &&
@@ -716,7 +715,7 @@ class ProjectService(
   }
 
   /**
-    * Main method of reversing the direction of a already created project link.
+    * Main method of reversing the direction of an already created project link.
     * 1st check if the project is writable in the current session, if it is then we check if there still are project links that are unchanged of unhandled, if there are none then the process continues by getting all the discontinuities of all project links.
     * After that we run the query to reverse the directions, after it's execution we re-fetch the project links (minus the terminated ones) and the original information of the roads.
     * Using said information we run an all project links of that project to update the "reversed" tag when relative to the side codes of the original roadways.
@@ -730,7 +729,8 @@ class ProjectService(
     * @return
     */
   def changeDirection(projectId: Long, roadPart: RoadPart, links: Seq[LinkToRevert], coordinates: ProjectCoordinates, username: String): Option[String] = {
-    roadAddressLinkBuilder.municipalityToViiteELYMapping // make sure it is populated outside of this TX
+   // roadAddressLinkBuilder.municipalityToViiteELYMapping // make sure it is populated outside of this TX
+    roadAddressLinkBuilder.municipalityToViiteEVKMapping
     try {
       runWithTransaction {
         projectWritableCheckInSession(projectId) match {
@@ -790,7 +790,7 @@ class ProjectService(
 
   /**
     * Adds reserved road links (from road parts) to a road address project. Clears
-    * project links that are no longer reserved for the project. Reservability is check before this.
+    * project links that are no longer reserved for the project. Reservability is checked before this.
     * for each reserved part get all roadways
     * validate if the road exists on the roadway table and if there isn't different ely codes reserved
     * in case there is, throw roadPartReserved exception
@@ -1124,7 +1124,11 @@ class ProjectService(
     }
     val nonProjectRoadLinks = (normalLinks ++ complementaryLinks).filterNot(rl => projectRoadLinks.exists(_.linkId == rl.linkId)) //    val buildEndTime = System.currentTimeMillis()
 
-    val filledTopology = RoadAddressFiller.fillTopology(nonProjectRoadLinks, addresses.values.flatten.toSeq)
+    val municipalityMapping = ProjectAddressLinkBuilder.municipalityToViiteEVKMapping
+
+    val municipalityNameMapping = ProjectAddressLinkBuilder.municipalityNamesMapping
+
+    val filledTopology = RoadAddressFiller.fillTopology(nonProjectRoadLinks, addresses.values.flatten.toSeq, municipalityMapping, municipalityNameMapping)
 
     val complementaryLinkIds = complementaryLinks.map(_.linkId).toSet
     val returningTopology = filledTopology.filter(link => !complementaryLinkIds.contains(link.linkId) ||
@@ -1186,7 +1190,7 @@ class ProjectService(
     val nonProjectAddresses = addresses.filterNot(a => projectLinks.contains(a._1))
 
     val nonProjectLinks = nonProjectAddresses.values.flatten.toSeq.map { address =>
-      address.linkId -> roadAddressLinkBuilder.build(address)
+      address.linkId -> roadAddressLinkBuilder.buildWithRoadAddress(address)
     }.toMap
 
     logger.info("Build road addresses completed in %d ms".format(System.currentTimeMillis() - buildStartTime))

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilder.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilder.scala
@@ -27,12 +27,11 @@ class RoadAddressLinkBuilder(roadwayDAO: RoadwayDAO, linearLocationDAO: LinearLo
 
   private val modifiedBy = "kgvModified"
 
-  def build(roadLink: RoadLinkLike, roadAddress: RoadAddress): RoadAddressLink = {
+  def buildWithRoadLinkAndRoadAddress(roadLink: RoadLinkLike, roadAddress: RoadAddress, municipalityName: String): RoadAddressLink = {
     val geom = GeometryUtils.truncateGeometry3D(roadLink.geometry, roadAddress.startMValue, roadAddress.endMValue)
     val length = GeometryUtils.geometryLength(geom)
     val roadName = roadAddress.roadName
     val municipalityCode = roadLink.municipalityCode
-    val municipalityName = municipalityNamesMapping.getOrElse(municipalityCode, "")
     val administrativeClass = roadAddress.administrativeClass match {
       case AdministrativeClass.Unknown => roadLink.administrativeClass
       case _ => roadAddress.administrativeClass
@@ -67,7 +66,7 @@ class RoadAddressLinkBuilder(roadwayDAO: RoadwayDAO, linearLocationDAO: LinearLo
       sourceId = roadLink.sourceId)
   }
 
-  def build(roadAddress: RoadAddress): RoadAddressLink = {
+  def buildWithRoadAddress(roadAddress: RoadAddress): RoadAddressLink = {
     val geom = roadAddress.geometry
     val length = GeometryUtils.geometryLength(geom)
     val municipalityCode = 0
@@ -102,17 +101,16 @@ class RoadAddressLinkBuilder(roadwayDAO: RoadwayDAO, linearLocationDAO: LinearLo
       sourceId = "")
   }
 
-  def build(roadLink: RoadLinkLike, unaddressedRoadLink: UnaddressedRoadLink): RoadAddressLink = {
+  def buildRoadLinksAndUnAddressedLinks(roadLink: RoadLinkLike, unaddressedRoadLink: UnaddressedRoadLink, roadMaintainer: ArealRoadMaintainer, municipalityName: String): RoadAddressLink = {
     roadLink match {
-      case rl: RoadLink => buildRoadLink(rl, unaddressedRoadLink)
+      case rl: RoadLink => buildRoadLink(rl, unaddressedRoadLink, roadMaintainer, municipalityName)
     }
   }
 
-  private def buildRoadLink(roadLink: RoadLink, unaddressedRoadLink: UnaddressedRoadLink): RoadAddressLink = {
+  private def buildRoadLink(roadLink: RoadLink, unaddressedRoadLink: UnaddressedRoadLink, roadMaintainer: ArealRoadMaintainer, municipalityName: String): RoadAddressLink = {
     val geom = GeometryUtils.truncateGeometry3D(roadLink.geometry, unaddressedRoadLink.startMValue.getOrElse(0.0), unaddressedRoadLink.endMValue.getOrElse(roadLink.length))
     val length = GeometryUtils.geometryLength(geom)
     val municipalityCode = roadLink.municipalityCode
-    val municipalityName = municipalityNamesMapping.getOrElse(municipalityCode, "")
     val administrativeClass = unaddressedRoadLink.administrativeClass match {
       case AdministrativeClass.Unknown => roadLink.administrativeClass
       case _ => unaddressedRoadLink.administrativeClass
@@ -138,7 +136,7 @@ class RoadAddressLinkBuilder(roadwayDAO: RoadwayDAO, linearLocationDAO: LinearLo
       Some("kgv_modified"),
       RoadPart(0, 0),
       Track.Unknown.value,
-      ArealRoadMaintainer.apply(municipalityToViiteEVKMapping.getOrElse(roadLink.municipalityCode, "EVK0")), // TODO: THIS IS ONE POSSIBLE WHERE THE EVK0 BUG MIGHT ORIGINATE FROM
+      roadMaintainer, // TODO: THIS IS ONE POSSIBLE WHERE THE EVK0 BUG MIGHT ORIGINATE FROM
       Discontinuity.Continuous.value,
       AddrMRange(0, 0),
       "",

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
@@ -6,6 +6,7 @@ import fi.liikennevirasto.digiroad2.client.vkm.VKMClient
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.util.LogUtils.time
 import fi.liikennevirasto.digiroad2.util.ViiteProperties
+import fi.liikennevirasto.viite.ProjectAddressLinkBuilder.municipalityNamesMapping
 import fi.liikennevirasto.viite.dao.{RoadwayPointDAO, _}
 import fi.liikennevirasto.viite.model.RoadAddressLink
 import fi.liikennevirasto.viite.process._
@@ -128,6 +129,8 @@ class RoadAddressService(
       }
 
     val allRoadLinks = roadLinks ++ complementaryRoadLinks
+    val municipalityRoadMaintainerMapping = ProjectAddressLinkBuilder.municipalityToViiteEVKMapping
+    val municipalityNamesMapping = ProjectAddressLinkBuilder.municipalityNamesMapping
 
     //removed apply changes before adjusting topology since in future NLS will give perfect geometry and supposedly, we will not need any changes
     val (adjustedLinearLocations, changeSet) = if (frozenKGV) (linearLocations, Seq()) else RoadAddressFiller.adjustToTopology(allRoadLinks, linearLocations)
@@ -137,7 +140,7 @@ class RoadAddressService(
     val roadAddresses = runWithReadOnlySession {
       roadwayAddressMapper.getRoadAddressesByLinearLocation(adjustedLinearLocations)
     }
-    RoadAddressFiller.fillTopology(allRoadLinks, roadAddresses)
+    RoadAddressFiller.fillTopology(allRoadLinks, roadAddresses, municipalityRoadMaintainerMapping, municipalityNamesMapping)
   }
 
   def getRoadAddressWithRoadNumberAddress(road: Long): Seq[RoadAddress] = {
@@ -228,7 +231,7 @@ class RoadAddressService(
       roadwayAddressMapper.getRoadAddressesByLinearLocation(linearLocations)
     }
 
-    roadAddresses.map(roadAddressLinkBuilder.build)
+    roadAddresses.map(roadAddressLinkBuilder.buildWithRoadAddress)
   }
 
   // maximum allowed length difference for VIITE-3083 rounding inconsistency
@@ -242,6 +245,9 @@ class RoadAddressService(
     */
   def getAllByMunicipality(municipality: Int, searchDate: Option[DateTime] = None): Seq[RoadAddressLink] = {
     val (roadLinks, _) = roadLinkService.getRoadLinksWithComplementaryAndChangesFromVVH(municipality)
+
+    val municipalityNames = municipalityNamesMapping
+    val municipalityName = municipalityNames.getOrElse(municipality, "")
 
     val linearLocations = runWithTransaction {
       time(logger, "Fetch addresses") {
@@ -262,7 +268,7 @@ class RoadAddressService(
     roadAddresses.flatMap { ra =>
       val roadLink = roadLinks.find(rl => rl.linkId == ra.linkId)
       roadLink.map(rl => {
-        val ral: RoadAddressLink = roadAddressLinkBuilder.build(rl, ra)
+        val ral: RoadAddressLink = roadAddressLinkBuilder.buildWithRoadLinkAndRoadAddress(rl, ra, municipalityName)
 
         // ---- Start of VIITE-3083 hack ---
         // Instead of returning just the RoadAddressLink returned by the roadAddressLinkBuilder.build function retain the linear location with "correct" 3 decimals in the last geometry point
@@ -419,10 +425,13 @@ class RoadAddressService(
         linearLocationDAO.fetchByRoadAddress(roadPart, addressM, track)
       }
     }
+    val municipalityRoadMaintainerMapping = ProjectAddressLinkBuilder.municipalityToViiteEVKMapping
+    val municipalityNamesMapping = ProjectAddressLinkBuilder.municipalityNamesMapping
+
     val linearLocationsLinkIds = linearLocations.map(_.linkId).toSet
     val roadAddresses = getRoadAddressForSearch(roadPart, addressM, track)
     val roadLinks = roadLinkService.getRoadLinksByLinkIds(linearLocationsLinkIds)
-    val rals = RoadAddressFiller.fillTopology(roadLinks, roadAddresses)
+    val rals = RoadAddressFiller.fillTopology(roadLinks, roadAddresses, municipalityRoadMaintainerMapping, municipalityNamesMapping)
     val filteredRals = rals.filter(al => al.addrMRange.start <= addressM && al.addrMRange.end >= addressM && (al.addrMRange.start != 0 || al.addrMRange.end != 0))
     val ral = filteredRals.filter(al => (track.nonEmpty && track.contains(al.trackCode)) || al.trackCode != Track.LeftSide.value)
     ral.headOption
@@ -650,12 +659,6 @@ class RoadAddressService(
       case _ => None
     }
 
-    println(s"MAPPING THE OPTIONAL ELY AND EVK PARAMETERS TO A SINGLE FILTER ::getTracksForRoadAddressBrowser:: ")
-    println(s"ELY :: $ely")
-    println(s"EVK :: $roadMaintainer")
-
-    println(s"MATCHED INTO ::: $roadMaintainerOpt")
-
     runWithReadOnlySession {
       roadwayDAO.fetchTracksForRoadAddressBrowser(situationDate, roadMaintainerOpt, roadNumber, minRoadPartNumber, maxRoadPartNumber)
     }
@@ -668,13 +671,6 @@ class RoadAddressService(
       case (None, roadMaintainer) => roadMaintainer
       case _ => None
     }
-
-    println(s"MAPPING THE OPTIONAL ELY AND EVK PARAMETERS TO A SINGLE FILTER :: getRoadPartsForRoadAddressBrowser :: ")
-    println(s"ELY :: $ely")
-    println(s"EVK :: $roadMaintainer")
-
-    println(s"MATCHED INTO ::: $roadMaintainerOpt")
-
 
     runWithReadOnlySession {
       roadwayDAO.fetchRoadPartsForRoadAddressBrowser(situationDate, roadMaintainerOpt, roadNumber, minRoadPartNumber, maxRoadPartNumber)
@@ -691,14 +687,6 @@ class RoadAddressService(
       case (None, roadMaintainer) => roadMaintainer
       case _ => None
     }
-
-    println(s"MAPPING THE OPTIONAL ELY AND EVK PARAMETERS TO A SINGLE FILTER :: getChangeInfosForRoadAddressChangesBrowser :: ")
-    println(s"ELY :: $ely")
-    println(s"EVK :: $roadMaintainer")
-
-    println(s"MATCHED INTO ::: $roadMaintainerOpt")
-
-
 
     runWithReadOnlySession {
       roadwayChangesDAO.fetchChangeInfosForRoadAddressChangesBrowser(startDate, endDate, dateTarget, roadMaintainerOpt, roadNumber, minRoadPartNumber, maxRoadPartNumber) //TODO: Add evk to the called function
@@ -762,13 +750,16 @@ class RoadAddressService(
 
     val roadlinks = roadLinkService.getAllVisibleRoadLinks(Set(linkId))
 
+    val municipalityRoadMaintainerMapping = ProjectAddressLinkBuilder.municipalityToViiteEVKMapping
+    val municipalityNamesMapping = ProjectAddressLinkBuilder.municipalityNamesMapping
+
     val roadAddresses = runWithReadOnlySession {
       val linearLocations = linearLocationDAO.fetchRoadwayByLinkId(Set(linkId))
 
       roadwayAddressMapper.getRoadAddressesByLinearLocation(linearLocations)
     }
 
-    RoadAddressFiller.fillTopology(roadlinks, roadAddresses).filter(_.linkId == linkId)
+    RoadAddressFiller.fillTopology(roadlinks, roadAddresses, municipalityRoadMaintainerMapping, municipalityNamesMapping).filter(_.linkId == linkId)
 
   }
 

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/RoadwayDAO.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/dao/RoadwayDAO.scala
@@ -1209,12 +1209,17 @@ class RoadwayDAO extends BaseDAO {
   def fetchTracksForRoadAddressBrowser(situationDate: Option[String], roadMaintainer: Option[String], roadNumber: Option[Long],
                                        minRoadPartNumber: Option[Long], maxRoadPartNumber: Option[Long]): Seq[TrackForRoadAddressBrowser] = {
 
+    val parsedSituationDate = situationDate.map(DateTime.parse)
+
     val dateCondition = situationDate.map(date =>
       sqls"AND start_date <= $date::date AND (end_date >= $date::date OR end_date IS NULL)"
     ).getOrElse(sqls"")
 
     val roadMaintainerCondition = roadMaintainer.map(roadMaintainer => sqls" AND road_maintainer = $roadMaintainer").getOrElse(sqls"")
     val roadNumberCondition = roadNumber.map(roadNumber => sqls" AND road_number = $roadNumber").getOrElse(sqls"")
+
+    val isRoadMaintainerEvk = roadMaintainer.exists(rm => rm.contains("EVK"))
+
 
     val roadPartCondition = {
       val parts = (minRoadPartNumber, maxRoadPartNumber)
@@ -1226,10 +1231,77 @@ class RoadwayDAO extends BaseDAO {
       }
     }
 
+
+    val transitionDateStart = DateTime.parse("2026-01-01")
+    val transitionDateEnd = DateTime.parse("2025-12-31")
+
+    val case1 = parsedSituationDate.exists(_.isBefore(transitionDateStart)) && isRoadMaintainerEvk
+    val case2 = parsedSituationDate.exists(_.isAfter(transitionDateEnd)) && !isRoadMaintainerEvk
+    val case3 = !case1 && !case2
+
+
+    val roadwaysCtePrefix: SQLSyntax =
+      if (case1) {  // Case 1: Elinvoimakeskus road_maintainer and before 2026-01-01
+        sqls"""
+      WITH roadway_numbers AS (
+        SELECT DISTINCT r0.roadway_number
+        FROM roadway r0
+        WHERE r0.valid_to IS NULL
+          $roadNumberCondition
+          $roadMaintainerCondition
+          $roadPartCondition
+          AND r0.start_date = DATE '2026-01-01'
+      ),
+      roadways AS (
+        SELECT r.*
+        FROM roadway r
+        JOIN roadway_numbers rn ON rn.roadway_number = r.roadway_number
+        WHERE r.valid_to IS NULL
+          $dateCondition
+          $roadNumberCondition
+          $roadPartCondition
+      )
+    """
+      } else if (case2) { // Case 2: ELY road_maintainer and after 2025-12-31
+        sqls"""
+      WITH roadway_numbers AS (
+        SELECT DISTINCT r0.roadway_number
+        FROM roadway r0
+        WHERE r0.valid_to IS NULL
+          $roadNumberCondition
+          $roadMaintainerCondition
+          $roadPartCondition
+          AND r0.end_date = DATE '2025-12-31'
+      ),
+      roadways AS (
+        SELECT r.*
+        FROM roadway r
+        JOIN roadway_numbers rn ON rn.roadway_number = r.roadway_number
+        WHERE r.valid_to IS NULL
+          $dateCondition
+          $roadNumberCondition
+          $roadPartCondition
+      )
+    """
+      } else { // Case 3: All other cases, no special filtering
+        sqls"""
+      WITH roadways AS (
+        SELECT *
+        FROM roadway r
+        WHERE r.valid_to IS NULL
+          $dateCondition
+          $roadNumberCondition
+          $roadMaintainerCondition
+          $roadPartCondition
+      )
+    """
+      }
+
     /** Form homogenous sections by road number, road part number, track, start date and road maintainer
      *
      * Use three CTE's (Common Table Expression)
      * 1. roadways: SELECT roadways FROM roadway table with the optional parameters
+     *    - split into three separate handlings ($roadwaysCtePrefix) to accomodate the transition date of 2026-01-01 and the road maintainer types of ELY and Elinvoimakeskus (EVK)
      * 2. roadwayswithstartaddr: SELECT roadways FROM the roadways CTE that don't have another roadway BEFORE it (r2.end_addr_m = r.start_addr_m...). Then set row numbers for these roadways.
      * 3. roadwayswithendaddr: SELECT roadways FROM the roadways CTE that don't have another roadway AFTER it (r2.start_addr_m = r.end_addr_m...). Then set row numbers for these roadways as well
      * Now we have two ROW NUMBERED CTE's: roadwayswithstartaddr and roadwayswithendaddr.
@@ -1237,15 +1309,8 @@ class RoadwayDAO extends BaseDAO {
      * Joining these CTE's by the row numbers will give us one list that tells us the startAddrM and endAddrM of the homogenous section.
      * */
     val query =
-      sql"""WITH roadways
-                AS (SELECT *
-                    FROM   roadway r
-                    WHERE  r.valid_to IS NULL
-                    $dateCondition
-                    $roadMaintainerCondition
-                    $roadNumberCondition
-                    $roadPartCondition
-                    ),
+      sql"""
+          $roadwaysCtePrefix,
            roadwayswithstartaddr AS (SELECT
                            road_maintainer,
                            road_number,

--- a/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/process/RoadAddressFiller.scala
+++ b/viite-backend/viite-main/src/main/scala/fi/liikennevirasto/viite/process/RoadAddressFiller.scala
@@ -6,7 +6,7 @@ import fi.liikennevirasto.viite.dao._
 import fi.liikennevirasto.viite.model.RoadAddressLink
 import fi.vaylavirasto.viite.dao.UnaddressedRoadLink
 import fi.vaylavirasto.viite.geometry.{GeometryUtils, Point}
-import fi.vaylavirasto.viite.model.{AdministrativeClass, RoadLinkLike}
+import fi.vaylavirasto.viite.model.{AdministrativeClass, ArealRoadMaintainer, RoadLinkLike}
 import org.slf4j.{Logger, LoggerFactory}
 
 
@@ -125,27 +125,31 @@ object RoadAddressFiller {
     * ATTENTION: We can in the future also crete here unaddressed parts if needed.
     * @param roadLink
     * @param roadAddresses
+    * @param municipalityMapping
     * @return
     */
-  private def generateUnaddressedSegments(roadLink: RoadLinkLike, roadAddresses: Seq[RoadAddress]): Seq[RoadAddressLink] = {
+  private def generateUnaddressedSegments(roadLink: RoadLinkLike, roadAddresses: Seq[RoadAddress], municipalityMapping: Map[Long, String], municipalityNameMapping: Map[Long, String]): Seq[RoadAddressLink] = {
     //TODO check if its needed to create unaddressed road link for part after VIITE-1536
     if (roadAddresses.isEmpty) {
       val unaddressedRoadLink =
         UnaddressedRoadLink(roadLink.linkId, None, AdministrativeClass.Unknown, None, None, Some(0.0), Some(roadLink.length),
           GeometryUtils.truncateGeometry3D(roadLink.geometry, 0.0, roadLink.length))
 
-      Seq(roadAddressLinkBuilder.build(roadLink, unaddressedRoadLink))
+      val roadMaintainer = ArealRoadMaintainer.apply(municipalityMapping.getOrElse(roadLink.municipalityCode, "EVK0"))
+      val municipalityName = municipalityNameMapping.getOrElse(roadLink.municipalityCode, "")
+
+      Seq(roadAddressLinkBuilder.buildRoadLinksAndUnAddressedLinks(roadLink, unaddressedRoadLink, roadMaintainer, municipalityName))
     } else {
       Seq()
     }
   }
 
-  private def generateSegments(topology: RoadLinkLike, roadAddresses: Seq[RoadAddress]): Seq[RoadAddressLink]  = {
-    roadAddresses.map(ra => roadAddressLinkBuilder.build(topology, ra))
+  private def generateSegments(topology: RoadLinkLike, roadAddresses: Seq[RoadAddress], municipalityMapping: Map[Long, String], municipalityNameMapping: Map[Long, String]): Seq[RoadAddressLink]  = {
+    roadAddresses.map(ra => roadAddressLinkBuilder.buildWithRoadLinkAndRoadAddress(topology, ra, municipalityNameMapping.getOrElse(topology.municipalityCode, "")))
   }
 
-  def fillTopology(topology: Seq[RoadLinkLike], roadAddresses: Seq[RoadAddress]): Seq[RoadAddressLink] = {
-    val fillOperations: Seq[(RoadLinkLike, Seq[RoadAddress]) => Seq[RoadAddressLink]] = Seq(
+  def fillTopology(topology: Seq[RoadLinkLike], roadAddresses: Seq[RoadAddress], municipalityMapping: Map[Long, String], municipalityNameMapping: Map[Long, String]): Seq[RoadAddressLink] = {
+    val fillOperations: Seq[(RoadLinkLike, Seq[RoadAddress], Map[Long, String], Map[Long, String]) => Seq[RoadAddressLink]] = Seq(
       generateUnaddressedSegments,
       generateSegments
     )
@@ -154,7 +158,7 @@ object RoadAddressFiller {
     topology.flatMap {
       roadLink =>
         val segments = roadAddressesMap.getOrElse(roadLink.linkId, Seq())
-        fillOperations.flatMap(operation => operation(roadLink, segments))
+        fillOperations.flatMap(operation => operation(roadLink, segments, municipalityMapping, municipalityNameMapping))
     }
   }
 }

--- a/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilderSpec.scala
+++ b/viite-backend/viite-main/src/test/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilderSpec.scala
@@ -86,7 +86,7 @@ class RoadAddressLinkBuilderSpec extends AnyFunSuite with Matchers {
    runWithRollback {
      val roadAddress = RoadAddress(1, 1234, RoadPart(5, 999), AdministrativeClass.Unknown, Track.Combined, Discontinuity.Discontinuous, AddrMRange(0L, 10L), Some(DateTime.parse("1901-01-01")), Some(DateTime.parse("1902-01-01")), Option("tester"), 12345L.toString, 0.0, 9.8, SideCode.TowardsDigitizing, 0, (None, None), Seq(Point(0.0, 0.0), Point(2.0, 9.8), Point(2.0, 9.8), Point(10.0, 19.8)), LinkGeomSource.NormalLinkInterface, ArealRoadMaintainer.getEVK(8), NoTermination, 0)
 
-     val roadAddressLink = roadAddressLinkBuilder.build(roadAddress)
+     val roadAddressLink = roadAddressLinkBuilder.buildWithRoadAddress(roadAddress)
      roadAddressLink.length should be (22.808)
      roadAddressLink.linearLocationId should be (1234)
      roadAddressLink.linkId should be (12345L.toString)
@@ -99,7 +99,10 @@ class RoadAddressLinkBuilderSpec extends AnyFunSuite with Matchers {
      val roadAddress = RoadAddress(1, 1234, RoadPart(5, 999), AdministrativeClass.Unknown, Track.Combined, Discontinuity.Discontinuous, AddrMRange(0L, 10L), Some(DateTime.parse("1901-01-01")), Some(DateTime.parse("1902-01-01")), Option("tester"), 12345L.toString, 0.0, 9.8, SideCode.TowardsDigitizing, 0, (None, None), Seq(Point(0.0, 0.0), Point(2.0, 9.8), Point(2.0, 9.8), Point(10.0, 19.8)), LinkGeomSource.NormalLinkInterface, ArealRoadMaintainer.getEVK(8), NoTermination, 0)
      val roadlink = RoadLink(linkId = 1L.toString, List(Point(0.0, 0.0), Point(120.0, 0.0)), 120.0, AdministrativeClass.Municipality, TrafficDirection.BothDirections, None, None, municipalityCode = 0, sourceId = "")
 
-     val roadAddressLink = roadAddressLinkBuilder.build(roadlink, roadAddress)
+     val municipalityNamesMapping = ProjectAddressLinkBuilder.municipalityNamesMapping
+     val municipalityName = municipalityNamesMapping.getOrElse(roadlink.municipalityCode, "")
+
+     val roadAddressLink = roadAddressLinkBuilder.buildWithRoadLinkAndRoadAddress(roadlink, roadAddress, municipalityName)
      roadAddressLink.length should be (9.8)
      roadAddressLink.linearLocationId should be (1234)
      roadAddressLink.linkId should be (1L.toString)


### PR DESCRIPTION
Historical Ely-data fetching allowed.

The query is divided into three separate lanes: 
1. Fetching data with startDate < 1.1.2026 with elinvoimakeskus code
2. Fetching data with startDate > 31.12.2025 with ely code
3. Neither above -> Normal filtering based on user given parameters.