### PR TITLE
Next release backup 0807

### DIFF
--- a/viite-backend/api-common/src/main/scala/fi/liikennevirasto/digiroad2/authentication/Authentication.scala
+++ b/viite-backend/api-common/src/main/scala/fi/liikennevirasto/digiroad2/authentication/Authentication.scala
@@ -8,8 +8,6 @@ import org.slf4j.LoggerFactory
 
 trait Authentication extends TestUserSupport {
 
-  println(s"GETTING USER INFO")
-
   private val authLogger = LoggerFactory.getLogger(getClass)
   val viewerUser: User = User(0, "", Configuration(roles = Set("viewer")))
 

--- a/viite-backend/database/src/main/resources/db/migration/V0_21__remove_remaining_evk0_values_from_projects.sql
+++ b/viite-backend/database/src/main/resources/db/migration/V0_21__remove_remaining_evk0_values_from_projects.sql
@@ -1,0 +1,26 @@
+-- Drop old obsolete columns for ELY information.
+-- Guard each table to keep migration idempotent across environments.
+
+DO $$
+BEGIN
+  IF to_regclass(format('%I.%I', current_schema(), 'roadway')) IS NOT NULL THEN
+ALTER TABLE ROADWAY DROP COLUMN IF EXISTS ELY;
+END IF;
+
+  IF to_regclass(format('%I.%I', current_schema(), 'project_link')) IS NOT NULL THEN
+ALTER TABLE PROJECT_LINK DROP COLUMN IF EXISTS ELY;
+END IF;
+
+  IF to_regclass(format('%I.%I', current_schema(), 'project')) IS NOT NULL THEN
+ALTER TABLE PROJECT DROP COLUMN IF EXISTS ELYS;
+END IF;
+
+  IF to_regclass(format('%I.%I', current_schema(), 'project_link_history')) IS NOT NULL THEN
+ALTER TABLE PROJECT_LINK_HISTORY DROP COLUMN IF EXISTS ELY;
+END IF;
+
+  IF to_regclass(format('%I.%I', current_schema(), 'roadway_changes')) IS NOT NULL THEN
+ALTER TABLE ROADWAY_CHANGES DROP COLUMN IF EXISTS NEW_ELY,
+DROP COLUMN IF EXISTS OLD_ELY;
+END IF;
+END $$;

--- a/viite-backend/database/src/main/resources/db/migration/V0_21__remove_remaining_evk0_values_from_projects.sql
+++ b/viite-backend/database/src/main/resources/db/migration/V0_21__remove_remaining_evk0_values_from_projects.sql
@@ -1,26 +1,5 @@
--- Drop old obsolete columns for ELY information.
--- Guard each table to keep migration idempotent across environments.
+-- Remove EVK0 from project.road_maintainers where present
 
-DO $$
-BEGIN
-  IF to_regclass(format('%I.%I', current_schema(), 'roadway')) IS NOT NULL THEN
-ALTER TABLE ROADWAY DROP COLUMN IF EXISTS ELY;
-END IF;
-
-  IF to_regclass(format('%I.%I', current_schema(), 'project_link')) IS NOT NULL THEN
-ALTER TABLE PROJECT_LINK DROP COLUMN IF EXISTS ELY;
-END IF;
-
-  IF to_regclass(format('%I.%I', current_schema(), 'project')) IS NOT NULL THEN
-ALTER TABLE PROJECT DROP COLUMN IF EXISTS ELYS;
-END IF;
-
-  IF to_regclass(format('%I.%I', current_schema(), 'project_link_history')) IS NOT NULL THEN
-ALTER TABLE PROJECT_LINK_HISTORY DROP COLUMN IF EXISTS ELY;
-END IF;
-
-  IF to_regclass(format('%I.%I', current_schema(), 'roadway_changes')) IS NOT NULL THEN
-ALTER TABLE ROADWAY_CHANGES DROP COLUMN IF EXISTS NEW_ELY,
-DROP COLUMN IF EXISTS OLD_ELY;
-END IF;
-END $$;
+UPDATE project p
+SET road_maintainers = array_remove(p.road_maintainers, 'EVK0'::varchar)
+WHERE 'EVK0'::varchar = ANY(p.road_maintainers);

--- a/viite-backend/database/src/main/resources/db/migration/V0_22__create_gist_index_for_linear_location_geometry.sql
+++ b/viite-backend/database/src/main/resources/db/migration/V0_22__create_gist_index_for_linear_location_geometry.sql
@@ -1,0 +1,3 @@
+-- Create GIST index for linear_location geometry column to speed up spatial queries
+
+CREATE INDEX IF NOT EXISTS linear_location_geometry_i ON linear_location USING gist (geometry);


### PR DESCRIPTION
Added a migration step to remove remaining 0-elinvoimakeskus roadMaintainers from the project table that failed to meet the conditions of previous migration. 

Basically left behind was a bunch of projects that didn't have a single ely selected to the project at the time when V0_19__replace_legacy_evk0_with_ely_codes.sql was executed.