### PR TITLE
VIITE-3675 Start dates to UI

### DIFF
--- a/viite-UI/src/view/NodeSearchForm.js
+++ b/viite-UI/src/view/NodeSearchForm.js
@@ -56,7 +56,8 @@
       return '<a id=' + nodePointTemplate.id + ' class="node-point-template-link" href="#node/nodePointTemplate/' + nodePointTemplate.id + '" style="font-weight:bold;cursor:pointer;color: darkorange;">' +
         nodePointTemplate.roadNumber + ' / ' +
         nodePointTemplate.roadPartNumber + ' / ' +
-        nodePointTemplate.addrM + '</a>';
+        nodePointTemplate.addrM + ' / ' +
+        (nodePointTemplate.validFrom || '') + '</a>';
     };
 
     var junctionTemplateLink = function (junctionTemplate) {
@@ -64,7 +65,8 @@
         junctionTemplate.roadNumber + ' / ' +
         junctionTemplate.track + ' / ' +
         junctionTemplate.roadPartNumber + ' / ' +
-        junctionTemplate.addrM + '</a>';
+        junctionTemplate.addrM + ' / ' +
+        (junctionTemplate.startDate || '') + '</a>';
     };
 
     var nodesAndRoadAttributesHtmlList = function () {
@@ -127,7 +129,7 @@
         topLabel: 'Käsittelemättömät liittymäaihiot',
         groupKey: 'elinvoimakeskusCode',
         linkRenderer: junctionTemplateLink,
-        addressHeader: '(TIE / AJR / OSA / AET)'
+        addressHeader: '(TIE / AJR / OSA / AET / ALKUPÄIVÄMÄÄRÄ)'
       });
     };
     
@@ -141,7 +143,7 @@
         topLabel: 'Käsittelemättömät solmukohta-aihiot',
         groupKey: 'roadMaintainer',
         linkRenderer: nodePointTemplateLink,
-        addressHeader: '(TIE / OSA / AET)'
+        addressHeader: '(TIE / OSA / AET / ALKUPÄIVÄMÄÄRÄ)'
       });
     };
 

--- a/viite-UI/src/view/RoadLayer.js
+++ b/viite-UI/src/view/RoadLayer.js
@@ -53,6 +53,7 @@
                 <div class="popup-line-div"><div>AET:&nbsp;</div><div class="selectable">${roadData.addrMRange.start}</div></div>
                 <div class="popup-line-div"><div>LET:&nbsp;</div><div class="selectable">${roadData.addrMRange.end}</div></div>
                 <div class="popup-line-div"><div>Hall. luokka:&nbsp;</div><div class="selectable">${displayAdministrativeClass(roadData.administrativeClassId)}</div></div>
+                <div class="popup-line-div"><div>Alkupäivämäärä:&nbsp;</div><div class="selectable">${roadData.startDate || '-'}</div></div>
               `;
 
               const altShiftPressed = event.originalEvent.shiftKey && event.originalEvent.altKey;


### PR DESCRIPTION
Lisätty alkupäivämäärät linkin hover popuppiin ja solmu valikkoon
<img width="291" height="429" alt="image" src="https://github.com/user-attachments/assets/52b741c4-f93f-41da-8c4b-223f83493be9" />

<img width="186" height="171" alt="image" src="https://github.com/user-attachments/assets/103c4806-e0fc-4925-832c-893584428082" />
